### PR TITLE
fix clang pkg name in fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo apt-get install -y build-essential git clang cmake libstdc++-10-dev libssl-
 #### Fedora 34 and later
 
 ```shell
-sudo dnf install -y git clang-c++ cmake openssl-devel xxhash-devel zlib-devel
+sudo dnf install -y git clang cmake openssl-devel xxhash-devel zlib-devel
 ```
 
 ### Compile mold


### PR DESCRIPTION
clang-c++ doesn't exist (at least not in fedora35)

```
~ : sudo dnf install clang-c++    
No match for argument: clang-c++
Error: Unable to find a match: clang-c++
```

I tried the installation process with just the clang package, and that works great.