### PR TITLE
Use `cmake --build` instead of `make` for mimalloc and TBB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,12 @@ $(OBJS): mold.h elf.h Makefile
 $(MIMALLOC_LIB):
 	mkdir -p mimalloc/out/release
 	(cd mimalloc/out/release; CFLAGS=-DMI_USE_ENVIRON=0 cmake ../..)
-	cmake --build mimalloc/out/release mimalloc-static
+	cmake --build mimalloc/out/release --target mimalloc-static
 
 $(TBB_LIB):
 	mkdir -p oneTBB/out
 	(cd oneTBB/out; cmake -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 ..)
-	cmake --build oneTBB/out tbb
+	cmake --build oneTBB/out --target tbb
 	(cd oneTBB/out; ln -sf *_relwithdebinfo libs)
 
 test tests check: all

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,12 @@ $(OBJS): mold.h elf.h Makefile
 $(MIMALLOC_LIB):
 	mkdir -p mimalloc/out/release
 	(cd mimalloc/out/release; CFLAGS=-DMI_USE_ENVIRON=0 cmake ../..)
-	$(MAKE) -C mimalloc/out/release mimalloc-static
+	cmake --build mimalloc/out/release mimalloc-static
 
 $(TBB_LIB):
 	mkdir -p oneTBB/out
 	(cd oneTBB/out; cmake -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 ..)
-	$(MAKE) -C oneTBB/out tbb
+	cmake --build oneTBB/out tbb
 	(cd oneTBB/out; ln -sf *_relwithdebinfo libs)
 
 test tests check: all


### PR DESCRIPTION
This will run whichever build tool was used to generate the cmake project

For example, I set `CMAKE_GENERATOR=Ninja` globally so that cmake will automatically use Ninja always. This would break with the current Makefile as it will try to run make in that directory when there is no Makefile

The only downside is I dont know which cmake version this was added, perhaps its too new, although the project already requires c++20 and some modern tooling

This could be backported to 0.9.1 as well potentially