### PR TITLE
Fix compilation error with GCC 11

### DIFF
--- a/mold.h
+++ b/mold.h
@@ -124,8 +124,7 @@ inline u64 hash_string(std::string_view str) {
   return XXH3_64bits(str.data(), str.size());
 }
 
-namespace tbb {
-template<> struct tbb_hash_compare<std::string_view> {
+template<> struct tbb::tbb_hash_compare<std::string_view> {
   static size_t hash(const std::string_view &k) {
     return hash_string(k);
   }
@@ -134,7 +133,6 @@ template<> struct tbb_hash_compare<std::string_view> {
     return k1 == k2;
   }
 };
-}
 
 template<typename ValueT> class ConcurrentMap {
 public:


### PR DESCRIPTION
```
mold.h:128:19: error: explicit specialization of
  ‘template<class Key> class tbb::detail::d1::tbb_hash_compare’
  outside its namespace must use a nested-name-specifier [-fpermissive]
  128 | template<> struct tbb_hash_compare<std::string_view> {
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>