### PR TITLE
Parse CIE and FDE extended length fields.

### DIFF
--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1285,7 +1285,7 @@ void EhFrameSection<E>::construct(Context<E> &ctx) {
     i64 offset = 0;
     for (FdeRecord<E> &fde : file->fdes) {
       fde.output_offset = offset;
-      offset += fde.size();
+      offset += fde.get_size();
     }
     file->fde_size = offset;
   });
@@ -1307,7 +1307,7 @@ void EhFrameSection<E>::construct(Context<E> &ctx) {
       } else {
         cie.output_offset = offset;
         cie.is_leader = true;
-        offset += cie.size();
+        offset += cie.get_size();
         leaders.push_back(&cie);
       }
     }


### PR DESCRIPTION
According to the exception frames [spec](https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/ehframechpt.html),
CIE and FDE records also have an optional extended length field. This
patch adds the necessary code to handle this optional field.

Signed-off-by: Robert Bartlensky <bartlensky.robert@gmail.com>