### PR TITLE
Force the execution of tests in English

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ $(TBB_LIB):
 
 ifeq ($(OS), Darwin)
 test tests check: all
-	$(MAKE) -C test -f Makefile.darwin --no-print-directory
+	LANG=C $(MAKE) -C test -f Makefile.darwin --no-print-directory
 else
 test tests check: all
-	$(MAKE) -C test -f Makefile.linux --no-print-directory --output-sync
+	LANG=C $(MAKE) -C test -f Makefile.linux --no-print-directory --output-sync
 endif
 
 install: all


### PR DESCRIPTION
If the tests are executed in a different locale like French, some logs  (ex: ```out/test/elf/auxiliary/log```) can contain output like:

```La section dynamique à l'offset 0x2000 contient 10 entrées :```

which of course doesn't work as the grep is
```
fgrep -q 'Auxiliary library: [foo]' $t/log
```