### PR TITLE
Using pathmax

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,13 @@ If you can specify an additional command line option to your compiler
 driver by modifying build system's config files, add one of the
 following flags to use `mold` instead of `/usr/bin/ld`:
 
-- Clang before 12: pass `-fuse-ld=<absolute-path-to-mold-executable>`;
+- Clang: pass `-fuse-ld=<absolute-path-to-mold-executable>`;
 
-- Clang 12 or later: pass `--ld-path=<absolute-path-to-mold-executable>`;
+- GCC 12.1.0 or later: pass `-fuse-ld=<absolute-path-to-mold-executable>`;
 
-- GCC: GCC does not accept `mold` as an argument neither for
-  `-fuse-ld` or `--ld-path` (a patch to support `--ld-path` [has been
-  declined by GCC maintainers](
-  https://gcc.gnu.org/pipermail/gcc-patches/2021-June/573833.html)).
-  However, there's still a way to use mold with GCC, as GCC looks for
-  `ld` command from a path given with `-B`.
+- GCC before 12.1.0: `-fuse-ld` does not accept `mold` as a valid
+  argument, so you need to use `-B` option instead. `-B` is an option
+  to tell GCC where to look for external commands such as `ld`.
 
   If you have installed mold with `make install`, there should be a
   directory named `/usr/libexec/mold` (or `/usr/local/libexec/mold`,

--- a/elf/subprocess.cc
+++ b/elf/subprocess.cc
@@ -16,6 +16,7 @@
 #endif
 
 #define DAEMON_TIMEOUT 30
+constexpr size_t pathmax = PATH_MAX;
 
 namespace mold::elf {
 
@@ -251,7 +252,7 @@ void daemonize(Context<E> &ctx, std::function<void()> *wait_for_client,
 
 template <typename E>
 static std::string get_self_path(Context<E> &ctx) {
-  char buf[4096];
+  char buf[pathmax];
   size_t n = readlink("/proc/self/exe", buf, sizeof(buf));
   if (n == -1)
     Fatal(ctx) << "readlink(\"/proc/self/exe\") failed: " << errno_string();

--- a/elf/subprocess.cc
+++ b/elf/subprocess.cc
@@ -16,7 +16,6 @@
 #endif
 
 #define DAEMON_TIMEOUT 30
-constexpr size_t pathmax = PATH_MAX;
 
 namespace mold::elf {
 
@@ -252,7 +251,7 @@ void daemonize(Context<E> &ctx, std::function<void()> *wait_for_client,
 
 template <typename E>
 static std::string get_self_path(Context<E> &ctx) {
-  char buf[pathmax];
+  char buf[PATH_MAX];
   size_t n = readlink("/proc/self/exe", buf, sizeof(buf));
   if (n == -1)
     Fatal(ctx) << "readlink(\"/proc/self/exe\") failed: " << errno_string();

--- a/filepath.cc
+++ b/filepath.cc
@@ -4,17 +4,15 @@
 
 namespace mold {
 
-constexpr size_t pathmax = PATH_MAX;
-
 std::string get_current_dir() {
-  std::string buf(pathmax, '\0');
+  std::string buf(PATH_MAX, '\0');
   getcwd(buf.data(), buf.size());
   buf.resize(buf.find_first_of('\0'));
   return buf;
 }
 
 std::string get_realpath(std::string_view path) {
-  std::string buf(pathmax, '\0');
+  std::string buf(PATH_MAX, '\0');
   if (!realpath(std::string(path).c_str(), buf.data()))
     return std::string(path);
   return buf;

--- a/filepath.cc
+++ b/filepath.cc
@@ -4,16 +4,18 @@
 
 namespace mold {
 
+constexpr size_t pathmax = PATH_MAX;
+
 std::string get_current_dir() {
-  std::string buf(8192, '\0');
+  std::string buf(pathmax, '\0');
   getcwd(buf.data(), buf.size());
   buf.resize(buf.find_first_of('\0'));
   return buf;
 }
 
 std::string get_realpath(std::string_view path) {
-  char buf[8192];
-  if (!realpath(std::string(path).c_str(), buf))
+  std::string buf(pathmax, '\0');
+  if (!realpath(std::string(path).c_str(), buf.data()))
     return std::string(path);
   return buf;
 }


### PR DESCRIPTION
reduce magic numbers (4096 & 8192) for the max path length with PATH_MAX.
should make the code also a tiny bit more portable

(I forgot to use -s in the first commit, 2 commit are the same changes, but with "-s")
