### PR TITLE
Fix out of bound check in get_shndx()

### DIFF
--- a/mold.h
+++ b/mold.h
@@ -2146,7 +2146,7 @@ inline std::string_view InputFile<E>::get_string(Context<E> &ctx, i64 idx) {
 template <typename E>
 inline i64 ObjectFile<E>::get_shndx(const ElfSym<E> &esym) {
   assert(&elf_syms[0] <= &esym);
-  assert(&esym < &elf_syms[elf_syms.size()]);
+  assert(&esym <= &elf_syms[elf_syms.size() - 1]);
 
   if (esym.st_shndx == SHN_XINDEX)
     return symtab_shndx_sec[&esym - &elf_syms[0]];


### PR DESCRIPTION
Assert failure:
```
/usr/include/c++/11.1.0/span:276:
  std::span::reference
  std::span<ElfSym<X86_64>, 18446744073709551615>
     ::operator[](std::span::size_type)
         const [_Type = ElfSym<X86_64>, _Extent = 18446744073709551615]:
           Assertion '__idx < size()' failed.
```
GDB stacktrace:
```
Thread 2.4 "mold" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fabc3d3f640 (LWP 17804)]
0x00007fabc496fd22 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007fabc496fd22 in raise () from /usr/lib/libc.so.6
#1  0x00007fabc4959862 in abort () from /usr/lib/libc.so.6
#2  0x000055a9685eb018 in std::__replacement_assert (...)
    at /usr/include/c++/11.1.0/x86_64-pc-linux-gnu/bits/c++config.h:504
#3  0x000055a968614c47 in std::span<ElfSym<X86_64>, ...>::operator[] (...)
    at /usr/include/c++/11.1.0/span:276
#4  ObjectFile<X86_64>::get_shndx (this=<...>, esym=...) at ./mold.h:2145
#5  ObjectFile<X86_64>::get_section (this=<...>, esym=...) at ./mold.h:2154
```
Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>