### PR TITLE
test/pie.sh: extend the check to other output

### DIFF
--- a/test/elf/pie.sh
+++ b/test/elf/pie.sh
@@ -16,7 +16,7 @@ int main() {
 EOF
 
 clang -fuse-ld=$mold -pie -o $t/exe $t/a.o
-readelf --file-header $t/exe | grep -q 'Shared object file'
+readelf --file-header $t/exe | grep -q -E '(Shared object file|Position-Independent Executable file)'
 $t/exe | grep -q 'Hello world'
 
 echo OK


### PR DESCRIPTION
On Debian unstable, the output doesn't contain 'Shared object file'
Parsing a different output

With GNU readelf (GNU Binutils for Debian) 2.37, the output is
```
$ LANG=C readelf --file-header out/test/elf/pie/exe
ELF Header:
  Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF64
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              DYN (Position-Independent Executable file)
  Machine:                           Advanced Micro Devices X86-64
  Version:                           0x1
  Entry point address:               0x1050
  Start of program headers:          64 (bytes into file)
  Start of section headers:          14608 (bytes into file)
  Flags:                             0x0
  Size of this header:               64 (bytes)
  Size of program headers:           56 (bytes)
  Number of program headers:         10
  Size of section headers:           64 (bytes)
  Number of section headers:         32
  Section header string table index: 29
```

Signed-off-by: Sylvestre Ledru <sylvestre@debian.org>