### PR TITLE
[tests] Fix pie test when cc isn't built with --enable-default-pie

### DIFF
--- a/test/pie.sh
+++ b/test/pie.sh
@@ -5,7 +5,7 @@ echo -n "Testing $(basename -s .sh $0) ... "
 t=$(pwd)/tmp/$(basename -s .sh $0)
 mkdir -p $t
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o $t/a.o -c -xc -fPIE -
 #include <stdio.h>
 
 int main() {


### PR DESCRIPTION
```
mold: /__w/mold/mold/test/tmp/pie/a.o:(.text): R_X86_64_32 relocation
       against symbol `.rodata' can not be used; recompile with -fPIE
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>