### PR TITLE
Fix string ctor param from strstr

### DIFF
--- a/archive_file.cc
+++ b/archive_file.cc
@@ -37,7 +37,7 @@ read_thin_archive_members(Context<E> &ctx, MemoryMappedFile<E> *mb) {
       Fatal(ctx) << mb->name << ": filename is not stored as a long filename";
 
     const char *start = strtab.data() + atoi(hdr.ar_name + 1);
-    std::string name(start, strstr(start, "/\n"));
+    std::string name(start, (const char *)strstr(start, "/\n"));
     std::string path = std::string(path_dirname(mb->name)) + "/" + name;
     vec.push_back(MemoryMappedFile<E>::must_open(ctx, path));
     data = body;
@@ -71,7 +71,7 @@ read_fat_archive_members(Context<E> &ctx, MemoryMappedFile<E> *mb) {
 
     if (hdr.ar_name[0] == '/') {
       const char *start = strtab.data() + atoi(hdr.ar_name + 1);
-      name = {start, strstr(start, "/\n")};
+      name = {start, (const char *)strstr(start, "/\n")};
     } else {
       name = {hdr.ar_name, strchr(hdr.ar_name, '/')};
     }


### PR DESCRIPTION
When using the (begin, end) constructor for string, the types of begin
and end must match, including cv qualifiers. Depending on the library
headers used, strstr(const char *, const char *) can potentially return
char * or const char *, the former being a call to the C function strstr
and the latter being a call to C++ std::strstr.

This commit fixes the clang portion of issue #21, by explicitly casting
the return value of strstr to match the 1st param of the string ctor so
that the ctor can be instantiated regardless of the header used.