### PR TITLE
Optimize CI build (enable ccache & run tests in parallel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: make
       run: make -j$(nproc)
     - name: make test
-      run: make test
+      run: make test -j$(nproc)
   build-gcc11:
     runs-on: ubuntu-20.04
     container: gcc:11.1.0
@@ -25,4 +25,4 @@ jobs:
     - name: make
       run: make CC=gcc CXX=g++ -j$(nproc)
     - name: make test
-      run: make test
+      run: make test -j$(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,30 @@ jobs:
     - uses: actions/checkout@v2
     - name: apt-get
       run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install build-essential libstdc++-10-dev cmake clang libssl-dev zlib1g-dev libxxhash-dev libtbb-dev git bsdmainutils dwarfdump libc6-dev:i386 lib32gcc-10-dev libstdc++-10-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
     - name: make
-      run: make -j$(nproc)
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        make -j$(nproc)
     - name: make test
-      run: make test -j$(nproc)
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        make test -j$(nproc)
   build-gcc11:
     runs-on: ubuntu-20.04
     container: gcc:11.1.0
     steps:
     - uses: actions/checkout@v2
     - name: apt-get
-      run: dpkg --add-architecture i386 && apt-get update && apt-get install -y libssl-dev zlib1g-dev libxxhash-dev cmake clang dwarfdump bsdextrautils libgcc-9-dev gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev:i386 lib32gcc-10-dev qemu-user
+      run: dpkg --add-architecture i386 && apt-get update && apt-get install -y sudo libssl-dev zlib1g-dev libxxhash-dev cmake clang dwarfdump bsdextrautils libgcc-9-dev gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev:i386 lib32gcc-10-dev qemu-user
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
     - name: make
-      run: make CC=gcc CXX=g++ -j$(nproc)
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        make CC=gcc CXX=g++ -j$(nproc)
     - name: make test
-      run: make test -j$(nproc)
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        make test -j$(nproc)


### PR DESCRIPTION
Some tests invoke `ld` instead of `mold` by a mistake. This creates an illusion that they run successfully for `mold`. Which isn't true for `copyrel-protected` & `ifunc-dso`.

Things we have to fix in `mold`:
- handling of `protected` when creating shared libraries
- handling of `ifunc`

Honestly, I'm not a linker expert, so don't think I can help. @rui314