### PR TITLE
Fix DSO detection for installed with PREFIX

### DIFF
--- a/subprocess.cc
+++ b/subprocess.cc
@@ -263,14 +263,11 @@ void process_run_subcommand(Context<E> &ctx, int argc, char **argv) {
   // Get the mold-wrapper.so path
   std::string self = get_self_path(ctx);
   std::string dso_path;
-  if (self == "/usr/bin/mold")
-    dso_path = "/usr/lib/mold/mold-wrapper.so";
-  else if (self == "/usr/local/bin/mold")
-    dso_path = "/usr/local/lib/mold/mold-wrapper.so";
-  else
-    dso_path = std::string(path_dirname(self)) + "/mold-wrapper.so";
+  dso_path = path_clean(self+"/../../lib/mold/mold-wrapper.so");
 
   struct stat st;
+  if (stat(dso_path.c_str(), &st) || (st.st_mode & S_IFMT) != S_IFREG)
+    dso_path = std::string(path_dirname(self)) + "/mold-wrapper.so";
   if (stat(dso_path.c_str(), &st) || (st.st_mode & S_IFMT) != S_IFREG)
     Fatal(ctx) << dso_path << " is missing";
 


### PR DESCRIPTION
mold cannot correctly detect the DSO path when installed with PREFIX.

```
$ PREFIX=/home/johejo/.local make install && /home/johejo/.local/bin/mold -run echo hello
install -m 755 mold /home/johejo/.local/bin
strip /home/johejo/.local/bin/mold
install -m 755 -d /home/johejo/.local/lib/mold
install -m 644 mold-wrapper.so /home/johejo/.local/lib/mold
strip /home/johejo/.local/lib/mold/mold-wrapper.so
install -m 644 docs/mold.1 /home/johejo/.local/share/man/man1
rm -f /home/johejo/.local/share/man/man1/mold.1.gz
gzip -9 /home/johejo/.local/share/man/man1/mold.1
mold: /home/johejo/.local/bin/mold-wrapper.so is missing
```

Signed-off-by: Mitsuo Heijo <mitsuo.heijo@gmail.com>