### PR TITLE
Fix building on Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ endif
 STRIP ?= strip
 
 OS ?= $(shell uname -s)
+OS2 ?= $(shell uname -o)
 
 # Used for both C and C++
 COMMON_FLAGS = -pthread -fPIE -fno-unwind-tables -fno-asynchronous-unwind-tables
@@ -58,15 +59,17 @@ else ifeq ($(TSAN), 1)
   CXXFLAGS += -fsanitize=thread
   LDFLAGS  += -fsanitize=thread
 else ifneq ($(OS), Darwin)
-  # By default, we want to use mimalloc as a memory allocator.
-  # Since replacing the standard malloc is not compatible with ASAN,
-  # we do that only when ASAN is not enabled.
-  ifdef SYSTEM_MIMALLOC
-    LIBS += -lmimalloc
-  else
-    MIMALLOC_LIB = out/mimalloc/libmimalloc.a
-    CPPFLAGS += -Ithird-party/mimalloc/include
-    LIBS += -Wl,-whole-archive $(MIMALLOC_LIB) -Wl,-no-whole-archive
+  ifneq ($(OS2), Android)
+    # By default, we want to use mimalloc as a memory allocator.
+    # Since replacing the standard malloc is not compatible with ASAN,
+    # we do that only when ASAN is not enabled.
+    ifdef SYSTEM_MIMALLOC
+      LIBS += -lmimalloc
+    else
+      MIMALLOC_LIB = out/mimalloc/libmimalloc.a
+      CPPFLAGS += -Ithird-party/mimalloc/include
+      LIBS += -Wl,-whole-archive $(MIMALLOC_LIB) -Wl,-no-whole-archive
+    endif
   endif
 endif
 


### PR DESCRIPTION
When building mold on android using Termux the resulting binary immediately causes a SIGSEV on startup. The reason is a infinite recusion between mi_malloc and a tls emulation function. It looks like Android is using the same TLS emulation as Darwin. The fix is to not use mimalloc when building mold on (or for) Android.