### PR TITLE
build: respect user *FLAGS, don't compress man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,6 @@ install: all
 
 	install -m 755 -d $D$(MANDIR)/man1
 	install -m 644 docs/mold.1 $D$(MANDIR)/man1
-	rm -f $D$(MANDIR)/man1/mold.1.gz
-	gzip -9 $D$(MANDIR)/man1/mold.1
 
 	ln -sf mold $D$(BINDIR)/ld.mold
 	ln -sf mold $D$(BINDIR)/ld64.mold


### PR DESCRIPTION
Forwarding downstream patches I've applied in Gentoo:

- Respect user CXXFLAGS
- Rename CPPFLAGS (previously used in the sense of "flags for the C++ compiler") -> CXXFLAGS
- CPPFLAGS is generally used for "flags for the C(++) preprocessor.", so let's
  use it for that
- Respect user LDFLAGS
  (In one instance, we were respecting LDFLAGS, but doing it too late.
  We need to pass LDFLAGS _before_ any objects in order for -Wl,--as-needed
  to work correctly.)
- Don't compress man pages
   (Negligible saving and downstream, distributions	usually	recompress or
    compress with their own	specific options. Unconditionally compressing
    man pages, while well intended,	usually	creates	more hassle there.)

Signed-off-by: Sam James <sam@gentoo.org>