### PR TITLE
include example of linking rust code

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ build command) as a subcommand of mold as follows:
 $ path/to/mold -run make <make-options-if-any>
 ```
 
+Here's an example showing how to link rust code when using the
+cargo package manager.
+
+```
+$ path/to/mold -run cargo build
+```
+
 Internally, mold invokes a given command with `LD_PRELOAD` environment
 variable set to its companion shared object file. The shared object
 file intercepts all function calls to exec-family functions to replace


### PR DESCRIPTION
This code sample shows how to use mold to link code built with cargo, rusts package manager.
Because cargo abstracts away the linking step many users of rust aren't aware of the details of how rust code is linked, and don't know that it's possible to switch linkers.

This example would make it very clear to users of rust, who may not have a strong background in programming langauges that use linkers, that they can use mold for their rust projects.