### PR TITLE
[oneTBB] build only required target(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(MIMALLOC_LIB):
 $(TBB_LIB):
 	mkdir -p oneTBB/out
 	(cd oneTBB/out; cmake -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 ..)
-	$(MAKE) -C oneTBB/out
+	$(MAKE) -C oneTBB/out tbb
 	(cd oneTBB/out; ln -sf *_relwithdebinfo libs)
 
 test tests check: all


### PR DESCRIPTION
The 'all' target builds `tbbmalloc` and `tbbmalloc_proxy`
which mold does not care about.

Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>