### PR TITLE
Explicitly instruct CMake to use Unix Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,12 @@ $(OBJS): mold.h elf.h Makefile
 
 $(MIMALLOC_LIB):
 	mkdir -p out/mimalloc
-	(cd out/mimalloc; CFLAGS=-DMI_USE_ENVIRON=0 cmake ../../mimalloc)
+	(cd out/mimalloc; CFLAGS=-DMI_USE_ENVIRON=0 cmake -G'Unix Makefiles' ../../mimalloc)
 	$(MAKE) -C out/mimalloc mimalloc-static
 
 $(TBB_LIB):
 	mkdir -p out/tbb
-	(cd out/tbb; cmake -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 -DTBB_STRICT=OFF ../../tbb)
+	(cd out/tbb; cmake -G'Unix Makefiles' -DBUILD_SHARED_LIBS=OFF -DTBB_TEST=OFF -DCMAKE_CXX_FLAGS=-D__TBB_DYNAMIC_LOAD_ENABLED=0 -DTBB_STRICT=OFF ../../tbb)
 	$(MAKE) -C out/tbb tbb
 	(cd out/tbb; ln -sf *_relwithdebinfo libs)
 


### PR DESCRIPTION
mold currently builds dependencies in its `Makefile` by explicitly
issuing `make -C ...` targeting the CMake build directory; this will
fail if a global `CMAKE_GENERATOR` environment variable is present that
specifies a different CMake build file generator.

Closes #91