### PR TITLE
Refactor sort symbols to deal with empty symbol table

### DIFF
--- a/mold.h
+++ b/mold.h
@@ -9,9 +9,11 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <execution>
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
PR #44 highlights that most generic algorithms use `first_it != last_it`
to determine when to stop -- this breaks if `first_it > last_it`.

This commit refactors the function to do noops when the symbol table is
empty. It also experimentally leverages C++17 Parallel STL using TBB to
replace the explicit calls to TBB parallel algorithms, and in doing so
removing the need to use a temporary vector.

I don't have a machine that has enough parallelism to benchmark this,
but it would be interesting to compare this implementation against the
existing one. If this approach performs well, it could pave the way to
make linking to TBB optional, making the algorithms fall back to their
sequenced versions where TBB is not available.

Signed-off-by: Jim Ye <gjimye@gmail.com>