### PR TITLE
Disable TBB_STRICT when building TBB (on by default)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(MIMALLOC_LIB):
 
 $(TBB_LIB):
 	mkdir -p out/tbb
-	(cd out/tbb; cmake -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 ../../tbb)
+	(cd out/tbb; cmake -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 -DTBB_STRICT=OFF ../../tbb)
 	$(MAKE) -C out/tbb tbb
 	(cd out/tbb; ln -sf *_relwithdebinfo libs)
 


### PR DESCRIPTION
This allows mold to build under clang++-14 which catches the write-only
`intptr_t drained` in `tbb/arena.cpp` as an unused parameter that
ultimately triggers `-Werror` to error out and abort the build.

It's 2021 and there are still projects that default to `-Werror` as the
default instead of using it only in the dev and CI environments... smh.

Closes #107.