### PR TITLE
Do not use custom `LDFLAGS` for linking `mold-wrapper.so`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 all: mold mold-wrapper.so
 
 mold: $(OBJS) $(MIMALLOC_LIB) $(TBB_LIB) $(XXHASH_LIB)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(OBJS) -o $@ $(LIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(EXTRA_LDFLAGS) $(OBJS) -o $@ $(LIBS)
 	ln -sf mold ld
 	ln -sf mold ld64.mold
 

--- a/build-static.sh
+++ b/build-static.sh
@@ -23,16 +23,16 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 EOF
 
-LDFLAGS='-fuse-ld=lld -static'
+EXTRA_LDFLAGS='-fuse-ld=lld -static'
 
 # libstdc++'s `std::__glibcxx_rwlock_rdlock` refers these symbols
 # as weak symbols, although they need to be defined. Otherwise,
 # the program crashes after juping to address 0.
 # So, we force loading symbols as a workaround.
-LDFLAGS="$LDFLAGS -Wl,-u,pthread_rwlock_rdlock"
-LDFLAGS="$LDFLAGS -Wl,-u,pthread_rwlock_unlock"
-LDFLAGS="$LDFLAGS -Wl,-u,pthread_rwlock_wrlock"
+EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-u,pthread_rwlock_rdlock"
+EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-u,pthread_rwlock_unlock"
+EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-u,pthread_rwlock_wrlock"
 
 docker run -it --rm -v "`pwd`:/mold" -u $(id -u):$(id -g) \
   mold-build-ubuntu20 \
-  make -C /mold -j$(nproc) LDFLAGS="$LDFLAGS"
+  make -C /mold -j$(nproc) EXTRA_LDFLAGS="$EXTRA_LDFLAGS"


### PR DESCRIPTION
Linking a dynamic library with `-static` would prevent it from being
loadable.

Fixes #191.

Signed-off-by: Christoph Erhardt <github@sicherha.de>