### PR TITLE
Do not hardcode clang/clang++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-CC = clang
-CXX = clang++
+ifeq ($(origin CC), default)
+	CC = clang
+endif
+
+ifeq ($(origin CXX), default)
+	CXX = clang++
+endif
 
 GIT_HASH ?= $(shell [ -d .git ] && git rev-parse HEAD)
 


### PR DESCRIPTION
When the environment has `CC`/`CXX` set, the build system ignores them and hardcodes `clang`/`clang++`. This changes the Makefile to use the values from the environment if they exist. This allows building with `gcc`/`g++` for example.

