### PR TITLE
[ELF] Fix '?' for globbing + version scripts

### DIFF
--- a/elf/main.cc
+++ b/elf/main.cc
@@ -22,11 +22,14 @@ std::string glob_to_regex(std::string_view pattern) {
     switch (c) {
     case '.': case '[': case ']': case '^':
     case '$': case '\\': case '(': case ')':
-    case '+': case '?': case '|':
+    case '+': case '|':
       ss << "\\" << c;
       break;
     case '*':
       ss << ".*";
+      break;
+    case '?':
+      ss << ".";
       break;
     default:
       ss << c;

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -609,8 +609,9 @@ void apply_version_script(Context<E> &ctx) {
   for (VersionPattern &elem : ctx.arg.version_patterns) {
     std::vector<std::string_view> vec;
 
+    std::regex re_glob("[*?]", std::regex_constants::optimize | std::regex_constants::nosubs);
     for (std::string_view pat : elem.patterns) {
-      if (pat.find('*') == pat.npos) {
+      if (!std::regex_search(pat.begin(), pat.end(), re_glob)) {
         Symbol<E> *sym = intern(ctx, pat);
         if (sym->file && !sym->file->is_dso)
           sym->ver_idx = elem.ver_idx;

--- a/test/elf/version-script8.sh
+++ b/test/elf/version-script8.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+export LANG=
+set -e
+cd $(dirname $0)
+mold=`pwd`/../../mold
+echo -n "Testing $(basename -s .sh $0) ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
+mkdir -p $t
+
+cat <<EOF > $t/a.ver
+ver1 {
+  global: ?oo;
+  local: *;
+};
+
+ver2 {
+  global: b?r;
+};
+EOF
+
+cat <<EOF | clang -fuse-ld=$mold -xc -shared -o $t/b.so -Wl,-version-script,$t/a.ver -
+void foo() {}
+void bar() {}
+void baz() {}
+EOF
+
+cat <<EOF | clang -xc -c -o $t/c.o -
+void foo();
+void bar();
+
+int main() {
+  foo();
+  bar();
+  return 0;
+}
+EOF
+
+clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.so
+$t/exe
+
+readelf --dyn-syms $t/b.so > $t/log
+fgrep -q 'foo@@ver1' $t/log
+fgrep -q 'bar@@ver2' $t/log
+! fgrep -q 'baz' $t/log || false
+
+echo OK


### PR DESCRIPTION
With all the buzz about mold, I tried to link LibreOffice with it. After implementing the setup with gcc -B, this resulted in missing symbols. Turned out that '?' for globbing was not handled correctly.