### PR TITLE
Add libstdc++-devel to fedora dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo apt-get install -y build-essential git clang cmake libstdc++-10-dev libssl-
 #### Fedora 34 and later
 
 ```shell
-sudo dnf install -y git clang-c++ cmake openssl-devel xxhash-devel zlib-devel
+sudo dnf install -y git clang-c++ cmake openssl-devel xxhash-devel zlib-devel libstdc++-devel
 ```
 
 ### Compile mold


### PR DESCRIPTION
In build environments such as SUSE OBS or Fedora COPR build fails without clang standard library.

https://build.opensuse.org/package/show/home:MarkNefedov/mold