### PR TITLE
Container improvements

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -41,4 +41,4 @@ fi
 
 docker run -it --rm "${docker_args[@]}" \
   mold-build-ubuntu20 \
-  make -C /mold -j$(nproc) EXTRA_LDFLAGS="$EXTRA_LDFLAGS"
+  make -C /mold -j$(nproc) EXTRA_LDFLAGS="$EXTRA_LDFLAGS" "$@"

--- a/build-static.sh
+++ b/build-static.sh
@@ -18,6 +18,7 @@ FROM ubuntu:20.04
 RUN apt-get update && \
   TZ=Europe/London apt-get install -y tzdata && \
   apt-get install -y --no-install-recommends build-essential clang lld \
+    bsdmainutils file gcc-multilib \
     cmake libstdc++-10-dev zlib1g-dev libssl-dev && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*

--- a/build-static.sh
+++ b/build-static.sh
@@ -33,6 +33,11 @@ EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-u,pthread_rwlock_rdlock"
 EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-u,pthread_rwlock_unlock"
 EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-u,pthread_rwlock_wrlock"
 
-docker run -it --rm -v "`pwd`:/mold" -u $(id -u):$(id -g) \
+docker_args=(-v "`pwd`:/mold:Z" -u "$(id -u)":"$(id -g)")
+if docker --version | grep -q podman; then
+  docker_args+=(--userns=keep-id)
+fi
+
+docker run -it --rm "${docker_args[@]}" \
   mold-build-ubuntu20 \
   make -C /mold -j$(nproc) EXTRA_LDFLAGS="$EXTRA_LDFLAGS"


### PR DESCRIPTION
This patch series brings the following enhancements for `build-static.sh`:
* Add compatibility for Podman + SELinux (a common combination on Fedora).
* Allow running the testsuite inside the container. Note: requires including a few extra packages in the container image.
* Allow passing extra arguments to `make` inside the container.

Let me know if you find these additions useful, and feel free to reject some or all of them if you don't. 🙂