### PR TITLE
feature: add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04 as builder
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y build-essential libstdc++-10-dev clang-10 libssl-dev zlib1g-dev cmake bsdmainutils git
+# the makefile requires clang++
+RUN ln -s /usr/bin/clang++-10 /usr/bin/clang++
+
+RUN git clone --recursive https://github.com/rui314/mold.git
+
+WORKDIR mold
+RUN make submodules -j$(nproc)
+RUN make STATIC=1 -j$(nproc)
+
+FROM debian:buster-slim
+COPY --from=builder /mold/mold /usr/local/bin/mold
+ENTRYPOINT ["mold"]
+


### PR DESCRIPTION
Hi!

Thanks for the blazing fast linker :)

I just found that it can be a little bit difficult for other users to build the linker from scratch (low-speed machines, lack of experience, wasting time for building, etc), so I've prepared the Docker image with `mold`.

I completely understand that can be some overhead with starting the `mold` binary in the container.

The Dockerfile is based on this one: https://github.com/rui314/mold/issues/25#issuecomment-812869216

I hope it will be merged since for you and other users will be easier for making their own Docker images or use an existing one.

Some possible ways for customizations:
* Use Alpine or Distroless as a base image instead of Debian Slim
* Prepare Docker image for released `mold` versions (even better will be integrating it into a CI)

I hope it'll help you.