### PR TITLE
Add lots of quotes to shell scripts

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -41,4 +41,4 @@ fi
 
 docker run -it --rm "${docker_args[@]}" \
   mold-build-ubuntu20 \
-  make -C /mold -j$(nproc) EXTRA_LDFLAGS="$EXTRA_LDFLAGS" "$@"
+  make -C /mold -j"$(nproc)" EXTRA_LDFLAGS="$EXTRA_LDFLAGS" "$@"

--- a/test/elf/aarch64-hello-static.sh
+++ b/test/elf/aarch64-hello-static.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-echo 'int main() {}' | aarch64-linux-gnu-gcc -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | aarch64-linux-gnu-gcc -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | aarch64-linux-gnu-gcc -o $t/a.o -c -g -xc -
+cat <<EOF | aarch64-linux-gnu-gcc -o "$t"/a.o -c -g -xc -
 #include <stdio.h>
 
 int main() {
@@ -21,12 +21,12 @@ int main() {
 }
 EOF
 
-aarch64-linux-gnu-gcc -B`dirname $mold` -o $t/exe $t/a.o -static
+aarch64-linux-gnu-gcc -B"`dirname "$mold"`" -o "$t"/exe "$t"/a.o -static
 
-readelf -p .comment $t/exe | grep -qw mold
+readelf -p .comment "$t"/exe | grep -qw mold
 
-readelf -a $t/exe > $t/log
-grep -Pq 'Machine:\s+AArch64' $t/log
-qemu-aarch64 -L /usr/aarch64-linux-gnu $t/exe | grep -q 'Hello world'
+readelf -a "$t"/exe > "$t"/log
+grep -Pq 'Machine:\s+AArch64' "$t"/log
+qemu-aarch64 -L /usr/aarch64-linux-gnu "$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/allow-multiple-definition.sh
+++ b/test/elf/allow-multiple-definition.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() { return 0; }' > $t/a.c
-echo 'int main() { return 0; }' > $t/b.c
+echo 'int main() { return 0; }' > "$t"/a.c
+echo 'int main() { return 0; }' > "$t"/b.c
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.c $t/b.c 2> /dev/null || false
-clang -fuse-ld=$mold -o $t/exe $t/a.c $t/b.c -Wl,-allow-multiple-definition
-clang -fuse-ld=$mold -o $t/exe $t/a.c $t/b.c -Wl,-z,muldefs
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.c "$t"/b.c 2> /dev/null || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.c "$t"/b.c -Wl,-allow-multiple-definition
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.c "$t"/b.c -Wl,-z,muldefs
 
 echo OK

--- a/test/elf/ar-alignment.sh
+++ b/test/elf/ar-alignment.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int two() { return 2; }
 EOF
 
-head -c 1 /dev/zero >> $t/a.o
+head -c 1 /dev/zero >> "$t"/a.o
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 int three() { return 3; }
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 #include <stdio.h>
 
 int two();
@@ -28,9 +28,9 @@ int main() {
 }
 EOF
 
-rm -f $t/d.a
-ar rcs $t/d.a $t/a.o $t/b.o
+rm -f "$t"/d.a
+ar rcs "$t"/d.a "$t"/a.o "$t"/b.o
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/d.a
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/d.a
 
 echo OK

--- a/test/elf/as-needed-weak.sh
+++ b/test/elf/as-needed-weak.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -o $t/a.o -c -xc -
+cat <<EOF | cc -fPIC -o "$t"/a.o -c -xc -
 __attribute__((weak)) int fn1();
 
 int main() {
@@ -15,24 +15,24 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -o $t/b.so -shared -fPIC -Wl,-soname,libfoo.so -xc -
+cat <<EOF | cc -o "$t"/b.so -shared -fPIC -Wl,-soname,libfoo.so -xc -
 int fn1() { return 42; }
 EOF
 
-cat <<EOF | cc -o $t/c.so -shared -fPIC -Wl,-soname,libbar.so -xc -
+cat <<EOF | cc -o "$t"/c.so -shared -fPIC -Wl,-soname,libbar.so -xc -
 int fn2() { return 42; }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.so $t/c.so
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.so "$t"/c.so
 
-readelf --dynamic $t/exe > $t/readelf
-fgrep -q 'Shared library: [libfoo.so]' $t/readelf
-fgrep -q 'Shared library: [libbar.so]' $t/readelf
+readelf --dynamic "$t"/exe > "$t"/readelf
+fgrep -q 'Shared library: [libfoo.so]' "$t"/readelf
+fgrep -q 'Shared library: [libbar.so]' "$t"/readelf
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-as-needed $t/b.so $t/c.so
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-as-needed "$t"/b.so "$t"/c.so
 
-readelf --dynamic $t/exe > $t/readelf
-! fgrep -q 'Shared library: [libfoo.so]' $t/readelf || false
-! fgrep -q 'Shared library: [libbar.so]' $t/readelf || false
+readelf --dynamic "$t"/exe > "$t"/readelf
+! fgrep -q 'Shared library: [libfoo.so]' "$t"/readelf || false
+! fgrep -q 'Shared library: [libbar.so]' "$t"/readelf || false
 
 echo OK

--- a/test/elf/as-needed.sh
+++ b/test/elf/as-needed.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void fn1();
 int main() {
   fn1();
 }
 EOF
 
-cat <<EOF | cc -o $t/b.so -shared -fPIC -Wl,-soname,libfoo.so -xc -
+cat <<EOF | cc -o "$t"/b.so -shared -fPIC -Wl,-soname,libfoo.so -xc -
 int fn1() { return 42; }
 EOF
 
-cat <<EOF | cc -o $t/c.so -shared -fPIC -Wl,-soname,libbar.so -xc -
+cat <<EOF | cc -o "$t"/c.so -shared -fPIC -Wl,-soname,libbar.so -xc -
 int fn2() { return 42; }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.so $t/c.so
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.so "$t"/c.so
 
-readelf --dynamic $t/exe > $t/readelf
-fgrep -q 'Shared library: [libfoo.so]' $t/readelf
-fgrep -q 'Shared library: [libbar.so]' $t/readelf
+readelf --dynamic "$t"/exe > "$t"/readelf
+fgrep -q 'Shared library: [libfoo.so]' "$t"/readelf
+fgrep -q 'Shared library: [libbar.so]' "$t"/readelf
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,--as-needed $t/b.so $t/c.so
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,--as-needed "$t"/b.so "$t"/c.so
 
-readelf --dynamic $t/exe > $t/readelf
-fgrep -q 'Shared library: [libfoo.so]' $t/readelf
-! fgrep -q 'Shared library: [libbar.so]' $t/readelf || false
+readelf --dynamic "$t"/exe > "$t"/readelf
+fgrep -q 'Shared library: [libfoo.so]' "$t"/readelf
+! fgrep -q 'Shared library: [libbar.so]' "$t"/readelf || false
 
 echo OK

--- a/test/elf/as-needed2.sh
+++ b/test/elf/as-needed2.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -shared -fPIC -o $t/a.so -xc -
+cat <<EOF | cc -shared -fPIC -o "$t"/a.so -xc -
 int foo() { return 3; }
 EOF
 
-cat <<EOF | cc -shared -fPIC -o $t/b.so -xc -
+cat <<EOF | cc -shared -fPIC -o "$t"/b.so -xc -
 int bar() { return 3; }
 EOF
 
-cat <<EOF | cc -shared -fPIC -o $t/c.so -xc -
+cat <<EOF | cc -shared -fPIC -o "$t"/c.so -xc -
 int foo();
 int baz() { return foo(); }
 EOF
 
-cat <<EOF | cc -c -o $t/d.o -xc -
+cat <<EOF | cc -c -o "$t"/d.o -xc -
 #include <stdio.h>
 int baz();
 int main() {
@@ -28,12 +28,12 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/d.o -Wl,--as-needed \
-  $t/c.so $t/b.so $t/a.so
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/d.o -Wl,--as-needed \
+  "$t"/c.so "$t"/b.so "$t"/a.so
 
-readelf --dynamic $t/exe > $t/log
-grep -q /a.so $t/log
-grep -q /c.so $t/log
-! grep -q /b.so $t/log || false
+readelf --dynamic "$t"/exe > "$t"/log
+grep -q /a.so "$t"/log
+grep -q /c.so "$t"/log
+! grep -q /b.so "$t"/log || false
 
 echo OK

--- a/test/elf/auxiliary.sh
+++ b/test/elf/auxiliary.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl _start
 _start:
   nop
 EOF
 
-$mold -o $t/b.so $t/a.o -auxiliary foo -f bar -shared
+"$mold" -o "$t"/b.so "$t"/a.o -auxiliary foo -f bar -shared
 
-readelf --dynamic $t/b.so > $t/log
-fgrep -q 'Auxiliary library: [foo]' $t/log
-fgrep -q 'Auxiliary library: [bar]' $t/log
+readelf --dynamic "$t"/b.so > "$t"/log
+fgrep -q 'Auxiliary library: [foo]' "$t"/log
+fgrep -q 'Auxiliary library: [bar]' "$t"/log
 
 echo OK

--- a/test/elf/basic.sh
+++ b/test/elf/basic.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-echo '.globl _start; _start: jmp loop' | cc -o $t/a.o -c -x assembler -
-echo '.globl loop; loop: jmp loop' | cc -o $t/b.o -c -x assembler -
-$mold -static -o $t/exe $t/a.o $t/b.o
-objdump -d $t/exe > /dev/null
-file $t/exe | grep -q ELF
+echo '.globl _start; _start: jmp loop' | cc -o "$t"/a.o -c -x assembler -
+echo '.globl loop; loop: jmp loop' | cc -o "$t"/b.o -c -x assembler -
+"$mold" -static -o "$t"/exe "$t"/a.o "$t"/b.o
+objdump -d "$t"/exe > /dev/null
+file "$t"/exe | grep -q ELF
 
 echo OK

--- a/test/elf/bno-symbolic.sh
+++ b/test/elf/bno-symbolic.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -fPIC -o$t/a.o -xc -
+cat <<EOF | cc -c -fPIC -o"$t"/a.o -xc -
 int foo = 4;
 
 int get_foo() {
@@ -19,9 +19,9 @@ void *bar() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -fPIC -o $t/b.so $t/a.o -Wl,-Bsymbolic -Wl,-Bno-symbolic
+clang -fuse-ld="$mold" -shared -fPIC -o "$t"/b.so "$t"/a.o -Wl,-Bsymbolic -Wl,-Bno-symbolic
 
-cat <<EOF | cc -c -o $t/c.o -xc - -fno-PIE
+cat <<EOF | cc -c -o "$t"/c.o -xc - -fno-PIE
 #include <stdio.h>
 
 extern int foo;
@@ -34,7 +34,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/c.o $t/b.so
-$t/exe | grep -q '3 3 1'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe | grep -q '3 3 1'
 
 echo OK

--- a/test/elf/bsymbolic-functions.sh
+++ b/test/elf/bsymbolic-functions.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -fPIC -xc -
+cat <<EOF | cc -c -o "$t"/a.o -fPIC -xc -
 int foo = 4;
 
 int get_foo() {
@@ -19,9 +19,9 @@ void *bar() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-Bsymbolic-functions
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-Bsymbolic-functions
 
-cat <<EOF | cc -c -o $t/c.o -xc - -fno-PIE
+cat <<EOF | cc -c -o "$t"/c.o -xc - -fno-PIE
 #include <stdio.h>
 
 extern int foo;
@@ -34,7 +34,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/c.o $t/b.so
-$t/exe | grep -q '3 3 0'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe | grep -q '3 3 0'
 
 echo OK

--- a/test/elf/bsymbolic.sh
+++ b/test/elf/bsymbolic.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -fPIC -o$t/a.o -xc -
+cat <<EOF | cc -c -fPIC -o"$t"/a.o -xc -
 int foo = 4;
 
 int get_foo() {
@@ -19,9 +19,9 @@ void *bar() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -fPIC -o $t/b.so $t/a.o -Wl,-Bsymbolic
+clang -fuse-ld="$mold" -shared -fPIC -o "$t"/b.so "$t"/a.o -Wl,-Bsymbolic
 
-cat <<EOF | cc -c -o $t/c.o -xc - -fno-PIE
+cat <<EOF | cc -c -o "$t"/c.o -xc - -fno-PIE
 #include <stdio.h>
 
 extern int foo;
@@ -34,7 +34,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/c.o $t/b.so
-$t/exe | grep -q '3 4 0'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe | grep -q '3 4 0'
 
 echo OK

--- a/test/elf/bug178.sh
+++ b/test/elf/bug178.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Verify that mold does not crash if no object file is included
 # in the output. The resulting executable doesn't contain any
 # meaningful code or data, so this is an edge case, though.
 
-cat <<EOF | cc -x assembler -c -o $t/a.o -
+cat <<EOF | cc -x assembler -c -o "$t"/a.o -
 .globl foo
 foo:
 EOF
 
-rm -f $t/a.a
-ar rcs $t/a.a $t/a.o
+rm -f "$t"/a.a
+ar rcs "$t"/a.a "$t"/a.o
 
-$mold -o $t/exe $t/a.a
+"$mold" -o "$t"/exe "$t"/a.a
 
 echo OK

--- a/test/elf/build-id.sh
+++ b/test/elf/build-id.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() { return 0; }' > $t/a.c
+echo 'int main() { return 0; }' > "$t"/a.c
 
-clang -o $t/exe $t/a.c -fuse-ld=$mold -Wl,-build-id
-readelf -n $t/exe | grep -qv 'GNU.*0x00000010.*NT_GNU_BUILD_ID'
+clang -o "$t"/exe "$t"/a.c -fuse-ld="$mold" -Wl,-build-id
+readelf -n "$t"/exe | grep -qv 'GNU.*0x00000010.*NT_GNU_BUILD_ID'
 
-clang -o $t/exe $t/a.c -fuse-ld=$mold -Wl,-build-id=uuid
-readelf -nW $t/exe |
+clang -o "$t"/exe "$t"/a.c -fuse-ld="$mold" -Wl,-build-id=uuid
+readelf -nW "$t"/exe |
   grep -Pq 'GNU.*0x00000010.*NT_GNU_BUILD_ID.*Build ID: ............4...[89abcdef]'
 
-clang -o $t/exe $t/a.c -fuse-ld=$mold -Wl,-build-id=md5
-readelf -n $t/exe | grep -q 'GNU.*0x00000010.*NT_GNU_BUILD_ID'
+clang -o "$t"/exe "$t"/a.c -fuse-ld="$mold" -Wl,-build-id=md5
+readelf -n "$t"/exe | grep -q 'GNU.*0x00000010.*NT_GNU_BUILD_ID'
 
-clang -o $t/exe $t/a.c -fuse-ld=$mold -Wl,-build-id=sha1
-readelf -n $t/exe | grep -q 'GNU.*0x00000014.*NT_GNU_BUILD_ID'
+clang -o "$t"/exe "$t"/a.c -fuse-ld="$mold" -Wl,-build-id=sha1
+readelf -n "$t"/exe | grep -q 'GNU.*0x00000014.*NT_GNU_BUILD_ID'
 
-clang -o $t/exe $t/a.c -fuse-ld=$mold -Wl,-build-id=sha256
-readelf -n $t/exe | grep -q 'GNU.*0x00000020.*NT_GNU_BUILD_ID'
+clang -o "$t"/exe "$t"/a.c -fuse-ld="$mold" -Wl,-build-id=sha256
+readelf -n "$t"/exe | grep -q 'GNU.*0x00000020.*NT_GNU_BUILD_ID'
 
-clang -o $t/exe $t/a.c -fuse-ld=$mold -Wl,-build-id=0xdeadbeef
-readelf -n $t/exe | grep -q 'Build ID: deadbeef'
+clang -o "$t"/exe "$t"/a.c -fuse-ld="$mold" -Wl,-build-id=0xdeadbeef
+readelf -n "$t"/exe | grep -q 'Build ID: deadbeef'
 
 echo OK

--- a/test/elf/canonical-plt.sh
+++ b/test/elf/canonical-plt.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.so -fPIC -shared -xc -
+cat <<EOF | cc -o "$t"/a.so -fPIC -shared -xc -
 void *foo() {
   return foo;
 }
@@ -17,7 +17,7 @@ void *bar() {
 }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc - -fPIC
+cat <<EOF | cc -o "$t"/b.o -c -xc - -fPIC
 void *bar();
 
 void *baz() {
@@ -25,7 +25,7 @@ void *baz() {
 }
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc - -fno-PIC
+cat <<EOF | cc -o "$t"/c.o -c -xc - -fno-PIC
 #include <stdio.h>
 
 void *foo();
@@ -37,7 +37,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/a.so $t/b.o $t/c.o
-$t/exe | grep -q '^1 1 1$'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/a.so "$t"/b.o "$t"/c.o
+"$t"/exe | grep -q '^1 1 1$'
 
 echo OK

--- a/test/elf/cmdline.sh
+++ b/test/elf/cmdline.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-(! $mold -zfoo) 2>&1 | grep -q 'unknown command line option: -zfoo'
-(! $mold -z foo) 2>&1 | grep -q 'unknown command line option: -z foo'
-(! $mold -abcdefg) 2>&1 | grep -q 'unknown command line option: -abcdefg'
-(! $mold --abcdefg) 2>&1 | grep -q 'unknown command line option: --abcdefg'
+(! "$mold" -zfoo) 2>&1 | grep -q 'unknown command line option: -zfoo'
+(! "$mold" -z foo) 2>&1 | grep -q 'unknown command line option: -z foo'
+(! "$mold" -abcdefg) 2>&1 | grep -q 'unknown command line option: -abcdefg'
+(! "$mold" --abcdefg) 2>&1 | grep -q 'unknown command line option: --abcdefg'
 
 echo OK

--- a/test/elf/color-diagnostics.sh
+++ b/test/elf/color-diagnostics.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int foo();
 int main() { foo(); }
 EOF
 
-! $mold -o $t/exe $t/a.o --color-diagnostics 2> $t/log
-grep -Pq '\e' $t/log
+! "$mold" -o "$t"/exe "$t"/a.o --color-diagnostics 2> "$t"/log
+grep -Pq '\e' "$t"/log
 
-! $mold -o $t/exe $t/a.o --color-diagnostics=always 2> $t/log
-grep -Pq '\e' $t/log
+! "$mold" -o "$t"/exe "$t"/a.o --color-diagnostics=always 2> "$t"/log
+grep -Pq '\e' "$t"/log
 
-! $mold -o $t/exe $t/a.o --color-diagnostics=never 2> $t/log
-! grep -Pq '\e' $t/log || false
+! "$mold" -o "$t"/exe "$t"/a.o --color-diagnostics=never 2> "$t"/log
+! grep -Pq '\e' "$t"/log || false
 
-! $mold -o $t/exe $t/a.o --color-diagnostics=auto 2> $t/log
-! grep -Pq '\e' $t/log || false
+! "$mold" -o "$t"/exe "$t"/a.o --color-diagnostics=auto 2> "$t"/log
+! grep -Pq '\e' "$t"/log || false
 
 echo OK

--- a/test/elf/comment.sh
+++ b/test/elf/comment.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-readelf -p .comment $t/exe | grep -q 'mold'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+readelf -p .comment "$t"/exe | grep -q 'mold'
 
 echo OK

--- a/test/elf/common-archive.sh
+++ b/test/elf/common-archive.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fcommon -xc -c -o $t/a.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/a.o -
 #include <stdio.h>
 
 int foo;
@@ -19,30 +19,30 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -fcommon -xc -c -o $t/b.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/b.o -
 int foo = 5;
 EOF
 
-cat <<EOF | cc -fcommon -xc -c -o $t/c.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/c.o -
 int bar;
 int two() { return 2; }
 EOF
 
-rm -f $t/d.a
-ar rcs $t/d.a $t/b.o $t/c.o
+rm -f "$t"/d.a
+ar rcs "$t"/d.a "$t"/b.o "$t"/c.o
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/d.a
-$t/exe | grep -q '5 0 -1'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/d.a
+"$t"/exe | grep -q '5 0 -1'
 
-cat <<EOF | cc -fcommon -xc -c -o $t/e.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/e.o -
 int bar = 0;
 int two() { return 2; }
 EOF
 
-rm -f $t/e.a
-ar rcs $t/e.a $t/b.o $t/e.o
+rm -f "$t"/e.a
+ar rcs "$t"/e.a "$t"/b.o "$t"/e.o
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/e.a
-$t/exe | grep -q '5 0 2'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/e.a
+"$t"/exe | grep -q '5 0 2'
 
 echo OK

--- a/test/elf/common-ref.sh
+++ b/test/elf/common-ref.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fcommon -xc -c -o $t/a.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/a.o -
 #include <stdio.h>
 
 int bar;
@@ -17,23 +17,23 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -fcommon -xc -c -o $t/b.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/b.o -
 int foo;
 EOF
 
-rm -f $t/c.a
-ar rcs $t/c.a $t/b.o
+rm -f "$t"/c.a
+ar rcs "$t"/c.a "$t"/b.o
 
-cat <<EOF | cc -fcommon -xc -c -o $t/d.o -
+cat <<EOF | cc -fcommon -xc -c -o "$t"/d.o -
 int foo;
 int bar = 5;
 int get_foo() { return foo; }
 EOF
 
-rm -f $t/e.a
-ar rcs $t/e.a $t/d.o
+rm -f "$t"/e.a
+ar rcs "$t"/e.a "$t"/d.o
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/c.a $t/e.a
-$t/exe | grep -q 5
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/c.a "$t"/e.a
+"$t"/exe | grep -q 5
 
 echo OK

--- a/test/elf/common.sh
+++ b/test/elf/common.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fcommon -xc -c -o $t/a.o -
+cat <<EOF | clang -fcommon -xc -c -o "$t"/a.o -
 int foo;
 int bar;
 int baz = 42;
 EOF
 
-cat <<EOF | clang -fcommon -xc -c -o $t/b.o -
+cat <<EOF | clang -fcommon -xc -c -o "$t"/b.o -
 #include <stdio.h>
 
 int foo;
@@ -25,10 +25,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '0 5 42'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '0 5 42'
 
-readelf --sections $t/exe > $t/log
-grep -q '.common .*NOBITS' $t/log
+readelf --sections "$t"/exe > "$t"/log
+grep -q '.common .*NOBITS' "$t"/log
 
 echo OK

--- a/test/elf/compress-debug-sections.sh
+++ b/test/elf/compress-debug-sections.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 which dwarfdump >& /dev/null || { echo skipped; exit; }
 
-cat <<EOF | clang -c -g -o $t/a.o -xc -
+cat <<EOF | clang -c -g -o "$t"/a.o -xc -
 #include <stdio.h>
 
 int main() {
@@ -18,14 +18,14 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,--compress-debug-sections=zlib
-dwarfdump $t/exe > $t/log
-fgrep -q '.debug_info SHF_COMPRESSED' $t/log
-fgrep -q '.debug_str SHF_COMPRESSED' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,--compress-debug-sections=zlib
+dwarfdump "$t"/exe > "$t"/log
+fgrep -q '.debug_info SHF_COMPRESSED' "$t"/log
+fgrep -q '.debug_str SHF_COMPRESSED' "$t"/log
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,--compress-debug-sections=zlib-gnu
-dwarfdump $t/exe > $t/log
-fgrep -q .zdebug_info $t/log
-fgrep -q .zdebug_str $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,--compress-debug-sections=zlib-gnu
+dwarfdump "$t"/exe > "$t"/log
+fgrep -q .zdebug_info "$t"/log
+fgrep -q .zdebug_str "$t"/log
 
 echo OK

--- a/test/elf/compressed-debug-info.sh
+++ b/test/elf/compressed-debug-info.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ..."
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ..."
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 which dwarfdump >& /dev/null || { echo skipped; exit; }
 
-cat <<EOF | g++ -c -o $t/a.o -g -gz=zlib-gnu -xc++ -
+cat <<EOF | g++ -c -o "$t"/a.o -g -gz=zlib-gnu -xc++ -
 int main() {
   return 0;
 }
 EOF
 
-cat <<EOF | g++ -c -o $t/b.o -g -gz=zlib -xc++ -
+cat <<EOF | g++ -c -o "$t"/b.o -g -gz=zlib -xc++ -
 int foo() {
   return 0;
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-dwarfdump $t/exe > /dev/null
-readelf --sections $t/exe | fgrep -q .debug_info
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+dwarfdump "$t"/exe > /dev/null
+readelf --sections "$t"/exe | fgrep -q .debug_info
 
 echo ' OK'

--- a/test/elf/copyrel-protected.sh
+++ b/test/elf/copyrel-protected.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -fno-PIE -
+cat <<EOF | cc -o "$t"/a.o -c -xc -fno-PIE -
 extern int foo;
 
 int main() {
@@ -15,11 +15,11 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -shared -o $t/b.so -xc -
+cat <<EOF | cc -shared -o "$t"/b.so -xc -
 __attribute__((visibility("protected"))) int foo;
 EOF
 
-! clang -fuse-ld=$mold $t/a.o $t/b.so -o $t/exe >& $t/log || false
-fgrep -q 'cannot make copy relocation for protected symbol' $t/log
+! clang -fuse-ld="$mold" "$t"/a.o "$t"/b.so -o "$t"/exe >& "$t"/log || false
+fgrep -q 'cannot make copy relocation for protected symbol' "$t"/log
 
 echo OK

--- a/test/elf/copyrel-relro.sh
+++ b/test/elf/copyrel-relro.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -fno-PIE -
+cat <<EOF | cc -o "$t"/a.o -c -xc -fno-PIE -
 extern const char readonly[100];
 extern char readwrite[100];
 
@@ -16,15 +16,15 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -shared -o $t/b.so -xc -
+cat <<EOF | cc -shared -o "$t"/b.so -xc -
 const char readonly[100] = "abc";
 char readwrite[100] = "abc";
 EOF
 
-clang -fuse-ld=$mold $t/a.o $t/b.so -o $t/exe
-readelf -a $t/exe > $t/log
+clang -fuse-ld="$mold" "$t"/a.o "$t"/b.so -o "$t"/exe
+readelf -a "$t"/exe > "$t"/log
 
-grep -Pqz '(?s)\[(\d+)\] .dynbss.rel.ro .* \1 readonly' $t/log
-grep -Pqz '(?s)\[(\d+)\] .dynbss .* \1 readwrite' $t/log
+grep -Pqz '(?s)\[(\d+)\] .dynbss.rel.ro .* \1 readonly' "$t"/log
+grep -Pqz '(?s)\[(\d+)\] .dynbss .* \1 readwrite' "$t"/log
 
 echo OK

--- a/test/elf/copyrel.sh
+++ b/test/elf/copyrel.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fno-PIC -o $t/a.o -c -xc -
+cat <<EOF | cc -fno-PIC -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 extern int foo;
@@ -19,7 +19,7 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -x assembler -
+cat <<EOF | cc -o "$t"/b.o -c -x assembler -
   .globl foo, bar
   .data;
 foo:
@@ -27,7 +27,7 @@ bar:
   .long 42
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '42 42 1'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '42 42 1'
 
 echo OK

--- a/test/elf/ctors-dtors.sh
+++ b/test/elf/ctors-dtors.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
 # Skip if libc is musl
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
-cat <<'EOF' | clang -c -o $t/a.o -x assembler -
+cat <<'EOF' | clang -c -o "$t"/a.o -x assembler -
 .L0:
   mov $0, %edi
   call print
@@ -64,7 +64,7 @@ cat <<'EOF' | clang -c -o $t/a.o -x assembler -
 .quad .L7
 EOF
 
-cat <<'EOF' | clang -c -o $t/b.o -x assembler -
+cat <<'EOF' | clang -c -o "$t"/b.o -x assembler -
 .L8:
   mov $8, %edi
   call print
@@ -115,7 +115,7 @@ cat <<'EOF' | clang -c -o $t/b.o -x assembler -
 .quad .Lf
 EOF
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 #include <stdio.h>
 
 void print(int n) {
@@ -125,7 +125,7 @@ void print(int n) {
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o $t/c.o
-$t/exe | grep -q '^013289baefdc6754$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o "$t"/c.o
+"$t"/exe | grep -q '^013289baefdc6754$'
 
 echo OK

--- a/test/elf/demangle.sh
+++ b/test/elf/demangle.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc++ -
+cat <<EOF | clang -c -o "$t"/a.o -xc++ -
 int foo(int, int);
 int main() {
   foo(3, 4);
 }
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-no-demangle 2> $t/log || false
-grep -q 'undefined symbol: .*: _Z3fooii' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-no-demangle 2> "$t"/log || false
+grep -q 'undefined symbol: .*: _Z3fooii' "$t"/log
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-demangle 2> $t/log || false
-grep -Pq 'undefined symbol: .*: foo\(int, int\)' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-demangle 2> "$t"/log || false
+grep -Pq 'undefined symbol: .*: foo\(int, int\)' "$t"/log
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o 2> $t/log || false
-grep -Pq 'undefined symbol: .*: foo\(int, int\)' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o 2> "$t"/log || false
+grep -Pq 'undefined symbol: .*: foo\(int, int\)' "$t"/log
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 extern int Pi;
 int main() {
   return Pi;
 }
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/b.o -Wl,-demangle 2> $t/log || false
-grep -q 'undefined symbol: .*: Pi' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o -Wl,-demangle 2> "$t"/log || false
+grep -q 'undefined symbol: .*: Pi' "$t"/log
 
 echo OK

--- a/test/elf/discard.sh
+++ b/test/elf/discard.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -Wa,--keep-locals -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -Wa,--keep-locals -
   .text
   .globl _start
 _start:
@@ -18,28 +18,28 @@ foo:
   nop
 EOF
 
-$mold -o $t/exe $t/a.o
-readelf --symbols $t/exe > $t/log
-fgrep -q _start $t/log
-fgrep -q foo $t/log
-fgrep -q .Lbar $t/log
+"$mold" -o "$t"/exe "$t"/a.o
+readelf --symbols "$t"/exe > "$t"/log
+fgrep -q _start "$t"/log
+fgrep -q foo "$t"/log
+fgrep -q .Lbar "$t"/log
 
-$mold -o $t/exe $t/a.o --discard-locals
-readelf --symbols $t/exe > $t/log
-fgrep -q _start $t/log
-fgrep -q foo $t/log
-! fgrep -q .Lbar $t/log || false
+"$mold" -o "$t"/exe "$t"/a.o --discard-locals
+readelf --symbols "$t"/exe > "$t"/log
+fgrep -q _start "$t"/log
+fgrep -q foo "$t"/log
+! fgrep -q .Lbar "$t"/log || false
 
-$mold -o $t/exe $t/a.o --discard-all
-readelf --symbols $t/exe > $t/log
-fgrep -q _start $t/log
-! fgrep -q foo $t/log || false
-! fgrep -q .Lbar $t/log || false
+"$mold" -o "$t"/exe "$t"/a.o --discard-all
+readelf --symbols "$t"/exe > "$t"/log
+fgrep -q _start "$t"/log
+! fgrep -q foo "$t"/log || false
+! fgrep -q .Lbar "$t"/log || false
 
-$mold -o $t/exe $t/a.o --strip-all
-readelf --symbols $t/exe > $t/log
-! fgrep -q _start $t/log || false
-! fgrep -q foo $t/log || false
-! fgrep -q .Lbar $t/log || false
+"$mold" -o "$t"/exe "$t"/a.o --strip-all
+readelf --symbols "$t"/exe > "$t"/log
+! fgrep -q _start "$t"/log || false
+! fgrep -q foo "$t"/log || false
+! fgrep -q .Lbar "$t"/log || false
 
 echo OK

--- a/test/elf/dt-init.sh
+++ b/test/elf/dt-init.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -x assembler -
+cat <<EOF | clang -c -o "$t"/a.o -x assembler -
 .globl main, init, fini
 main:
   ret
@@ -17,18 +17,18 @@ fini:
   ret
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-readelf -a $t/exe > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+readelf -a "$t"/exe > "$t"/log
 
-grep -Pqz '(?s)\(INIT\)\s+0x([0-9a-f]+)\b.*\1\s+0 \w+\s+GLOBAL \w+\s+\d+ _init\b' $t/log
+grep -Pqz '(?s)\(INIT\)\s+0x([0-9a-f]+)\b.*\1\s+0 \w+\s+GLOBAL \w+\s+\d+ _init\b' "$t"/log
 
-grep -Pqz '(?s)\(FINI\)\s+0x([0-9a-f]+)\b.*\1\s+0 \w+\s+GLOBAL \w+\s+\d+ _fini\b' $t/log
+grep -Pqz '(?s)\(FINI\)\s+0x([0-9a-f]+)\b.*\1\s+0 \w+\s+GLOBAL \w+\s+\d+ _fini\b' "$t"/log
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-init,init -Wl,-fini,fini
-readelf -a $t/exe > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-init,init -Wl,-fini,fini
+readelf -a "$t"/exe > "$t"/log
 
-grep -Pqz '(?s)\(INIT\)\s+0x([0-9a-f]+)\b.*\1\s+0 NOTYPE  GLOBAL DEFAULT\s+\d+ init\b' $t/log
+grep -Pqz '(?s)\(INIT\)\s+0x([0-9a-f]+)\b.*\1\s+0 NOTYPE  GLOBAL DEFAULT\s+\d+ init\b' "$t"/log
 
-grep -Pqz '(?s)\(FINI\)\s+0x([0-9a-f]+)\b.*\1\s+0 NOTYPE  GLOBAL DEFAULT\s+\d+ fini\b' $t/log
+grep -Pqz '(?s)\(FINI\)\s+0x([0-9a-f]+)\b.*\1\s+0 NOTYPE  GLOBAL DEFAULT\s+\d+ fini\b' "$t"/log
 
 echo OK

--- a/test/elf/dt-needed.sh
+++ b/test/elf/dt-needed.sh
@@ -1,33 +1,33 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 void foo() {}
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/libfoo.so $t/a.o -Wl,--soname,libfoo
-clang -fuse-ld=$mold -shared -o $t/libbar.so $t/a.o
+clang -fuse-ld="$mold" -shared -o "$t"/libfoo.so "$t"/a.o -Wl,--soname,libfoo
+clang -fuse-ld="$mold" -shared -o "$t"/libbar.so "$t"/a.o
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/libfoo.so
-readelf --dynamic $t/exe | fgrep -q 'Shared library: [libfoo]'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/libfoo.so
+readelf --dynamic "$t"/exe | fgrep -q 'Shared library: [libfoo]'
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o -L $t -lfoo
-readelf --dynamic $t/exe | fgrep -q 'Shared library: [libfoo]'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o -L "$t" -lfoo
+readelf --dynamic "$t"/exe | fgrep -q 'Shared library: [libfoo]'
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/libbar.so
-readelf --dynamic $t/exe | grep -Pq 'Shared library: \[.*dt-needed/libbar\.so\]'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/libbar.so
+readelf --dynamic "$t"/exe | grep -Pq 'Shared library: \[.*dt-needed/libbar\.so\]'
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o -L$t -lbar
-readelf --dynamic $t/exe | fgrep -q 'Shared library: [libbar.so]'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o -L"$t" -lbar
+readelf --dynamic "$t"/exe | fgrep -q 'Shared library: [libbar.so]'
 
 echo OK

--- a/test/elf/duplicate-error.sh
+++ b/test/elf/duplicate-error.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl main
 main:
   nop
 EOF
 
-! $mold -o $t/exe $t/a.o $t/a.o 2> $t/log || false
-grep -q 'duplicate symbol: .*\.o: .*\.o: main' $t/log
+! "$mold" -o "$t"/exe "$t"/a.o "$t"/a.o 2> "$t"/log || false
+grep -q 'duplicate symbol: .*\.o: .*\.o: main' "$t"/log
 
 echo OK

--- a/test/elf/dynamic-linker.sh
+++ b/test/elf/dynamic-linker.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -x assembler -
+cat <<EOF | clang -c -o "$t"/a.o -x assembler -
 .globl _start
 _start:
   ret
 EOF
 
-$mold -o $t/exe $t/a.o
+"$mold" -o "$t"/exe "$t"/a.o
 
-readelf --sections $t/exe > $t/log
-! fgrep .interp $t/log || false
+readelf --sections "$t"/exe > "$t"/log
+! fgrep .interp "$t"/log || false
 
-readelf --dynamic $t/exe > $t/log
+readelf --dynamic "$t"/exe > "$t"/log
 
-$mold -o $t/exe $t/a.o --dynamic-linker=/foo/bar
+"$mold" -o "$t"/exe "$t"/a.o --dynamic-linker=/foo/bar
 
-readelf --sections $t/exe > $t/log
-fgrep -q .interp $t/log
+readelf --sections "$t"/exe > "$t"/log
+fgrep -q .interp "$t"/log
 
 echo OK

--- a/test/elf/dynamic-list.sh
+++ b/test/elf/dynamic-list.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void foo() {}
 void bar() {}
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
 
-readelf --dyn-syms $t/exe > $t/log
-! grep -q ' foo$' $t/log || false
-! grep -q ' bar$' $t/log || false
+readelf --dyn-syms "$t"/exe > "$t"/log
+! grep -q ' foo$' "$t"/log || false
+! grep -q ' bar$' "$t"/log || false
 
-cat <<EOF > $t/dyn
+cat <<EOF > "$t"/dyn
 { foo; bar; };
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-dynamic-list=$t/dyn
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-dynamic-list="$t"/dyn
 
-readelf --dyn-syms $t/exe > $t/log
-grep -q ' foo$' $t/log
-grep -q ' bar$' $t/log
+readelf --dyn-syms "$t"/exe > "$t"/log
+grep -q ' foo$' "$t"/log
+grep -q ' bar$' "$t"/log
 
 echo OK

--- a/test/elf/dynamic-list2.sh
+++ b/test/elf/dynamic-list2.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void foo(int x) {}
 void bar(int x) {}
 EOF
 
-cat <<EOF | c++ -o $t/b.o -c -xc++ -
+cat <<EOF | c++ -o "$t"/b.o -c -xc++ -
 void baz(int x) {}
 int main() {}
 EOF
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
 
-readelf --dyn-syms $t/exe > $t/log
-! grep -q ' foo$' $t/log || false
-! grep -q ' bar$' $t/log || false
+readelf --dyn-syms "$t"/exe > "$t"/log
+! grep -q ' foo$' "$t"/log || false
+! grep -q ' bar$' "$t"/log || false
 
-cat <<EOF > $t/dyn
+cat <<EOF > "$t"/dyn
 { foo; extern "C++" { "baz(int)"; }; };
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-dynamic-list=$t/dyn
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-dynamic-list="$t"/dyn
 
-readelf --dyn-syms $t/exe > $t/log
-grep -q ' foo$' $t/log
-! grep -q ' bar$' $t/log || false
-grep -q ' _Z3bazi$' $t/log
+readelf --dyn-syms "$t"/exe > "$t"/log
+grep -q ' foo$' "$t"/log
+! grep -q ' bar$' "$t"/log || false
+grep -q ' _Z3bazi$' "$t"/log
 
 echo OK

--- a/test/elf/dynamic.sh
+++ b/test/elf/dynamic.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo '.globl main; main:' | cc -o $t/a.o -c -x assembler -
+echo '.globl main; main:' | cc -o "$t"/a.o -c -x assembler -
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
 
-readelf --dynamic $t/exe > $t/log
-grep -Pq 'Shared library:.*\blibc.so\b' $t/log
+readelf --dynamic "$t"/exe > "$t"/log
+grep -Pq 'Shared library:.*\blibc.so\b' "$t"/log
 
-readelf -W --symbols --use-dynamic $t/exe > $t/log2
-grep -Pq 'FUNC\s+GLOBAL\s+DEFAULT\s+UND\s+__libc_start_main' $t/log2
+readelf -W --symbols --use-dynamic "$t"/exe > "$t"/log2
+grep -Pq 'FUNC\s+GLOBAL\s+DEFAULT\s+UND\s+__libc_start_main' "$t"/log2
 
-cat <<EOF | clang -c -fPIC -o $t/b.o -xc -
+cat <<EOF | clang -c -fPIC -o "$t"/b.o -xc -
 #include <stdio.h>
 
 int main() {
@@ -25,8 +25,8 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe -pie $t/b.o
-count=$(readelf -W --relocs $t/exe | grep -P 'R_[\w\d_]+_RELATIVE' | wc -l)
-readelf -W --dynamic $t/exe | grep -q "RELACOUNT.*\b$count\b"
+clang -fuse-ld="$mold" -o "$t"/exe -pie "$t"/b.o
+count=$(readelf -W --relocs "$t"/exe | grep -P 'R_[\w\d_]+_RELATIVE' | wc -l)
+readelf -W --dynamic "$t"/exe | grep -q "RELACOUNT.*\b$count\b"
 
 echo OK

--- a/test/elf/empty-file.sh
+++ b/test/elf/empty-file.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-rm -f $t/b.script
-touch $t/b.script
+rm -f "$t"/b.script
+touch "$t"/b.script
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,--version-script,$t/b.script
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,--version-script,"$t"/b.script
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/empty-version.sh
+++ b/test/elf/empty-version.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc -
 void foo1() {}
 void foo2() {}
 
@@ -15,9 +15,9 @@ __asm__(".symver foo1, bar1@");
 __asm__(".symver foo2, bar2@@");
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o
 
-readelf --dyn-syms $t/b.so | grep -q 'bar1$'
-readelf --dyn-syms $t/b.so | grep -q 'bar2$'
+readelf --dyn-syms "$t"/b.so | grep -q 'bar1$'
+readelf --dyn-syms "$t"/b.so | grep -q 'bar2$'
 
 echo OK

--- a/test/elf/entry.sh
+++ b/test/elf/entry.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 .globl foo, bar
 foo:
   .quad 0
@@ -15,16 +15,16 @@ bar:
   .quad 0
 EOF
 
-$mold -e foo -static -o $t/exe $t/a.o
-readelf -e $t/exe > $t/log
-grep -q 'Entry point address:.*0x201000' $t/log
+"$mold" -e foo -static -o "$t"/exe "$t"/a.o
+readelf -e "$t"/exe > "$t"/log
+grep -q 'Entry point address:.*0x201000' "$t"/log
 
-$mold -e bar -static -o $t/exe $t/a.o
-readelf -e $t/exe > $t/log
-grep -q 'Entry point address:.*0x201008' $t/log
+"$mold" -e bar -static -o "$t"/exe "$t"/a.o
+readelf -e "$t"/exe > "$t"/log
+grep -q 'Entry point address:.*0x201008' "$t"/log
 
-$mold -static -o $t/exe $t/a.o
-readelf -e $t/exe > $t/log
-grep -q 'Entry point address:.*0x201000' $t/log
+"$mold" -static -o "$t"/exe "$t"/a.o
+readelf -e "$t"/exe > "$t"/log
+grep -q 'Entry point address:.*0x201000' "$t"/log
 
 echo OK

--- a/test/elf/exception.sh
+++ b/test/elf/exception.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.cc
+cat <<EOF > "$t"/a.cc
 int main() {
   try {
     throw 0;
@@ -18,19 +18,19 @@ int main() {
 }
 EOF
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.cc -static
-$t/exe
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.cc -static
+"$t"/exe
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.cc
-$t/exe
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.cc
+"$t"/exe
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.cc -Wl,--gc-sections
-$t/exe
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.cc -Wl,--gc-sections
+"$t"/exe
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.cc -static -Wl,--gc-sections
-$t/exe
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.cc -static -Wl,--gc-sections
+"$t"/exe
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.cc -static -mcmodel=large
-$t/exe
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.cc -static -mcmodel=large
+"$t"/exe
 
 echo OK

--- a/test/elf/exclude-libs.sh
+++ b/test/elf/exclude-libs.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fPIC -xc -c -o $t/a.o -
+cat <<EOF | clang -fPIC -xc -c -o "$t"/a.o -
 int foo() {
   return 3;
 }
 EOF
 
-cat <<EOF | clang -fPIC -xc -c -o $t/b.o -
+cat <<EOF | clang -fPIC -xc -c -o "$t"/b.o -
 int bar() {
   return 5;
 }
 EOF
 
-rm -f $t/c.a
-ar crs $t/c.a $t/a.o
+rm -f "$t"/c.a
+ar crs "$t"/c.a "$t"/a.o
 
-rm -f $t/d.a
-ar crs $t/d.a $t/b.o
+rm -f "$t"/d.a
+ar crs "$t"/d.a "$t"/b.o
 
-cat <<EOF | clang -fPIC -xc -c -o $t/e.o -
+cat <<EOF | clang -fPIC -xc -c -o "$t"/e.o -
 int foo();
 int bar();
 
@@ -36,28 +36,28 @@ int baz() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/f.so $t/e.o $t/c.a $t/d.a
-readelf --dyn-syms $t/f.so > $t/log
-fgrep -q foo $t/log
-fgrep -q bar $t/log
-fgrep -q baz $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/f.so "$t"/e.o "$t"/c.a "$t"/d.a
+readelf --dyn-syms "$t"/f.so > "$t"/log
+fgrep -q foo "$t"/log
+fgrep -q bar "$t"/log
+fgrep -q baz "$t"/log
 
-clang -fuse-ld=$mold -shared -o $t/f.so $t/e.o $t/c.a $t/d.a -Wl,-exclude-libs=c.a
-readelf --dyn-syms $t/f.so > $t/log
-! fgrep -q foo $t/log || false
-fgrep -q bar $t/log
-fgrep -q baz $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/f.so "$t"/e.o "$t"/c.a "$t"/d.a -Wl,-exclude-libs=c.a
+readelf --dyn-syms "$t"/f.so > "$t"/log
+! fgrep -q foo "$t"/log || false
+fgrep -q bar "$t"/log
+fgrep -q baz "$t"/log
 
-clang -fuse-ld=$mold -shared -o $t/f.so $t/e.o $t/c.a $t/d.a -Wl,-exclude-libs=c.a -Wl,-exclude-libs=d.a
-readelf --dyn-syms $t/f.so > $t/log
-! fgrep -q foo $t/log || false
-! fgrep -q bar $t/log || false
-fgrep -q baz $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/f.so "$t"/e.o "$t"/c.a "$t"/d.a -Wl,-exclude-libs=c.a -Wl,-exclude-libs=d.a
+readelf --dyn-syms "$t"/f.so > "$t"/log
+! fgrep -q foo "$t"/log || false
+! fgrep -q bar "$t"/log || false
+fgrep -q baz "$t"/log
 
-clang -fuse-ld=$mold -shared -o $t/f.so $t/e.o $t/c.a $t/d.a -Wl,-exclude-libs=ALL
-readelf --dyn-syms $t/f.so > $t/log
-! fgrep -q foo $t/log || false
-! fgrep -q bar $t/log || false
-fgrep -q baz $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/f.so "$t"/e.o "$t"/c.a "$t"/d.a -Wl,-exclude-libs=ALL
+readelf --dyn-syms "$t"/f.so > "$t"/log
+! fgrep -q foo "$t"/log || false
+! fgrep -q bar "$t"/log || false
+fgrep -q baz "$t"/log
 
 echo OK

--- a/test/elf/exclude-libs2.sh
+++ b/test/elf/exclude-libs2.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -x assembler -c -o $t/a.o -
+cat <<EOF | clang -x assembler -c -o "$t"/a.o -
 .globl foo
 foo:
   ret
 EOF
 
-rm -f $t/b.a
-ar crs $t/b.a $t/a.o
+rm -f "$t"/b.a
+ar crs "$t"/b.a "$t"/a.o
 
-cat <<EOF | clang -xc -c -o $t/c.o -
+cat <<EOF | clang -xc -c -o "$t"/c.o -
 int foo() {
   return 3;
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/d.so $t/c.o $t/b.a -Wl,-exclude-libs=b.a
-readelf --dyn-syms $t/d.so > $t/log
-fgrep -q foo $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/d.so "$t"/c.o "$t"/b.a -Wl,-exclude-libs=b.a
+readelf --dyn-syms "$t"/d.so > "$t"/log
+fgrep -q foo "$t"/log
 
 echo OK

--- a/test/elf/exclude-libs3.sh
+++ b/test/elf/exclude-libs3.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -xc -c -o $t/a.o -
+cat <<EOF | clang -xc -c -o "$t"/a.o -
 void foo();
 void bar() { foo(); }
 EOF
 
-rm -f $t/b.a
-ar crs $t/b.a $t/a.o
+rm -f "$t"/b.a
+ar crs "$t"/b.a "$t"/a.o
 
-cat <<EOF | clang -xc -c -o $t/c.o -
+cat <<EOF | clang -xc -c -o "$t"/c.o -
 void bar();
 void foo() { bar(); }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/d.so $t/c.o $t/b.a -Wl,-exclude-libs=ALL
-readelf --dyn-syms $t/d.so > $t/log
-fgrep -q foo $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/d.so "$t"/c.o "$t"/b.a -Wl,-exclude-libs=ALL
+readelf --dyn-syms "$t"/d.so > "$t"/log
+fgrep -q foo "$t"/log
 
 echo OK

--- a/test/elf/execstack.sh
+++ b/test/elf/execstack.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -xc -o $t/a.o -
+cat <<EOF | clang -c -xc -o "$t"/a.o -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-z,execstack
-readelf --segments -W $t/exe > $t/log
-grep -q 'GNU_STACK.* RWE ' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-z,execstack
+readelf --segments -W "$t"/exe > "$t"/log
+grep -q 'GNU_STACK.* RWE ' "$t"/log
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-z,execstack \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-z,execstack \
   -Wl,-z,noexecstack
-readelf --segments -W $t/exe > $t/log
-grep -q 'GNU_STACK.* RW ' $t/log
+readelf --segments -W "$t"/exe > "$t"/log
+grep -q 'GNU_STACK.* RW ' "$t"/log
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-readelf --segments -W $t/exe > $t/log
-grep -q 'GNU_STACK.* RW ' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+readelf --segments -W "$t"/exe > "$t"/log
+grep -q 'GNU_STACK.* RW ' "$t"/log
 
 echo OK

--- a/test/elf/export-dynamic.sh
+++ b/test/elf/export-dynamic.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl foo
   .hidden foo
@@ -21,11 +21,11 @@ _start:
   nop
 EOF
 
-cc -shared -fPIC -o $t/b.so -xc /dev/null
-$mold -o $t/exe $t/a.o $t/b.so --export-dynamic
+cc -shared -fPIC -o "$t"/b.so -xc /dev/null
+"$mold" -o "$t"/exe "$t"/a.o "$t"/b.so --export-dynamic
 
-readelf --dyn-syms $t/exe > $t/log
-fgrep -q 'NOTYPE  GLOBAL DEFAULT    6 bar' $t/log
-fgrep -q 'NOTYPE  GLOBAL DEFAULT    6 _start' $t/log
+readelf --dyn-syms "$t"/exe > "$t"/log
+fgrep -q 'NOTYPE  GLOBAL DEFAULT    6 bar' "$t"/log
+fgrep -q 'NOTYPE  GLOBAL DEFAULT    6 _start' "$t"/log
 
 echo OK

--- a/test/elf/export-from-exe.sh
+++ b/test/elf/export-from-exe.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void expfn1() {}
 void expfn2() {}
 int main() {}
 EOF
 
-cat <<EOF | cc -shared -o $t/b.so -xc -
+cat <<EOF | cc -shared -o "$t"/b.so -xc -
 void expfn1();
 void expfn2() {}
 
@@ -22,8 +22,8 @@ int foo() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.so
-readelf --dyn-syms $t/exe | grep -q expfn2
-readelf --dyn-syms $t/exe | grep -q expfn1
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.so
+readelf --dyn-syms "$t"/exe | grep -q expfn2
+readelf --dyn-syms "$t"/exe | grep -q expfn1
 
 echo OK

--- a/test/elf/fatal-warnings.sh
+++ b/test/elf/fatal-warnings.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fcommon -xc -c -o $t/a.o -
+cat <<EOF | clang -fcommon -xc -c -o "$t"/a.o -
 int foo;
 EOF
 
-cat <<EOF | clang -fcommon -xc -c -o $t/b.o -
+cat <<EOF | clang -fcommon -xc -c -o "$t"/b.o -
 int foo;
 
 int main() {
@@ -19,10 +19,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o \
   -Wl,-warn-common 2> /dev/null
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o \
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o \
   -Wl,-warn-common -Wl,-fatal-warnings 2> /dev/null || false
 
 echo OK

--- a/test/elf/filler.sh
+++ b/test/elf/filler.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 __attribute__((aligned(512)))
@@ -21,13 +21,13 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -static -Wl,--filler,0xfe -o $t/exe1 $t/a.o
-sed -i -e 's/--filler 0xfe/--filler 0x00/' $t/exe1
-hexdump -C $t/exe1 > $t/txt1
+clang -fuse-ld="$mold" -static -Wl,--filler,0xfe -o "$t"/exe1 "$t"/a.o
+sed -i -e 's/--filler 0xfe/--filler 0x00/' "$t"/exe1
+hexdump -C "$t"/exe1 > "$t"/txt1
 
-clang -fuse-ld=$mold -static -Wl,--filler,0x00 -o $t/exe2 $t/a.o
-hexdump -C $t/exe2 > $t/txt2
+clang -fuse-ld="$mold" -static -Wl,--filler,0x00 -o "$t"/exe2 "$t"/a.o
+hexdump -C "$t"/exe2 > "$t"/txt2
 
-diff -q $t/txt1 $t/txt2
+diff -q "$t"/txt1 "$t"/txt2
 
 echo OK

--- a/test/elf/filter.sh
+++ b/test/elf/filter.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl _start
 _start:
   nop
 EOF
 
-$mold -o $t/b.so $t/a.o --filter foo -F bar -shared
+"$mold" -o "$t"/b.so "$t"/a.o --filter foo -F bar -shared
 
-readelf --dynamic $t/b.so > $t/log
-fgrep -q 'Filter library: [foo]' $t/log
-fgrep -q 'Filter library: [bar]' $t/log
+readelf --dynamic "$t"/b.so > "$t"/log
+fgrep -q 'Filter library: [foo]' "$t"/log
+fgrep -q 'Filter library: [bar]' "$t"/log
 
 echo OK

--- a/test/elf/func-addr.sh
+++ b/test/elf/func-addr.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -shared -o $t/a.so -xc -
+cat <<EOF | cc -shared -o "$t"/a.so -xc -
 void fn() {}
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -fno-PIC -
+cat <<EOF | cc -o "$t"/b.o -c -xc -fno-PIC -
 #include <stdio.h>
 
 typedef void Func();
@@ -24,7 +24,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/a.so
-$t/exe | grep -q 1
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/a.so
+"$t"/exe | grep -q 1
 
 echo OK

--- a/test/elf/gc-sections.sh
+++ b/test/elf/gc-sections.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.cc
+cat <<EOF > "$t"/a.cc
 #include <stdio.h>
 
 int two() { return 2; }
@@ -28,30 +28,30 @@ int main() {
 }
 EOF
 
-cflags="-ffunction-sections -fdata-sections -fuse-ld=$mold"
+cflags=(-ffunction-sections -fdata-sections -fuse-ld="$mold")
 
-clang++ -o $t/exe1 $t/a.cc $cflags
-readelf --symbols $t/exe1 > $t/log.1
-grep -qv live_fn1 $t/log.1
-grep -qv live_fn2 $t/log.1
-grep -qv dead_fn1 $t/log.1
-grep -qv dead_fn2 $t/log.1
-grep -qv live_var1 $t/log.1
-grep -qv live_var2 $t/log.1
-grep -qv dead_var1 $t/log.1
-grep -qv dead_var2 $t/log.1
-$t/exe1 | grep -q '1 2'
+clang++ -o "$t"/exe1 "$t"/a.cc "${cflags[@]}"
+readelf --symbols "$t"/exe1 > "$t"/log.1
+grep -qv live_fn1 "$t"/log.1
+grep -qv live_fn2 "$t"/log.1
+grep -qv dead_fn1 "$t"/log.1
+grep -qv dead_fn2 "$t"/log.1
+grep -qv live_var1 "$t"/log.1
+grep -qv live_var2 "$t"/log.1
+grep -qv dead_var1 "$t"/log.1
+grep -qv dead_var2 "$t"/log.1
+"$t"/exe1 | grep -q '1 2'
 
-clang++ -o $t/exe2 $t/a.cc $cflags -Wl,-gc-sections
-readelf --symbols $t/exe2 > $t/log.2
-grep -q  live_fn1 $t/log.2
-grep -q  live_fn2 $t/log.2
-grep -qv dead_fn1 $t/log.2
-grep -qv dead_fn2 $t/log.2
-grep -q  live_var1 $t/log.2
-grep -q  live_var2 $t/log.2
-grep -qv dead_var1 $t/log.2
-grep -qv dead_var2 $t/log.2
-$t/exe2 | grep -q '1 2'
+clang++ -o "$t"/exe2 "$t"/a.cc "${cflags[@]}" -Wl,-gc-sections
+readelf --symbols "$t"/exe2 > "$t"/log.2
+grep -q  live_fn1 "$t"/log.2
+grep -q  live_fn2 "$t"/log.2
+grep -qv dead_fn1 "$t"/log.2
+grep -qv dead_fn2 "$t"/log.2
+grep -q  live_var1 "$t"/log.2
+grep -q  live_var2 "$t"/log.2
+grep -qv dead_var1 "$t"/log.2
+grep -qv dead_var2 "$t"/log.2
+"$t"/exe2 | grep -q '1 2'
 
 echo OK

--- a/test/elf/glibc-2.22-bug.sh
+++ b/test/elf/glibc-2.22-bug.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # glibc 2.22 or prior have a bug that ld-linux.so.2 crashes on dlopen()
 # if .rela.dyn and .rela.plt are not contiguous in a given DSO.
 # This test verifies that these sections are contiguous in mold's output.
 
-cat <<EOF | cc -o $t/a.o -fPIC -c -xc -
+cat <<EOF | cc -o "$t"/a.o -fPIC -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/b.so -shared $t/a.o
-readelf -W --sections $t/b.so | fgrep -A1 .rela.dyn | fgrep -q .rela.plt
+clang -fuse-ld="$mold" -o "$t"/b.so -shared "$t"/a.o
+readelf -W --sections "$t"/b.so | fgrep -A1 .rela.dyn | fgrep -q .rela.plt
 
 echo OK

--- a/test/elf/gnu-hash.sh
+++ b/test/elf/gnu-hash.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | c++ -o $t/exe -Wl,-hash-style=gnu -xc++ -
+cat <<EOF | c++ -o "$t"/exe -Wl,-hash-style=gnu -xc++ -
 #include <iostream>
 
 int main() {
@@ -15,6 +15,6 @@ int main() {
 }
 EOF
 
-$t/exe | grep -q foo
+"$t"/exe | grep -q foo
 
 echo OK

--- a/test/elf/gnu-warning.sh
+++ b/test/elf/gnu-warning.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | gcc -c -o $t/a.o -xc -
+cat <<EOF | gcc -c -o "$t"/a.o -xc -
 void foo() {}
 
 __attribute__((section(".gnu.warning.foo")))
 static const char foo_warning[] = "warning message";
 EOF
 
-cat <<EOF | cc -c -o $t/b.o -xc -
+cat <<EOF | cc -c -o "$t"/b.o -xc -
 void foo();
 
 int main() { foo(); }
 EOF
 
 # Make sure that we do not copy .gnu.warning.* sections.
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-! readelf --sections $t/exe | fgrep -q .gnu.warning || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+! readelf --sections "$t"/exe | fgrep -q .gnu.warning || false
 
 echo OK

--- a/test/elf/hello-dynamic.sh
+++ b/test/elf/hello-dynamic.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/hello-static.sh
+++ b/test/elf/hello-static.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -15,7 +15,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -static
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -static
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/help.sh
+++ b/test/elf/help.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-$mold --help | grep -q Usage
+"$mold" --help | grep -q Usage
 
 echo OK

--- a/test/elf/i386-hello-dynamic.sh
+++ b/test/elf/i386-hello-dynamic.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | cc -m32 -o $t/a.o -c -xc -
+cat <<EOF | cc -m32 -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -19,7 +19,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -m32 -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -m32 -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/i386-hello-static.sh
+++ b/test/elf/i386-hello-static.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | cc -m32 -o $t/a.o -c -xc -
+cat <<EOF | cc -m32 -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -19,7 +19,7 @@ int main() {
 }
 EOF
 
-clang -m32 -o $t/exe $t/a.o -static
-$t/exe | grep -q 'Hello world'
+clang -m32 -o "$t"/exe "$t"/a.o -static
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/i386-mergeable-strings.sh
+++ b/test/elf/i386-mergeable-strings.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<'EOF' | cc -o $t/a.o -c -x assembler -m32 -
+cat <<'EOF' | cc -o "$t"/a.o -c -x assembler -m32 -
   .text
   .globl main
 main:
@@ -29,7 +29,7 @@ main:
   .string "foo world\n"
 EOF
 
-clang -m32 -fuse-ld=$mold -static -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -m32 -fuse-ld="$mold" -static -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/i386-shared.sh
+++ b/test/elf/i386-shared.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | clang -fPIC -c -o $t/a.o -xc - -m32
+cat <<EOF | clang -fPIC -c -o "$t"/a.o -xc - -m32
 int foo = 5;
 void set_foo(int x) { foo = x; }
 int get_foo() { return foo; }
@@ -20,9 +20,9 @@ void set_bar(int x) { bar = x; }
 int get_bar() { return bar; }
 EOF
 
-clang -fuse-ld=$mold -o $t/b.so -shared $t/a.o -m32
+clang -fuse-ld="$mold" -o "$t"/b.so -shared "$t"/a.o -m32
 
-cat <<EOF > $t/c.c
+cat <<EOF > "$t"/c.c
 #include <stdio.h>
 
 int get_foo();
@@ -35,16 +35,16 @@ int main() {
 }
 EOF
 
-clang -c -o $t/d.o $t/c.c -fno-PIC -m32
-clang -fuse-ld=$mold -o $t/exe $t/d.o $t/b.so -m32
-$t/exe | grep -q '5 7 2'
+clang -c -o "$t"/d.o "$t"/c.c -fno-PIC -m32
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/d.o "$t"/b.so -m32
+"$t"/exe | grep -q '5 7 2'
 
-clang -c -o $t/e.o $t/c.c -fPIE -m32
-clang -fuse-ld=$mold -o $t/exe $t/e.o $t/b.so -m32
-$t/exe | grep -q '5 7 2'
+clang -c -o "$t"/e.o "$t"/c.c -fPIE -m32
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/e.o "$t"/b.so -m32
+"$t"/exe | grep -q '5 7 2'
 
-clang -c -o $t/f.o $t/c.c -fPIC -m32
-clang -fuse-ld=$mold -o $t/exe $t/f.o $t/b.so -m32
-$t/exe | grep -q '5 7 2'
+clang -c -o "$t"/f.o "$t"/c.c -fPIC -m32
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/f.o "$t"/b.so -m32
+"$t"/exe | grep -q '5 7 2'
 
 echo OK

--- a/test/elf/i386-tls-gd.sh
+++ b/test/elf/i386-tls-gd.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc - -m32
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc - -m32
 #include <stdio.h>
 
 static _Thread_local int x1 = 1;
@@ -28,26 +28,26 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -fPIC -c -o $t/b.o -xc - -m32
+cat <<EOF | cc -fPIC -c -o "$t"/b.o -xc - -m32
 _Thread_local int x3 = 3;
 static _Thread_local int x5 = 5;
 int get_x5() { return x5; }
 EOF
 
 
-cat <<EOF | cc -fPIC -c -o $t/c.o -xc - -m32
+cat <<EOF | cc -fPIC -c -o "$t"/c.o -xc - -m32
 _Thread_local int x4 = 4;
 static _Thread_local int x6 = 6;
 int get_x6() { return x6; }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/d.so $t/b.o -m32
-clang -fuse-ld=$mold -shared -o $t/e.so $t/c.o -Wl,--no-relax -m32
+clang -fuse-ld="$mold" -shared -o "$t"/d.so "$t"/b.o -m32
+clang -fuse-ld="$mold" -shared -o "$t"/e.so "$t"/c.o -Wl,--no-relax -m32
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/d.so $t/e.so -m32
-$t/exe | grep -q '1 2 3 4 5 6'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/d.so "$t"/e.so -m32
+"$t"/exe | grep -q '1 2 3 4 5 6'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/d.so $t/e.so -Wl,-no-relax -m32
-$t/exe | grep -q '1 2 3 4 5 6'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/d.so "$t"/e.so -Wl,-no-relax -m32
+"$t"/exe | grep -q '1 2 3 4 5 6'
 
 echo OK

--- a/test/elf/i386-tls-ld.sh
+++ b/test/elf/i386-tls-ld.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | cc -ftls-model=local-dynamic -fPIC -c -o $t/a.o -xc - -m32
+cat <<EOF | cc -ftls-model=local-dynamic -fPIC -c -o "$t"/a.o -xc - -m32
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -27,14 +27,14 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -ftls-model=local-dynamic -fPIC -c -o $t/b.o -xc - -m32
+cat <<EOF | cc -ftls-model=local-dynamic -fPIC -c -o "$t"/b.o -xc - -m32
 _Thread_local int foo = 3;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -m32
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -m32
+"$t"/exe | grep -q '3 5 3 5'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-no-relax -m32
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-no-relax -m32
+"$t"/exe | grep -q '3 5 3 5'
 
 echo OK

--- a/test/elf/i386-tlsdesc.sh
+++ b/test/elf/i386-tlsdesc.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | gcc -fPIC -mtls-dialect=gnu2 -c -o $t/a.o -xc - -m32
+cat <<EOF | gcc -fPIC -mtls-dialect=gnu2 -c -o "$t"/a.o -xc - -m32
 extern _Thread_local int foo;
 
 int get_foo() {
@@ -18,7 +18,7 @@ int get_foo() {
 }
 EOF
 
-cat <<EOF | clang -fPIC -c -o $t/b.o -xc - -m32
+cat <<EOF | clang -fPIC -c -o "$t"/b.o -xc - -m32
 #include <stdio.h>
 
 _Thread_local int foo;
@@ -32,18 +32,18 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -m32
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -m32
+"$t"/exe | grep -q 42
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o -m32
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/c.so -m32
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o -m32
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/c.so -m32
+"$t"/exe | grep -q 42
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-no-relax -m32
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-no-relax -m32
+"$t"/exe | grep -q 42
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o -Wl,-no-relax -m32
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/c.so -Wl,-no-relax -m32
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o -Wl,-no-relax -m32
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/c.so -Wl,-no-relax -m32
+"$t"/exe | grep -q 42
 
 echo OK

--- a/test/elf/icf.sh
+++ b/test/elf/icf.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -ffunction-sections -fdata-sections -xc -
+cat <<EOF | cc -c -o "$t"/a.o -ffunction-sections -fdata-sections -xc -
 #include <stdio.h>
 
 int bar() {
@@ -33,7 +33,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-icf=all
-$t/exe | grep -q '1 0'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-icf=all
+"$t"/exe | grep -q '1 0'
 
 echo OK

--- a/test/elf/ifunc-dso.sh
+++ b/test/elf/ifunc-dso.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if libc is musl because musl does not support GNU FUNC
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
-cat <<EOF | cc -fPIC -o $t/a.o -c -xc -
+cat <<EOF | cc -fPIC -o "$t"/a.o -c -xc -
 void foobar(void);
 
 int main() {
@@ -19,7 +19,7 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -fPIC -shared -o $t/b.so -xc -
+cat <<EOF | cc -fPIC -shared -o "$t"/b.so -xc -
 #include <stdio.h>
 
 __attribute__((ifunc("resolve_foobar")))
@@ -36,7 +36,7 @@ static Func *resolve_foobar(void) {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.so
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.so
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/ifunc-dynamic.sh
+++ b/test/elf/ifunc-dynamic.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if libc is musl because musl does not support GNU FUNC
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 __attribute__((ifunc("resolve_foobar")))
@@ -32,7 +32,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/ifunc-export.sh
+++ b/test/elf/ifunc-export.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if libc is musl because musl does not support GNU FUNC
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
-cat <<EOF | cc -c -fPIC -o $t/a.o -xc -
+cat <<EOF | cc -c -fPIC -o "$t"/a.o -xc -
 #include <stdio.h>
 
 __attribute__((ifunc("resolve_foobar")))
@@ -28,7 +28,7 @@ Func *resolve_foobar(void) {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o
-readelf --dyn-syms $t/b.so | grep -Pq '(IFUNC|<OS specific>: 10)\s+GLOBAL DEFAULT   \d+ foobar'
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o
+readelf --dyn-syms "$t"/b.so | grep -Pq '(IFUNC|<OS specific>: 10)\s+GLOBAL DEFAULT   \d+ foobar'
 
 echo OK

--- a/test/elf/ifunc-static.sh
+++ b/test/elf/ifunc-static.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if libc is musl because musl does not support GNU FUNC
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
-cat <<EOF | clang -o $t/a.o -c -xc -
+cat <<EOF | clang -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 void foo() __attribute__((ifunc("resolve_foo")));
@@ -30,7 +30,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -static
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -static
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/image-base.sh
+++ b/test/elf/image-base.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,8 +16,8 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/a.o -Wl,--image-base=0x8000000
-$t/exe | grep -q 'Hello world'
-readelf -W --sections $t/exe | grep -Pq '.interp\s+PROGBITS\s+0000000008000...\b'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/a.o -Wl,--image-base=0x8000000
+"$t"/exe | grep -q 'Hello world'
+readelf -W --sections "$t"/exe | grep -Pq '.interp\s+PROGBITS\s+0000000008000...\b'
 
 echo OK

--- a/test/elf/incompatible-libs.sh
+++ b/test/elf/incompatible-libs.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -m32 -o $t/exe -xc - >& /dev/null \
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
   || { echo skipped; exit; }
 
-cat <<EOF | cc -m32 -c -o $t/a.o -xc -
+cat <<EOF | cc -m32 -c -o "$t"/a.o -xc -
 char hello[] = "Hello world";
 EOF
 
-mkdir -p $t/lib32
-ar crs $t/lib32/libfoo.a $t/a.o
-clang -m32 -shared -o $t/lib32/libfoo.so $t/a.o
+mkdir -p "$t"/lib32
+ar crs "$t"/lib32/libfoo.a "$t"/a.o
+clang -m32 -shared -o "$t"/lib32/libfoo.so "$t"/a.o
 
-cat <<EOF | cc -c -o $t/d.o -xc -
+cat <<EOF | cc -c -o "$t"/d.o -xc -
 char hello[] = "Hello world";
 EOF
 
-mkdir -p $t/lib64
-ar crs $t/lib64/libfoo.a $t/d.o
-clang -shared -o $t/lib64/libfoo.so $t/d.o
+mkdir -p "$t"/lib64
+ar crs "$t"/lib64/libfoo.a "$t"/d.o
+clang -shared -o "$t"/lib64/libfoo.so "$t"/d.o
 
-cat <<EOF | cc -c -o $t/e.o -xc -
+cat <<EOF | cc -c -o "$t"/e.o -xc -
 #include <stdio.h>
 
 extern char hello[];
@@ -36,15 +36,15 @@ int main() {
 }
 EOF
 
-mkdir -p $t/script
-echo 'OUTPUT_FORMAT(elf32-i386)' > $t/script/libfoo.so
+mkdir -p "$t"/script
+echo 'OUTPUT_FORMAT(elf32-i386)' > "$t"/script/libfoo.so
 
-clang -fuse-ld=$mold -o $t/exe -L$t/script -L$t/lib32 -L$t/lib64 \
-  $t/e.o -lfoo -rpath $t/lib64 >& $t/log
+clang -fuse-ld="$mold" -o "$t"/exe -L"$t"/script -L"$t"/lib32 -L"$t"/lib64 \
+  "$t"/e.o -lfoo -rpath "$t"/lib64 >& "$t"/log
 
-grep -q 'script/libfoo.so: skipping incompatible file' $t/log
-grep -q 'lib32/libfoo.so: skipping incompatible file' $t/log
-grep -q 'lib32/libfoo.a: skipping incompatible file' $t/log
-$t/exe | grep -q 'Hello world'
+grep -q 'script/libfoo.so: skipping incompatible file' "$t"/log
+grep -q 'lib32/libfoo.so: skipping incompatible file' "$t"/log
+grep -q 'lib32/libfoo.a: skipping incompatible file' "$t"/log
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/init-array-priorities.sh
+++ b/test/elf/init-array-priorities.sh
@@ -1,58 +1,58 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | clang -c -o $t/a.o -xc -
+cat <<'EOF' | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 __attribute__((constructor(10000))) void init4() { printf("1"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/b.o -xc -
+cat <<'EOF' | clang -c -o "$t"/b.o -xc -
 #include <stdio.h>
 __attribute__((constructor(100))) void init3() { printf("2"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/c.o -xc -
+cat <<'EOF' | clang -c -o "$t"/c.o -xc -
 #include <stdio.h>
 __attribute__((constructor)) void init1() { printf("3"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/d.o -xc -
+cat <<'EOF' | clang -c -o "$t"/d.o -xc -
 #include <stdio.h>
 __attribute__((constructor)) void init2() { printf("4"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/e.o -xc -
+cat <<'EOF' | clang -c -o "$t"/e.o -xc -
 #include <stdio.h>
 __attribute__((destructor(10000))) void fini4() { printf("5"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/f.o -xc -
+cat <<'EOF' | clang -c -o "$t"/f.o -xc -
 #include <stdio.h>
 __attribute__((destructor(100))) void fini3() { printf("6"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/g.o -xc -
+cat <<'EOF' | clang -c -o "$t"/g.o -xc -
 #include <stdio.h>
 __attribute__((destructor)) void fini1() { printf("7"); }
 EOF
 
-cat <<'EOF' | clang -c -o $t/h.o -xc -
+cat <<'EOF' | clang -c -o "$t"/h.o -xc -
 #include <stdio.h>
 __attribute__((destructor)) void fini2() { printf("8"); }
 EOF
 
-cat <<EOF | clang -c -o $t/i.o -xc -
+cat <<EOF | clang -c -o "$t"/i.o -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o $t/c.o $t/d.o \
-  $t/e.o $t/f.o $t/g.o $t/h.o $t/i.o
-$t/exe | grep -q '21348756'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o "$t"/c.o "$t"/d.o \
+  "$t"/e.o "$t"/f.o "$t"/g.o "$t"/h.o "$t"/i.o
+"$t"/exe | grep -q '21348756'
 
 echo OK

--- a/test/elf/init-array.sh
+++ b/test/elf/init-array.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -x assembler -Wa,-no-warn -
+cat <<EOF | cc -c -o "$t"/a.o -x assembler -Wa,-no-warn -
 .globl init1, init2, fini1, fini2
 
 .section .init_array,"aw",@progbits
@@ -27,7 +27,7 @@ cat <<EOF | cc -c -o $t/a.o -x assembler -Wa,-no-warn -
 .quad fini2
 EOF
 
-cat <<EOF | cc -c -o $t/b.o -xc -
+cat <<EOF | cc -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 void init1() { printf("init1 "); }
@@ -40,7 +40,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q 'init1 init2 fini2 fini1'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q 'init1 init2 fini2 fini1'
 
 echo OK

--- a/test/elf/initfirst.sh
+++ b/test/elf/initfirst.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -fPIC -o $t/a.o -xc -
+cat <<EOF | clang -c -fPIC -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void foo() {
@@ -15,7 +15,7 @@ void foo() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,initfirst
-readelf --dynamic $t/b.so | grep -q 'Flags: INITFIRST'
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,initfirst
+readelf --dynamic "$t"/b.so | grep -q 'Flags: INITFIRST'
 
 echo OK

--- a/test/elf/interpose.sh
+++ b/test/elf/interpose.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -fPIC -o $t/a.o -xc -
+cat <<EOF | clang -c -fPIC -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void foo() {
@@ -15,7 +15,7 @@ void foo() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,interpose
-readelf --dynamic $t/b.so | grep -q 'Flags: INTERPOSE'
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,interpose
+readelf --dynamic "$t"/b.so | grep -q 'Flags: INTERPOSE'
 
 echo OK

--- a/test/elf/link-order.sh
+++ b/test/elf/link-order.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fPIC -c -o $t/a.o -xc -
+cat <<EOF | clang -fPIC -c -o "$t"/a.o -xc -
 void foo() {}
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/libfoo.so $t/a.o
-ar crs $t/libfoo.a $t/a.o
+clang -fuse-ld="$mold" -shared -o "$t"/libfoo.so "$t"/a.o
+ar crs "$t"/libfoo.a "$t"/a.o
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 void foo();
 int main() {
   foo();
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o -Wl,--as-needed \
-  $t/libfoo.so $t/libfoo.a
-ldd $t/exe | grep -q libfoo
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o -Wl,--as-needed \
+  "$t"/libfoo.so "$t"/libfoo.a
+ldd "$t"/exe | grep -q libfoo
 
-clang -fuse-ld=$mold -o $t/exe $t/b.o -Wl,--as-needed \
-  $t/libfoo.a $t/libfoo.so
-! ldd $t/exe | grep -q libfoo || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o -Wl,--as-needed \
+  "$t"/libfoo.a "$t"/libfoo.so
+! ldd "$t"/exe | grep -q libfoo || false
 
 echo OK

--- a/test/elf/linker-script.sh
+++ b/test/elf/linker-script.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF > $t/script
-GROUP($t/a.o)
+cat <<EOF > "$t"/script
+GROUP("$t/a.o")
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/script
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/script
+"$t"/exe | grep -q 'Hello world'
 
-clang -fuse-ld=$mold -o $t/exe -Wl,-T,$t/script
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe -Wl,-T,"$t"/script
+"$t"/exe | grep -q 'Hello world'
 
-clang -fuse-ld=$mold -o $t/exe -Wl,--script,$t/script
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe -Wl,--script,"$t"/script
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/linker-script2.sh
+++ b/test/elf/linker-script2.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-mkdir -p $t/foo/bar
-rm -f $t/foo/bar/libfoo.a
-ar rcs $t/foo/bar/libfoo.a $t/a.o
+mkdir -p "$t"/foo/bar
+rm -f "$t"/foo/bar/libfoo.a
+ar rcs "$t"/foo/bar/libfoo.a "$t"/a.o
 
-cat <<EOF > $t/b.script
+cat <<EOF > "$t"/b.script
 INPUT(-lfoo)
 EOF
 
-clang -o $t/exe -L$t/foo/bar $t/b.script
+clang -o "$t"/exe -L"$t"/foo/bar "$t"/b.script
 
 echo OK

--- a/test/elf/linker-script3.sh
+++ b/test/elf/linker-script3.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-mkdir -p $t/foo
+mkdir -p "$t"/foo
 
-cat <<EOF | cc -o $t/foo/a.o -c -xc -
+cat <<EOF | cc -o "$t"/foo/a.o -c -xc -
 int main() {}
 EOF
 
-cat <<EOF > $t/b.script
+cat <<EOF > "$t"/b.script
 INPUT(a.o)
 EOF
 
-clang -o $t/exe -L$t/foo $t/b.script
+clang -o "$t"/exe -L"$t"/foo "$t"/b.script
 
 echo OK

--- a/test/elf/linker-script4.sh
+++ b/test/elf/linker-script4.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'VERSION { ver_x { global: *; }; };' > $t/a.script
+echo 'VERSION { ver_x { global: *; }; };' > "$t"/a.script
 
-cat <<EOF > $t/b.s
+cat <<EOF > "$t"/b.s
 .globl foo, bar, baz
 foo:
   nop
@@ -19,9 +19,9 @@ baz:
   nop
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.script $t/b.s
-readelf --version-info $t/c.so > $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.script "$t"/b.s
+readelf --version-info "$t"/c.so > "$t"/log
 
-fgrep -q 'Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: ver_x' $t/log
+fgrep -q 'Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: ver_x' "$t"/log
 
 echo OK

--- a/test/elf/lto-gcc-error.sh
+++ b/test/elf/lto-gcc-error.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | gcc -flto -c -o $t/a.o -xc -
+cat <<EOF | gcc -flto -c -o "$t"/a.o -xc -
 int main() {}
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o &> $t/log
-grep -q '.*/a.o: .*mold does not support LTO' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o &> "$t"/log
+grep -q '.*/a.o: .*mold does not support LTO' "$t"/log
 
 echo OK

--- a/test/elf/lto-llvm-error.sh
+++ b/test/elf/lto-llvm-error.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -flto -c -o $t/a.o -xc -
+cat <<EOF | clang -flto -c -o "$t"/a.o -xc -
 int main() {}
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o &> $t/log
-grep -q '.*/a.o: .*mold does not support LTO' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o &> "$t"/log
+grep -q '.*/a.o: .*mold does not support LTO' "$t"/log
 
 echo OK

--- a/test/elf/many-sections.sh
+++ b/test/elf/many-sections.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-seq 1 65500 | sed 's/.*/.section .text.\0, "ax",@progbits/' > $t/a.s
+seq 1 65500 | sed 's/.*/.section .text.\0, "ax",@progbits/' > "$t"/a.s
 
-cc -c -o $t/a.o $t/a.s
+cc -c -o "$t"/a.o "$t"/a.s
 
-cat <<'EOF' | cc -c -xc -o $t/b.o -
+cat <<'EOF' | cc -c -xc -o "$t"/b.o -
 #include <stdio.h>
 
 int main() {
@@ -20,7 +20,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q Hello
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q Hello
 
 echo OK

--- a/test/elf/mergeable-strings.sh
+++ b/test/elf/mergeable-strings.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if target is not x86-64
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<'EOF' | cc -o $t/a.o -c -x assembler -
+cat <<'EOF' | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl main
 main:
@@ -32,7 +32,7 @@ main:
   .string "foo world\n"
 EOF
 
-clang -fuse-ld=$mold -static -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -static -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/missing-but-ok.sh
+++ b/test/elf/missing-but-ok.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl _start, foo
 _start:
   nop
 EOF
 
-$mold -o $t/exe $t/a.o
+"$mold" -o "$t"/exe "$t"/a.o
 
 echo OK

--- a/test/elf/missing-error.sh
+++ b/test/elf/missing-error.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int foo();
 
 int main() {
@@ -15,7 +15,7 @@ int main() {
 }
 EOF
 
-! $mold -o $t/exe $t/a.o 2> $t/log || false
-grep -q 'undefined symbol: .*\.o: foo' $t/log
+! "$mold" -o "$t"/exe "$t"/a.o 2> "$t"/log || false
+grep -q 'undefined symbol: .*\.o: foo' "$t"/log
 
 echo OK

--- a/test/elf/mold-wrapper.sh
+++ b/test/elf/mold-wrapper.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-ldd $mold-wrapper.so | grep -q libasan && { echo skipped; exit; }
+ldd "$mold"-wrapper.so | grep -q libasan && { echo skipped; exit; }
 
-cat <<'EOF' > $t/a.sh
+cat <<'EOF' > "$t"/a.sh
 #!/bin/bash
 echo "$0" "$@"
 EOF
 
-chmod 755 $t/a.sh
+chmod 755 "$t"/a.sh
 
-cat <<'EOF' | cc -xc -o $t/exe -
+cat <<'EOF' | cc -xc -o "$t"/exe -
 #define _GNU_SOURCE 1
 
 #include <assert.h>
@@ -69,11 +69,11 @@ int main(int argc, char **argv) {
 }
 EOF
 
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh $t/exe execl | grep -q 'a.sh execl'
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh $t/exe execlp | grep -q 'a.sh execlp'
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh $t/exe execle | grep -q 'a.sh execle'
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh $t/exe execv | grep -q 'a.sh execv'
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh $t/exe execvp | grep -q 'a.sh execvp'
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh $t/exe execvpe | grep -q 'a.sh execvpe'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh "$t"/exe execl | grep -q 'a.sh execl'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh "$t"/exe execlp | grep -q 'a.sh execlp'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh "$t"/exe execle | grep -q 'a.sh execle'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh "$t"/exe execv | grep -q 'a.sh execv'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh "$t"/exe execvp | grep -q 'a.sh execvp'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$t/a.sh "$t"/exe execvpe | grep -q 'a.sh execvpe'
 
 echo OK

--- a/test/elf/mold-wrapper2.sh
+++ b/test/elf/mold-wrapper2.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-ldd $mold-wrapper.so | grep -q libasan && { echo skipped; exit; }
+ldd "$mold"-wrapper.so | grep -q libasan && { echo skipped; exit; }
 
-rm -rf $t
-mkdir -p $t/bin $t/lib/mold
-cp $mold $t/bin
-cp $mold-wrapper.so $t/bin
+rm -rf "$t"
+mkdir -p "$t"/bin "$t"/lib/mold
+cp "$mold" "$t"/bin
+cp "$mold"-wrapper.so "$t"/bin
 
-$t/bin/mold -run bash -c 'echo $LD_PRELOAD' | grep -q '/bin/mold-wrapper.so'
+"$t"/bin/mold -run bash -c 'echo $LD_PRELOAD' | grep -q '/bin/mold-wrapper.so'
 
 echo OK

--- a/test/elf/no-quick-exit.sh
+++ b/test/elf/no-quick-exit.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,7 +16,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-no-quick-exit
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-no-quick-exit
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/nocopyreloc.sh
+++ b/test/elf/nocopyreloc.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -shared -o $t/a.so -xc -
+cat <<EOF | cc -shared -o "$t"/a.so -xc -
 int foo = 3;
 int bar = 5;
 EOF
 
-cat <<EOF | cc -fno-PIC -c -o $t/b.o -xc -
+cat <<EOF | cc -fno-PIC -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 extern int foo;
@@ -24,12 +24,12 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/a.so $t/b.o
-$t/exe | grep -q '3 5'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/a.so "$t"/b.o
+"$t"/exe | grep -q '3 5'
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.so $t/b.o \
-  -Wl,-z,nocopyreloc 2> $t/log || false
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.so "$t"/b.o \
+  -Wl,-z,nocopyreloc 2> "$t"/log || false
 
-grep -q 'recompile with -fPIC' $t/log
+grep -q 'recompile with -fPIC' "$t"/log
 
 echo OK

--- a/test/elf/note-property.sh
+++ b/test/elf/note-property.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if target is not x86-64
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<EOF | clang -fcf-protection=branch -c -o $t/a.o -xc -
+cat <<EOF | clang -fcf-protection=branch -c -o "$t"/a.o -xc -
 void _start() {}
 EOF
 
-cat <<EOF | clang -fcf-protection=none -c -o $t/b.o -xc -
+cat <<EOF | clang -fcf-protection=none -c -o "$t"/b.o -xc -
 void _start() {}
 EOF
 
-$mold -o $t/exe $t/a.o
-readelf -n $t/exe | grep -q 'x86 feature: IBT'
+"$mold" -o "$t"/exe "$t"/a.o
+readelf -n "$t"/exe | grep -q 'x86 feature: IBT'
 
-$mold -o $t/exe $t/b.o
-! readelf -n $t/exe | grep -q 'x86 feature: IBT' || false
+"$mold" -o "$t"/exe "$t"/b.o
+! readelf -n "$t"/exe | grep -q 'x86 feature: IBT' || false
 
 echo OK

--- a/test/elf/note.sh
+++ b/test/elf/note.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 .text
 .globl _start
 _start:
@@ -30,16 +30,16 @@ _start:
 .quad 42
 EOF
 
-$mold -static -o $t/exe $t/a.o
-readelf -W --sections $t/exe > $t/log
+"$mold" -static -o "$t"/exe "$t"/a.o
+readelf -W --sections "$t"/exe > "$t"/log
 
-grep -Pq '.note.bar\s+NOTE.+000008 00   A  0   0  4' $t/log
-grep -Pq '.note.baz\s+NOTE.+000008 00   A  0   0  8' $t/log
-grep -Pq '.note.nonalloc\s+NOTE.+000008 00      0   0  1' $t/log
+grep -Pq '.note.bar\s+NOTE.+000008 00   A  0   0  4' "$t"/log
+grep -Pq '.note.baz\s+NOTE.+000008 00   A  0   0  8' "$t"/log
+grep -Pq '.note.nonalloc\s+NOTE.+000008 00      0   0  1' "$t"/log
 
-readelf --segments $t/exe > $t/log
-fgrep -q '01     .note.bar' $t/log
-fgrep -q '02     .note.baz .note.foo' $t/log
-! grep -q 'NOTE.*0x0000000000000000 0x0000000000000000' $t/log || false
+readelf --segments "$t"/exe > "$t"/log
+fgrep -q '01     .note.bar' "$t"/log
+fgrep -q '02     .note.baz .note.foo' "$t"/log
+! grep -q 'NOTE.*0x0000000000000000 0x0000000000000000' "$t"/log || false
 
 echo OK

--- a/test/elf/note2.sh
+++ b/test/elf/note2.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 .section .note.a, "a", @note
 .p2align 3
 .quad 42
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -x assembler -
+cat <<EOF | cc -o "$t"/b.o -c -x assembler -
 .section .note.b, "a", @note
 .p2align 2
 .quad 42
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -x assembler -
+cat <<EOF | cc -o "$t"/c.o -c -x assembler -
 .section .note.c, "a", @note
 .p2align 3
 .quad 42
 EOF
 
-cat <<EOF | cc -o $t/d.o -c -xc -
+cat <<EOF | cc -o "$t"/d.o -c -xc -
 int main() {}
 EOF
 
-$mold -static -o $t/exe $t/a.o $t/b.o $t/c.o $t/d.o
+"$mold" -static -o "$t"/exe "$t"/a.o "$t"/b.o "$t"/c.o "$t"/d.o
 
-readelf --segments $t/exe > $t/log
-fgrep -q '01     .note.b' $t/log
-fgrep -q '02     .note.a .note.c' $t/log
+readelf --segments "$t"/exe > "$t"/log
+fgrep -q '01     .note.b' "$t"/log
+fgrep -q '02     .note.a .note.c' "$t"/log
 
 echo OK

--- a/test/elf/now.sh
+++ b/test/elf/now.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -fPIC -o $t/a.o -xc -
+cat <<EOF | clang -c -fPIC -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void foo() {
@@ -15,11 +15,11 @@ void foo() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,now
-readelf --dynamic $t/b.so | grep -q 'Flags: NOW'
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,now
+readelf --dynamic "$t"/b.so | grep -q 'Flags: NOW'
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,now,-z,lazy
-readelf --dynamic $t/b.so > $t/log
-! grep -q 'Flags: NOW' $t/log || false
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,now,-z,lazy
+readelf --dynamic "$t"/b.so > "$t"/log
+! grep -q 'Flags: NOW' "$t"/log || false
 
 echo OK

--- a/test/elf/omagic.sh
+++ b/test/elf/omagic.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,6 +16,6 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold $t/a.o -o $t/exe -static -Wl,--omagic
+clang -fuse-ld="$mold" "$t"/a.o -o "$t"/exe -static -Wl,--omagic
 
 echo OK

--- a/test/elf/pie.sh
+++ b/test/elf/pie.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -fPIE -
+cat <<EOF | cc -o "$t"/a.o -c -xc -fPIE -
 #include <stdio.h>
 
 int main() {
@@ -16,8 +16,8 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -pie -o $t/exe $t/a.o
-readelf --file-header $t/exe | grep -q -E '(Shared object file|Position-Independent Executable file)'
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -pie -o "$t"/exe "$t"/a.o
+readelf --file-header "$t"/exe | grep -q -E '(Shared object file|Position-Independent Executable file)'
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/plt-dso.sh
+++ b/test/elf/plt-dso.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void world() {
@@ -24,9 +24,9 @@ void hello() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o
 
-cat <<EOF | cc -c -o $t/c.o -xc -
+cat <<EOF | cc -c -o "$t"/c.o -xc -
 #include <stdio.h>
 
 void world() {
@@ -40,7 +40,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe -Wl,-rpath=$t $t/c.o $t/b.so
-$t/exe | grep -q 'Hello WORLD'
+clang -fuse-ld="$mold" -o "$t"/exe -Wl,-rpath="$t" "$t"/c.o "$t"/b.so
+"$t"/exe | grep -q 'Hello WORLD'
 
 echo OK

--- a/test/elf/plt.sh
+++ b/test/elf/plt.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<'EOF' | cc -o $t/a.o -c -x assembler -
+cat <<'EOF' | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl main
 main:
@@ -26,11 +26,11 @@ msg:
   .string "Hello world\n"
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
 
-readelf --sections $t/exe | fgrep -q '.got'
-readelf --sections $t/exe | fgrep -q '.got.plt'
+readelf --sections "$t"/exe | fgrep -q '.got'
+readelf --sections "$t"/exe | fgrep -q '.got.plt'
 
-$t/exe | grep -q 'Hello world'
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/pltgot.sh
+++ b/test/elf/pltgot.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<EOF | cc -fPIC -shared -o $t/a.so -x assembler -
+cat <<EOF | cc -fPIC -shared -o "$t"/a.so -x assembler -
 .globl ext1, ext2
 ext1:
   nop
@@ -17,7 +17,7 @@ ext2:
   nop
 EOF
 
-cat <<EOF | cc -c -o $t/b.o -x assembler -
+cat <<EOF | cc -c -o "$t"/b.o -x assembler -
 .globl _start
 _start:
   call ext1@PLT
@@ -26,10 +26,10 @@ _start:
   ret
 EOF
 
-$mold --pie -o $t/exe $t/b.o $t/a.so
+"$mold" --pie -o "$t"/exe "$t"/b.o "$t"/a.so
 
-objdump -d -j .plt.got $t/exe > $t/log
+objdump -d -j .plt.got "$t"/exe > "$t"/log
 
-grep -Pq '1020:\s+ff 25 da 0f 00 00\s+jmp.*# 2000 <ext2>' $t/log
+grep -Pq '1020:\s+ff 25 da 0f 00 00\s+jmp.*# 2000 <ext2>' "$t"/log
 
 echo OK

--- a/test/elf/preload.sh
+++ b/test/elf/preload.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-rm -f $t/exe
+rm -f "$t"/exe
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-preload
-! test -e $t/exe || false
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-preload
+! test -e "$t"/exe || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/protected-dynsym.sh
+++ b/test/elf/protected-dynsym.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc -
 extern int foo;
 EOF
 
-cat <<EOF | cc -fPIC -c -o $t/b.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/b.o -xc -
 __attribute__((visibility("protected"))) int foo;
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o $t/b.o -Wl,-strip-all
-readelf --symbols $t/c.so | grep -Pq 'PROTECTED\b.*\bfoo\b'
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o "$t"/b.o -Wl,-strip-all
+readelf --symbols "$t"/c.so | grep -Pq 'PROTECTED\b.*\bfoo\b'
 
 echo OK

--- a/test/elf/protected.sh
+++ b/test/elf/protected.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fPIC -c -o $t/a.o -xc -
+cat <<EOF | clang -fPIC -c -o "$t"/a.o -xc -
 int foo() __attribute__((visibility("protected")));
 int bar() __attribute__((visibility("protected")));
 void *baz() __attribute__((visibility("protected")));
@@ -25,9 +25,9 @@ void *baz() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/b.so -shared $t/a.o
+clang -fuse-ld="$mold" -o "$t"/b.so -shared "$t"/a.o
 
-cat <<EOF | cc -c -o $t/c.o -xc - -fno-PIE
+cat <<EOF | cc -c -o "$t"/c.o -xc - -fno-PIE
 #include <stdio.h>
 
 int foo() {
@@ -42,7 +42,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -o $t/exe $t/c.o $t/b.so
-$t/exe | grep -q '3 4 0'
+clang -fuse-ld="$mold" -no-pie -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe | grep -q '3 4 0'
 
 echo OK

--- a/test/elf/push-pop-state.sh
+++ b/test/elf/push-pop-state.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -shared -o $t/a.so -xc -
+cat <<EOF | clang -shared -o "$t"/a.so -xc -
 int foo = 1;
 EOF
 
-cat <<EOF | clang -shared -o $t/b.so -xc -
+cat <<EOF | clang -shared -o "$t"/b.so -xc -
 int bar = 1;
 EOF
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,-as-needed \
-  -Wl,-push-state -Wl,-no-as-needed $t/a.so -Wl,-pop-state $t/b.so
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,-as-needed \
+  -Wl,-push-state -Wl,-no-as-needed "$t"/a.so -Wl,-pop-state "$t"/b.so
 
-readelf --dynamic $t/exe > $t/log
-fgrep -q a.so $t/log
-! fgrep -q b.so $t/log || false
+readelf --dynamic "$t"/exe > "$t"/log
+fgrep -q a.so "$t"/log
+! fgrep -q b.so "$t"/log || false
 
 echo OK

--- a/test/elf/relax.sh
+++ b/test/elf/relax.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if target is not x86-64
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<EOF | clang -o $t/a.o -c -x assembler -Wa,-mrelax-relocations=yes -
+cat <<EOF | clang -o "$t"/a.o -c -x assembler -Wa,-mrelax-relocations=yes -
 .globl bar
 bar:
   mov foo@GOTPCREL(%rip), %rax
@@ -33,7 +33,7 @@ bar:
   jmp  *foo@GOTPCREL(%rip)
 EOF
 
-cat <<EOF | clang -o $t/b.o -c -xc -
+cat <<EOF | clang -o "$t"/b.o -c -xc -
 void foo() {}
 
 int main() {
@@ -41,46 +41,46 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-objdump -d $t/exe | grep -A20 '<bar>:' > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+objdump -d "$t"/exe | grep -A20 '<bar>:' > "$t"/log
 
-grep -Pq 'lea \s*0x.+\(%rip\),%rax .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%rcx .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%rdx .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%rbx .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%rbp .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%rsi .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%rdi .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r8  .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r9  .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r10 .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r11 .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r12 .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r13 .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r14 .*<foo>' $t/log
-grep -Pq 'lea \s*0x.+\(%rip\),%r15 .*<foo>' $t/log
-grep -Pq 'call.*<foo>' $t/log
-grep -Pq 'jmp.*<foo>' $t/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rax .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rcx .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rdx .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rbx .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rbp .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rsi .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%rdi .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r8  .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r9  .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r10 .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r11 .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r12 .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r13 .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r14 .*<foo>' "$t"/log
+grep -Pq 'lea \s*0x.+\(%rip\),%r15 .*<foo>' "$t"/log
+grep -Pq 'call.*<foo>' "$t"/log
+grep -Pq 'jmp.*<foo>' "$t"/log
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-no-relax
-objdump -d $t/exe | grep -A20 '<bar>:' > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-no-relax
+objdump -d "$t"/exe | grep -A20 '<bar>:' > "$t"/log
 
-grep -Pq 'mov \s*0x.+\(%rip\),%rax' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%rcx' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%rdx' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%rbx' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%rbp' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%rsi' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%rdi' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r8 ' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r9 ' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r10' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r11' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r12' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r13' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r14' $t/log
-grep -Pq 'mov \s*0x.+\(%rip\),%r15' $t/log
-grep -Pq 'call.*\(%rip\)' $t/log
-grep -Pq 'jmp.*\(%rip\)' $t/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rax' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rcx' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rdx' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rbx' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rbp' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rsi' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%rdi' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r8 ' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r9 ' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r10' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r11' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r12' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r13' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r14' "$t"/log
+grep -Pq 'mov \s*0x.+\(%rip\),%r15' "$t"/log
+grep -Pq 'call.*\(%rip\)' "$t"/log
+grep -Pq 'jmp.*\(%rip\)' "$t"/log
 
 echo OK

--- a/test/elf/reloc-overflow.sh
+++ b/test/elf/reloc-overflow.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .globl foo
   .data
 foo:
   .short foo
 EOF
 
-! $mold -e foo -static -o $t/exe $t/a.o 2> $t/log || false
-fgrep -q 'relocation R_X86_64_16 against foo out of range' $t/log
+! "$mold" -e foo -static -o "$t"/exe "$t"/a.o 2> "$t"/log || false
+fgrep -q 'relocation R_X86_64_16 against foo out of range' "$t"/log
 
 echo OK

--- a/test/elf/reloc-rodata.sh
+++ b/test/elf/reloc-rodata.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fno-PIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fno-PIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 int foo;
@@ -18,7 +18,7 @@ int main() {
 }
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o -pie >& $t/log
-grep -Pq 'relocation against symbol .+ can not be used; recompile with -fPIC' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -pie >& "$t"/log
+grep -Pq 'relocation against symbol .+ can not be used; recompile with -fPIC' "$t"/log
 
 echo OK

--- a/test/elf/reloc-zero.sh
+++ b/test/elf/reloc-zero.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 foo: jmp 0
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
 
 echo OK

--- a/test/elf/reloc.sh
+++ b/test/elf/reloc.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<'EOF' | cc -fPIC -c -o $t/a.o -x assembler -
+cat <<'EOF' | cc -fPIC -c -o "$t"/a.o -x assembler -
 .data
 .globl ext_var
 .type ext_var, @object
@@ -18,7 +18,7 @@ ext_var:
   .long 56
 EOF
 
-cat <<'EOF' | cc -fPIC -c -o $t/b.o -xc -
+cat <<'EOF' | cc -fPIC -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 int print(int x) {
@@ -32,10 +32,10 @@ int print64(long x) {
 }
 EOF
 
-cc -shared -o $t/c.so $t/a.o $t/b.o
+cc -shared -o "$t"/c.so "$t"/a.o "$t"/b.o
 
 # Absolute symbol
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl abs_sym
 .set abs_sym, 42
 
@@ -48,13 +48,13 @@ main:
   ret
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -no-pie
-$t/exe | grep -q 42
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -pie
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -no-pie
+"$t"/exe | grep -q 42
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -pie
+"$t"/exe | grep -q 42
 
 # GOT
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -65,13 +65,13 @@ main:
   ret
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -no-pie
-$t/exe | grep -q 56
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -pie
-$t/exe | grep -q 56
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -no-pie
+"$t"/exe | grep -q 56
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -pie
+"$t"/exe | grep -q 56
 
 # Copyrel
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -81,14 +81,14 @@ main:
   ret
 EOF
 
-clang -c -o $t/d.o $t/d.s
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.o -no-pie
-$t/exe | grep -q 56
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -pie
-$t/exe | grep -q 56
+clang -c -o "$t"/d.o "$t"/d.s
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.o -no-pie
+"$t"/exe | grep -q 56
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -pie
+"$t"/exe | grep -q 56
 
 # Copyrel
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -103,13 +103,13 @@ foo:
   .quad ext_var
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -no-pie
-$t/exe | grep -q 56
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -pie
-$t/exe | grep -q 56
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -no-pie
+"$t"/exe | grep -q 56
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -pie
+"$t"/exe | grep -q 56
 
 # PLT
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -119,13 +119,13 @@ main:
   ret
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -no-pie
-$t/exe | grep -q 76
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -pie
-$t/exe | grep -q 76
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -no-pie
+"$t"/exe | grep -q 76
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -pie
+"$t"/exe | grep -q 76
 
 # PLT
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -136,13 +136,13 @@ main:
   ret
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -no-pie
-$t/exe | grep -q 76
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s -pie
-$t/exe | grep -q 76
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -no-pie
+"$t"/exe | grep -q 76
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s -pie
+"$t"/exe | grep -q 76
 
 # SIZE32
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -158,11 +158,11 @@ main:
 foo:
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s
-$t/exe | grep -q 26
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s
+"$t"/exe | grep -q 26
 
 # SIZE64
-cat <<'EOF' > $t/d.s
+cat <<'EOF' > "$t"/d.s
 .globl main
 main:
   sub $8, %rsp
@@ -178,11 +178,11 @@ main:
 foo:
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/d.s
-$t/exe | grep -q 61
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/d.s
+"$t"/exe | grep -q 61
 
 # GOTPCREL64
-cat <<'EOF' > $t/e.c
+cat <<'EOF' > "$t"/e.c
 extern long ext_var;
 void print64(long);
 
@@ -191,12 +191,12 @@ int main() {
 }
 EOF
 
-clang -c -o $t/e.o $t/e.c -mcmodel=large -fPIC
-clang -fuse-ld=$mold -o $t/exe $t/c.so $t/e.o
-$t/exe | grep -q 56
+clang -c -o "$t"/e.o "$t"/e.c -mcmodel=large -fPIC
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.so "$t"/e.o
+"$t"/exe | grep -q 56
 
 # R_X86_64_32 against non-alloc section
-cat <<'EOF' > $t/f.s
+cat <<'EOF' > "$t"/f.s
 .globl main
 main:
   sub $8, %rsp
@@ -214,11 +214,11 @@ bar:
 .quad foo
 EOF
 
-clang -c -o $t/f.o $t/f.s
-clang -fuse-ld=$mold -o $t/exe $t/f.o
-readelf -x .foo -x .bar $t/exe > $t/log
+clang -c -o "$t"/f.o "$t"/f.s
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/f.o
+readelf -x .foo -x .bar "$t"/exe > "$t"/log
 
-fgrep -q '0x00000010 00000000 00000000 10000000 00000000' $t/log
-fgrep -q '0x00000010 18000000 00000000' $t/log
+fgrep -q '0x00000010 00000000 00000000 10000000 00000000' "$t"/log
+fgrep -q '0x00000010 18000000 00000000' "$t"/log
 
 echo OK

--- a/test/elf/relocatable-archive.sh
+++ b/test/elf/relocatable-archive.sh
@@ -1,40 +1,40 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -xc -
+cat <<EOF | cc -c -o "$t"/a.o -xc -
 void bar();
 void foo() {
   bar();
 }
 EOF
 
-cat <<EOF | cc -c -o $t/b.o -xc -
+cat <<EOF | cc -c -o "$t"/b.o -xc -
 void bar() {}
 EOF
 
-cat <<EOF | cc -c -o $t/c.o -xc -
+cat <<EOF | cc -c -o "$t"/c.o -xc -
 void baz() {}
 EOF
 
-cat <<EOF | cc -c -o $t/d.o -xc -
+cat <<EOF | cc -c -o "$t"/d.o -xc -
 void foo();
 int main() {
   foo();
 }
 EOF
 
-ar crs $t/e.a $t/a.o $t/b.o $t/c.o
-$mold -r -o $t/f.o $t/d.o $t/e.a
+ar crs "$t"/e.a "$t"/a.o "$t"/b.o "$t"/c.o
+"$mold" -r -o "$t"/f.o "$t"/d.o "$t"/e.a
 
-readelf --symbols $t/f.o > $t/log
-grep -q 'foo$' $t/log
-grep -q 'bar$' $t/log
-! grep -q 'baz$' $t/log || false
+readelf --symbols "$t"/f.o > "$t"/log
+grep -q 'foo$' "$t"/log
+grep -q 'bar$' "$t"/log
+! grep -q 'baz$' "$t"/log || false
 
 echo OK

--- a/test/elf/relocatable.sh
+++ b/test/elf/relocatable.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang++ -c -o $t/a.o -xc++ -
+cat <<EOF | clang++ -c -o "$t"/a.o -xc++ -
 int one() { return 1; }
 
 struct Foo {
@@ -20,7 +20,7 @@ int a() {
 }
 EOF
 
-cat <<EOF | clang++ -c -o $t/b.o -xc++ -
+cat <<EOF | clang++ -c -o "$t"/b.o -xc++ -
 int two() { return 2; }
 
 struct Foo {
@@ -33,12 +33,12 @@ int b() {
 }
 EOF
 
-$mold --relocatable -o $t/c.o $t/a.o $t/b.o
+"$mold" --relocatable -o "$t"/c.o "$t"/a.o "$t"/b.o
 
-[ -f $t/c.o ]
+[ -f "$t"/c.o ]
 ! [ -x t/c.o ] || false
 
-cat <<EOF | clang++ -c -o $t/d.o -xc++ -
+cat <<EOF | clang++ -c -o "$t"/d.o -xc++ -
 #include <iostream>
 
 int one();
@@ -54,7 +54,7 @@ int main() {
 }
 EOF
 
-clang++ -fuse-ld=$mold -o $t/exe $t/c.o $t/d.o
-$t/exe | grep -q '^1 2 3$'
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/d.o
+"$t"/exe | grep -q '^1 2 3$'
 
 echo OK

--- a/test/elf/relro.sh
+++ b/test/elf/relro.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -xc -o $t/a.o -
+cat <<EOF | clang -c -xc -o "$t"/a.o -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-readelf --segments -W $t/exe > $t/log
-grep -q 'GNU_RELRO ' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+readelf --segments -W "$t"/exe > "$t"/log
+grep -q 'GNU_RELRO ' "$t"/log
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-z,norelro
-readelf --segments -W $t/exe > $t/log
-! grep -q 'GNU_RELRO ' $t/log || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-z,norelro
+readelf --segments -W "$t"/exe > "$t"/log
+! grep -q 'GNU_RELRO ' "$t"/log || false
 
 echo OK

--- a/test/elf/repro.sh
+++ b/test/elf/repro.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,23 +16,23 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-! readelf --sections $t/exe | fgrep -q .repro || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+! readelf --sections "$t"/exe | fgrep -q .repro || false
 
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-repro
-objcopy --dump-section .repro=$t/repro.tar.gz $t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-repro
+objcopy --dump-section .repro="$t"/repro.tar.gz "$t"/exe
 
-tar -C $t -xzf $t/repro.tar.gz
-fgrep -q /a.o  $t/repro/response.txt
-fgrep -q mold $t/repro/version.txt
+tar -C "$t" -xzf "$t"/repro.tar.gz
+fgrep -q /a.o  "$t"/repro/response.txt
+fgrep -q mold "$t"/repro/version.txt
 
 
-MOLD_REPRO=1 clang -fuse-ld=$mold -o $t/exe $t/a.o
-objcopy --dump-section .repro=$t/repro.tar.gz $t/exe
+MOLD_REPRO=1 clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+objcopy --dump-section .repro="$t"/repro.tar.gz "$t"/exe
 
-tar -C $t -xzf $t/repro.tar.gz
-fgrep -q /a.o  $t/repro/response.txt
-fgrep -q mold $t/repro/version.txt
+tar -C "$t" -xzf "$t"/repro.tar.gz
+fgrep -q /a.o  "$t"/repro/response.txt
+fgrep -q mold "$t"/repro/version.txt
 
 echo OK

--- a/test/elf/require-defined.sh
+++ b/test/elf/require-defined.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void foobar() {}
 EOF
 
-rm -f $t/b.a
-ar rcs $t/b.a $t/a.o
+rm -f "$t"/b.a
+ar rcs "$t"/b.a "$t"/a.o
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.a
-! readelf --symbols $t/exe | grep -q foobar || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.a
+! readelf --symbols "$t"/exe | grep -q foobar || false
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.a -Wl,-require-defined,foobar
-readelf --symbols $t/exe | grep -q foobar
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.a -Wl,-require-defined,foobar
+readelf --symbols "$t"/exe | grep -q foobar
 
-! clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.a -Wl,-require-defined,xyz >& $t/log
-grep -q 'undefined symbol: xyz' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.a -Wl,-require-defined,xyz >& "$t"/log
+grep -q 'undefined symbol: xyz' "$t"/log
 
 echo OK

--- a/test/elf/response-file.sh
+++ b/test/elf/response-file.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-echo '.globl _start; _start: jmp loop' | cc -o $t/a.o -c -x assembler -
-echo '.globl loop; loop: jmp loop' | cc -o $t/b.o -c -x assembler -
-echo "-o $t/exe '$t/a.o' $t/b.o" > $t/rsp
-$mold -static @$t/rsp
-objdump -d $t/exe > /dev/null
-file $t/exe | grep -q ELF
+echo '.globl _start; _start: jmp loop' | cc -o "$t"/a.o -c -x assembler -
+echo '.globl loop; loop: jmp loop' | cc -o "$t"/b.o -c -x assembler -
+echo "-o '$t/exe' '$t/a.o' '$t/b.o'" > "$t"/rsp
+"$mold" -static @"$t"/rsp
+objdump -d "$t"/exe > /dev/null
+file "$t"/exe | grep -q ELF
 
 echo OK

--- a/test/elf/retain-symbols-file.sh
+++ b/test/elf/retain-symbols-file.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 static void foo() {}
 void bar() {}
 void baz() {}
 int main() {}
 EOF
 
-cat <<EOF > $t/symbols
+cat <<EOF > "$t"/symbols
 foo
 baz
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o \
-  -Wl,--retain-symbols-file=$t/symbols
-readelf --symbols $t/exe > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o \
+  -Wl,--retain-symbols-file="$t"/symbols
+readelf --symbols "$t"/exe > "$t"/log
 
-! grep -qw foo $t/log || false
-! grep -qw bar $t/log || false
-! grep -qw main $t/log || false
+! grep -qw foo "$t"/log || false
+! grep -qw bar "$t"/log || false
+! grep -qw main "$t"/log || false
 
-grep -qw baz $t/log
+grep -qw baz "$t"/log
 
 echo OK

--- a/test/elf/rodata-name.sh
+++ b/test/elf/rodata-name.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | cc -c -o $t/a.o -x assembler -
+cat <<'EOF' | cc -c -o "$t"/a.o -x assembler -
 .globl val1, val2, val3
 
 .section .rodata.str1.1,"aMS",@progbits,1
@@ -25,7 +25,7 @@ val3:
 .ascii "abcdefgh"
 EOF
 
-cat <<'EOF' | cc -c -o $t/b.o -xc -
+cat <<'EOF' | cc -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 extern char val1, val2, val3;
@@ -35,10 +35,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
 
-readelf -p .rodata.str $t/exe | grep -q Hello
-readelf -p .rodata.str $t/exe | grep -q world
-readelf -p .rodata.cst $t/exe | grep -q abcdefgh
+readelf -p .rodata.str "$t"/exe | grep -q Hello
+readelf -p .rodata.str "$t"/exe | grep -q world
+readelf -p .rodata.cst "$t"/exe | grep -q abcdefgh
 
 echo OK

--- a/test/elf/rpath.sh
+++ b/test/elf/rpath.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl main
 main:
   nop
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o \
   -Wl,-rpath,/foo -Wl,-rpath,/bar -Wl,-R/no/such/directory -Wl,-R/
 
-readelf --dynamic $t/exe | \
+readelf --dynamic "$t"/exe | \
   fgrep -q 'Library runpath: [/foo:/bar:/no/such/directory:/]'
 
 echo OK

--- a/test/elf/run.sh
+++ b/test/elf/run.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # ASAN doesn't work with LD_PRELOAD
-ldd $mold-wrapper.so | grep -q libasan && { echo skipped; exit; }
+ldd "$mold"-wrapper.so | grep -q libasan && { echo skipped; exit; }
 
-cat <<'EOF' | cc -xc -c -o $t/a.o -
+cat <<'EOF' | cc -xc -c -o "$t"/a.o -
 #include <stdio.h>
 
 int main() {
@@ -19,55 +19,55 @@ int main() {
 }
 EOF
 
-gcc -fuse-ld=bfd -o $t/exe $t/a.o
-readelf -p .comment $t/exe > $t/log
-! grep -q mold $t/log || false
+gcc -fuse-ld=bfd -o "$t"/exe "$t"/a.o
+readelf -p .comment "$t"/exe > "$t"/log
+! grep -q mold "$t"/log || false
 
-clang -fuse-ld=bfd -o $t/exe $t/a.o
-readelf -p .comment $t/exe > $t/log
-! grep -q mold $t/log || false
-
-LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$mold \
-  gcc -o $t/exe $t/a.o -B/usr/bin
-readelf -p .comment $t/exe > $t/log
-grep -q mold $t/log
+clang -fuse-ld=bfd -o "$t"/exe "$t"/a.o
+readelf -p .comment "$t"/exe > "$t"/log
+! grep -q mold "$t"/log || false
 
 LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$mold \
-  clang -o $t/exe $t/a.o -fuse-ld=/usr/bin/ld
-readelf -p .comment $t/exe > $t/log
-grep -q mold $t/log
+  gcc -o "$t"/exe "$t"/a.o -B/usr/bin
+readelf -p .comment "$t"/exe > "$t"/log
+grep -q mold "$t"/log
 
-$mold -run env | grep -q '^MOLD_PATH=.*/mold$'
+LD_PRELOAD=$mold-wrapper.so MOLD_PATH=$mold \
+  clang -o "$t"/exe "$t"/a.o -fuse-ld=/usr/bin/ld
+readelf -p .comment "$t"/exe > "$t"/log
+grep -q mold "$t"/log
 
-$mold -run /usr/bin/ld --version | grep -q mold
-$mold -run /usr/bin/ld.lld --version | grep -q mold
-$mold -run /usr/bin/ld.gold --version | grep -q mold
+"$mold" -run env | grep -q '^MOLD_PATH=.*/mold$'
 
-rm -f $t/ld $t/ld.lld $t/ld.gold $t/foo.ld
-touch $t/ld $t/ld.lld $t/ld.gold $t/foo.ld
-chmod 755 $t/ld $t/ld.lld $t/ld.gold $t/foo.ld
+"$mold" -run /usr/bin/ld --version | grep -q mold
+"$mold" -run /usr/bin/ld.lld --version | grep -q mold
+"$mold" -run /usr/bin/ld.gold --version | grep -q mold
 
-$mold -run $t/ld --version | grep -q mold
-$mold -run $t/ld.lld --version | grep -q mold
-$mold -run $t/ld.gold --version | grep -q mold
-$mold -run $t/foo.ld --version | grep -q mold && false
+rm -f "$t"/ld "$t"/ld.lld "$t"/ld.gold "$t"/foo.ld
+touch "$t"/ld "$t"/ld.lld "$t"/ld.gold "$t"/foo.ld
+chmod 755 "$t"/ld "$t"/ld.lld "$t"/ld.gold "$t"/foo.ld
 
-cat <<'EOF' > $t/sh
+"$mold" -run "$t"/ld --version | grep -q mold
+"$mold" -run "$t"/ld.lld --version | grep -q mold
+"$mold" -run "$t"/ld.gold --version | grep -q mold
+"$mold" -run "$t"/foo.ld --version | grep -q mold && false
+
+cat <<'EOF' > "$t"/sh
 #!/bin/sh
 $1 --version
 EOF
 
-chmod 755 $t/sh
+chmod 755 "$t"/sh
 
-$mold -run $t/sh ld --version | grep -q mold
-$mold -run $t/sh foo.ld --version >& /dev/null | grep -q mold && false
+"$mold" -run "$t"/sh ld --version | grep -q mold
+"$mold" -run "$t"/sh foo.ld --version >& /dev/null | grep -q mold && false
 
-$mold -run $t/sh $t/ld --version | grep -q mold
-$mold -run $t/sh $t/ld.lld --version | grep -q mold
-$mold -run $t/sh $t/ld.gold --version | grep -q mold
-$mold -run $t/sh $t/foo.ld --version | grep -q mold && false
+"$mold" -run "$t"/sh "$t"/ld --version | grep -q mold
+"$mold" -run "$t"/sh "$t"/ld.lld --version | grep -q mold
+"$mold" -run "$t"/sh "$t"/ld.gold --version | grep -q mold
+"$mold" -run "$t"/sh "$t"/foo.ld --version | grep -q mold && false
 
-ln -sf $mold $t/mold
-PATH="$t:$PATH" mold -run $t/sh ld --version | grep -q mold
+ln -sf "$mold" "$t"/mold
+PATH="$t:$PATH" mold -run "$t"/sh ld --version | grep -q mold
 
 echo OK

--- a/test/elf/section-alignment.sh
+++ b/test/elf/section-alignment.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | clang -c -o $t/a.o -xc -
+cat <<'EOF' | clang -c -o "$t"/a.o -xc -
 #include <stdint.h>
 #include <stdio.h>
 
@@ -38,7 +38,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q '^0 0 0$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q '^0 0 0$'
 
 echo OK

--- a/test/elf/section-name.sh
+++ b/test/elf/section-name.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | cc -o $t/a.o -c -x assembler -
+cat <<'EOF' | cc -o "$t"/a.o -c -x assembler -
 .globl _start
 .text
 _start:
@@ -64,23 +64,23 @@ _start:
 .ascii ".gcc_except_table.foo "
 EOF
 
-$mold -o $t/exe $t/a.o -z keep-text-section-prefix
+"$mold" -o "$t"/exe "$t"/a.o -z keep-text-section-prefix
 
-readelf -p .text.hot $t/exe | fgrep -q '.text.hot .text.hot.foo'
-readelf -p .text.unknown $t/exe | fgrep -q '.text.unknown .text.unknown.foo'
-readelf -p .text.unlikely $t/exe | fgrep -q '.text.unlikely .text.unlikely.foo'
-readelf -p .text.startup $t/exe | fgrep -q '.text.startup .text.startup.foo'
-readelf -p .text.exit $t/exe | fgrep -q '.text.exit .text.exit.foo'
-readelf -p .text $t/exe | fgrep -q '.text .text.foo'
-readelf -p .data.rel.ro $t/exe | fgrep -q '.data.rel.ro .data.rel.ro.foo'
-readelf -p .data $t/exe | fgrep -q '.data .data.foo'
-readelf -p .rodata $t/exe | fgrep -q '.rodata .rodata.foo'
-readelf -p .gcc_except_table $t/exe | fgrep -q '.gcc_except_table .gcc_except_table.foo'
+readelf -p .text.hot "$t"/exe | fgrep -q '.text.hot .text.hot.foo'
+readelf -p .text.unknown "$t"/exe | fgrep -q '.text.unknown .text.unknown.foo'
+readelf -p .text.unlikely "$t"/exe | fgrep -q '.text.unlikely .text.unlikely.foo'
+readelf -p .text.startup "$t"/exe | fgrep -q '.text.startup .text.startup.foo'
+readelf -p .text.exit "$t"/exe | fgrep -q '.text.exit .text.exit.foo'
+readelf -p .text "$t"/exe | fgrep -q '.text .text.foo'
+readelf -p .data.rel.ro "$t"/exe | fgrep -q '.data.rel.ro .data.rel.ro.foo'
+readelf -p .data "$t"/exe | fgrep -q '.data .data.foo'
+readelf -p .rodata "$t"/exe | fgrep -q '.rodata .rodata.foo'
+readelf -p .gcc_except_table "$t"/exe | fgrep -q '.gcc_except_table .gcc_except_table.foo'
 
-$mold -o $t/exe $t/a.o
-! readelf --sections $t/exe | fgrep -q .text.hot || false
+"$mold" -o "$t"/exe "$t"/a.o
+! readelf --sections "$t"/exe | fgrep -q .text.hot || false
 
-$mold -o $t/exe $t/a.o -z nokeep-text-section-prefix
-! readelf --sections $t/exe | fgrep -q .text.hot || false
+"$mold" -o "$t"/exe "$t"/a.o -z nokeep-text-section-prefix
+! readelf --sections "$t"/exe | fgrep -q .text.hot || false
 
 echo OK

--- a/test/elf/shared.sh
+++ b/test/elf/shared.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | clang -fPIC -c -o $t/a.o -xc -
+cat <<'EOF' | clang -fPIC -c -o "$t"/a.o -xc -
 void fn2();
 void fn1() { fn2(); }
 void fn3() {}
 EOF
 
-clang -shared -fuse-ld=$mold -o $t/b.so $t/a.o
+clang -shared -fuse-ld="$mold" -o "$t"/b.so "$t"/a.o
 
-readelf --dyn-syms $t/b.so > $t/log
+readelf --dyn-syms "$t"/b.so > "$t"/log
 
-grep -q '0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND fn2' $t/log
-grep -Pq 'FUNC    GLOBAL DEFAULT   \d+ fn1' $t/log
+grep -q '0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND fn2' "$t"/log
+grep -Pq 'FUNC    GLOBAL DEFAULT   \d+ fn1' "$t"/log
 
-cat <<EOF | clang -fPIC -c -o $t/c.o -xc -
+cat <<EOF | clang -fPIC -c -o "$t"/c.o -xc -
 #include <stdio.h>
 
 int fn1();
@@ -35,8 +35,8 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.so
-$t/exe | grep -q hello
-! readelf --symbols $t/exe | grep -q fn3 || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe | grep -q hello
+! readelf --symbols "$t"/exe | grep -q fn3 || false
 
 echo OK

--- a/test/elf/soname.sh
+++ b/test/elf/soname.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fPIC -c -o $t/a.o -xc -
+cat <<EOF | clang -fPIC -c -o "$t"/a.o -xc -
 void foo() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/b.so -shared $t/a.o -Wl,-soname,foo
-readelf --dynamic $t/b.so | fgrep -q 'Library soname: [foo]'
+clang -fuse-ld="$mold" -o "$t"/b.so -shared "$t"/a.o -Wl,-soname,foo
+readelf --dynamic "$t"/b.so | fgrep -q 'Library soname: [foo]'
 
 echo OK

--- a/test/elf/spare-dynamic-tags.sh
+++ b/test/elf/spare-dynamic-tags.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo '.globl main; main:' | cc -o $t/a.o -c -x assembler -
+echo '.globl main; main:' | cc -o "$t"/a.o -c -x assembler -
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-size_before=$((16#$(readelf --wide --sections $t/exe  | grep .dynamic | tr -s ' ' | cut -d ' ' -f7)))
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+size_before=$((16#$(readelf --wide --sections "$t"/exe  | grep .dynamic | tr -s ' ' | cut -d ' ' -f7)))
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-spare-dynamic-tags=100
-size_after=$((16#$(readelf --wide --sections $t/exe  | grep .dynamic | tr -s ' ' | cut -d ' ' -f7)))
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-spare-dynamic-tags=100
+size_after=$((16#$(readelf --wide --sections "$t"/exe  | grep .dynamic | tr -s ' ' | cut -d ' ' -f7)))
 
 # Ensure space for 95 additional spare tags has been added (default: 5)
 [[ $(( $size_after - $size_before )) == $(( 16*95 )) ]]

--- a/test/elf/start-lib.sh
+++ b/test/elf/start-lib.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int foo() { return 3; }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 int bar() { return 3; }
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe -Wl,-start-lib $t/a.o -Wl,-end-lib $t/b.o $t/c.o
-nm $t/exe > $t/log
-! grep -q ' foo$' $t/log || false
-grep -q ' bar$' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe -Wl,-start-lib "$t"/a.o -Wl,-end-lib "$t"/b.o "$t"/c.o
+nm "$t"/exe > "$t"/log
+! grep -q ' foo$' "$t"/log || false
+grep -q ' bar$' "$t"/log
 
 echo OK

--- a/test/elf/start-stop-symbol.sh
+++ b/test/elf/start-stop-symbol.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | clang -c -o $t/a.o -xc -
+cat <<'EOF' | clang -c -o "$t"/a.o -xc -
 __attribute__((section("foo")))
 char data[] = "section foo";
 EOF
 
-ar rcs $t/b.a $t/a.o
+ar rcs "$t"/b.a "$t"/a.o
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 #include <stdio.h>
 
 extern char data[];
@@ -26,10 +26,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.a
-$t/exe | grep -q 'section foo section foo'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.a
+"$t"/exe | grep -q 'section foo section foo'
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.a -Wl,-gc-sections
-$t/exe | grep -q 'section foo section foo'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.a -Wl,-gc-sections
+"$t"/exe | grep -q 'section foo section foo'
 
 echo OK

--- a/test/elf/static-archive.sh
+++ b/test/elf/static-archive.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/long-long-long-filename.o -c -xc -
+cat <<EOF | cc -o "$t"/long-long-long-filename.o -c -xc -
 int three() { return 3; }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 int five() { return 5; }
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 #include <stdio.h>
 
 int three();
@@ -26,15 +26,15 @@ int main() {
 }
 EOF
 
-rm -f $t/d.a
-(cd $t; ar rcs d.a long-long-long-filename.o b.o)
+rm -f "$t"/d.a
+(cd "$t"; ar rcs d.a long-long-long-filename.o b.o)
 
-clang -fuse-ld=$mold -Wl,--trace -o $t/exe $t/c.o $t/d.a > $t/log
+clang -fuse-ld="$mold" -Wl,--trace -o "$t"/exe "$t"/c.o "$t"/d.a > "$t"/log
 
-fgrep -q 'static-archive/d.a(long-long-long-filename.o)' $t/log
-fgrep -q 'static-archive/d.a(b.o)' $t/log
-fgrep -q static-archive/c.o $t/log
+fgrep -q 'static-archive/d.a(long-long-long-filename.o)' "$t"/log
+fgrep -q 'static-archive/d.a(b.o)' "$t"/log
+fgrep -q static-archive/c.o "$t"/log
 
-$t/exe | grep -q '8'
+"$t"/exe | grep -q '8'
 
 echo OK

--- a/test/elf/stdout.sh
+++ b/test/elf/stdout.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,8 +16,8 @@ int main() {
 }
 EOF
 
-clang -Wl,-build-id=sha1 -fuse-ld=$mold $t/a.o -o - > $t/exe
-chmod 755 $t/exe
-$t/exe | grep -q 'Hello world'
+clang -Wl,-build-id=sha1 -fuse-ld="$mold" "$t"/a.o -o - > "$t"/exe
+chmod 755 "$t"/exe
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/strip.sh
+++ b/test/elf/strip.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' | cc -x assembler -c -o $t/a.o -Wa,-L -
+cat <<'EOF' | cc -x assembler -c -o "$t"/a.o -Wa,-L -
 .globl _start, foo
 _start:
 foo:
@@ -15,18 +15,18 @@ bar:
 .L.baz:
 EOF
 
-$mold -o $t/exe $t/a.o
-readelf --symbols $t/exe > $t/log
-fgrep -q _start $t/log
-fgrep -q foo $t/log
-fgrep -q bar $t/log
-fgrep -q .L.baz $t/log
+"$mold" -o "$t"/exe "$t"/a.o
+readelf --symbols "$t"/exe > "$t"/log
+fgrep -q _start "$t"/log
+fgrep -q foo "$t"/log
+fgrep -q bar "$t"/log
+fgrep -q .L.baz "$t"/log
 
-$mold -o $t/exe $t/a.o -strip-all
-readelf --symbols $t/exe > $t/log
-! fgrep -q _start $t/log || false
-! fgrep -q foo $t/log || false
-! fgrep -q bar $t/log || false
-! fgrep -q .L.baz $t/log || false
+"$mold" -o "$t"/exe "$t"/a.o -strip-all
+readelf --symbols "$t"/exe > "$t"/log
+! fgrep -q _start "$t"/log || false
+! fgrep -q foo "$t"/log || false
+! fgrep -q bar "$t"/log || false
+! fgrep -q .L.baz "$t"/log || false
 
 echo OK

--- a/test/elf/symbol-version.sh
+++ b/test/elf/symbol-version.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fPIC -c -o $t/a.o -xc -
+cat <<EOF | clang -fPIC -c -o "$t"/a.o -xc -
 void foo1() {}
 void foo2() {}
 void foo3() {}
@@ -23,12 +23,12 @@ void bar() {
 }
 EOF
 
-echo 'VER1 { local: *; }; VER2 { local: *; }; VER3 { local: *; };' > $t/b.ver
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o -Wl,--version-script=$t/b.ver
-readelf --symbols $t/c.so > $t/log
+echo 'VER1 { local: *; }; VER2 { local: *; }; VER3 { local: *; };' > "$t"/b.ver
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o -Wl,--version-script="$t"/b.ver
+readelf --symbols "$t"/c.so > "$t"/log
 
-fgrep -q 'foo@VER1' $t/log
-fgrep -q 'foo@VER2' $t/log
-fgrep -q 'foo@@VER3' $t/log
+fgrep -q 'foo@VER1' "$t"/log
+fgrep -q 'foo@VER2' "$t"/log
+fgrep -q 'foo@@VER3' "$t"/log
 
 echo OK

--- a/test/elf/symtab.sh
+++ b/test/elf/symtab.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .globl foo, bar, this_is_global
 local1:
 foo:
@@ -15,7 +15,7 @@ bar:
   .byte 0
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -x assembler -
+cat <<EOF | cc -o "$t"/b.o -c -x assembler -
   .globl this_is_global
 local2:
 this_is_global:
@@ -24,17 +24,17 @@ this_is_global:
 module_local:
 EOF
 
-echo '{ local: module_local; };' > $t/c.map
+echo '{ local: module_local; };' > "$t"/c.map
 
-$mold -o $t/exe $t/a.o $t/b.o --version-script=$t/c.map
+"$mold" -o "$t"/exe "$t"/a.o "$t"/b.o --version-script="$t"/c.map
 
-readelf --symbols $t/exe > $t/log
+readelf --symbols "$t"/exe > "$t"/log
 
-grep -Pq '0 NOTYPE  LOCAL  DEFAULT    \d+ local1' $t/log
-grep -Pq '0 NOTYPE  LOCAL  DEFAULT    \d+ local2' $t/log
-grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ foo' $t/log
-grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ bar' $t/log
-grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ this_is_global' $t/log
-grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ module_local' $t/log
+grep -Pq '0 NOTYPE  LOCAL  DEFAULT    \d+ local1' "$t"/log
+grep -Pq '0 NOTYPE  LOCAL  DEFAULT    \d+ local2' "$t"/log
+grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ foo' "$t"/log
+grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ bar' "$t"/log
+grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ this_is_global' "$t"/log
+grep -Pq '0 NOTYPE  GLOBAL DEFAULT    \d+ module_local' "$t"/log
 
 echo OK

--- a/test/elf/synthetic-symbols.sh
+++ b/test/elf/synthetic-symbols.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -x assembler -
+cat <<EOF | clang -c -o "$t"/a.o -x assembler -
 .section foo,"a",@progbits
 .ascii "section foo"
 EOF
 
 # Test synthetic symbols
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -44,17 +44,17 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -Wl,--image-base=0x40000 \
-  -o $t/exe $t/a.o $t/b.o
-$t/exe > $t/log
+clang -fuse-ld="$mold" -no-pie -Wl,--image-base=0x40000 \
+  -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe > "$t"/log
 
-grep -q '^__ehdr_start=0x40000$' $t/log
-grep -q '^__executable_start=0x40000$' $t/log
-grep -q '^section foo$' $t/log
+grep -q '^__ehdr_start=0x40000$' "$t"/log
+grep -q '^__executable_start=0x40000$' "$t"/log
+grep -q '^section foo$' "$t"/log
 
 # Make sure that synthetic symbols overwrite existing ones
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -88,15 +88,15 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -no-pie -Wl,--image-base=0x40000 \
-  -o $t/exe $t/a.o $t/c.o
-$t/exe > $t/log
+clang -fuse-ld="$mold" -no-pie -Wl,--image-base=0x40000 \
+  -o "$t"/exe "$t"/a.o "$t"/c.o
+"$t"/exe > "$t"/log
 
-grep -q '^end=foo$' $t/log
-grep -q '^etext=foo$' $t/log
-grep -q '^edata=foo$' $t/log
-grep -q '^__ehdr_start=0x40000$' $t/log
-grep -q '^__executable_start=0x40000$' $t/log
-grep -q '^section foo$' $t/log
+grep -q '^end=foo$' "$t"/log
+grep -q '^etext=foo$' "$t"/log
+grep -q '^edata=foo$' "$t"/log
+grep -q '^__ehdr_start=0x40000$' "$t"/log
+grep -q '^__executable_start=0x40000$' "$t"/log
+grep -q '^section foo$' "$t"/log
 
 echo OK

--- a/test/elf/sysroot-linker-script.sh
+++ b/test/elf/sysroot-linker-script.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void foo() {}
 EOF
 
-mkdir -p $t/foo/bar
-rm -f $t/foo/bar/libfoo.a
-ar rcs $t/foo/bar/libfoo.a $t/a.o
+mkdir -p "$t"/foo/bar
+rm -f "$t"/foo/bar/libfoo.a
+ar rcs "$t"/foo/bar/libfoo.a "$t"/a.o
 
-cat <<EOF > $t/foo/bar/b.script
+cat <<EOF > "$t"/foo/bar/b.script
 INPUT(/foo/bar/libfoo.a)
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 void foo();
 int main() { foo(); }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,--sysroot=$t/ $t/foo/bar/b.script
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,--sysroot="$t"/ "$t"/foo/bar/b.script
 
 echo OK

--- a/test/elf/sysroot.sh
+++ b/test/elf/sysroot.sh
@@ -1,46 +1,46 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 void foo() {}
 EOF
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 void bar() {}
 EOF
 
-mkdir -p $t/foo/bar
-rm -f $t/foo/bar/libfoo.a
-ar rcs $t/foo/bar/libfoo.a $t/a.o $t/b.o
+mkdir -p "$t"/foo/bar
+rm -f "$t"/foo/bar/libfoo.a
+ar rcs "$t"/foo/bar/libfoo.a "$t"/a.o "$t"/b.o
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 void foo();
 int main() {
   foo();
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,--sysroot=$t/ \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,--sysroot="$t"/ \
   -Wl,-L=foo/bar -lfoo
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,--sysroot=$t/ \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,--sysroot="$t"/ \
   -Wl,-L=/foo/bar -lfoo
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,--sysroot=$t/ \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,--sysroot="$t"/ \
   '-Wl,-L$SYSROOTfoo/bar' -lfoo
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,--sysroot=$t/ \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,--sysroot="$t"/ \
   '-Wl,-L$SYSROOT/foo/bar' -lfoo
 
-! clang -fuse-ld=$mold -o $t/exe $t/c.o -lfoo >& /dev/null
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -lfoo >& /dev/null
 
-! clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,--sysroot=$t \
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,--sysroot="$t" \
   -Wl,-Lfoo/bar -lfoo >& /dev/null
 
 echo OK

--- a/test/elf/sysroot2.sh
+++ b/test/elf/sysroot2.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-mkdir -p $t/sysroot/foo
+mkdir -p "$t"/sysroot/foo
 
-cat <<EOF > $t/a.script
+cat <<EOF > "$t"/a.script
 INPUT(=/foo/x.o)
 EOF
 
-cat <<EOF > $t/sysroot/b.script
+cat <<EOF > "$t"/sysroot/b.script
 INPUT(/foo/y.o)
 EOF
 
-cat <<EOF | clang -c -o $t/sysroot/foo/x.o -xc -
+cat <<EOF | clang -c -o "$t"/sysroot/foo/x.o -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | clang -c -o $t/sysroot/foo/y.o -xc -
+cat <<EOF | clang -c -o "$t"/sysroot/foo/y.o -xc -
 #include <stdio.h>
 void hello2() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 void hello();
 void hello2();
 
@@ -41,7 +41,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe -Wl,--sysroot=$t/sysroot \
-  $t/a.script $t/sysroot/b.script $t/c.o
+clang -fuse-ld="$mold" -o "$t"/exe -Wl,--sysroot="$t"/sysroot \
+  "$t"/a.script "$t"/sysroot/b.script "$t"/c.o
 
 echo OK

--- a/test/elf/thin-archive.sh
+++ b/test/elf/thin-archive.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/long-long-long-filename.o -c -xc -
+cat <<EOF | cc -o "$t"/long-long-long-filename.o -c -xc -
 int three() { return 3; }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 int five() { return 5; }
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 int seven() { return 7; }
 EOF
 
-cat <<EOF | cc -o $t/d.o -c -xc -
+cat <<EOF | cc -o "$t"/d.o -c -xc -
 #include <stdio.h>
 
 int three();
@@ -31,16 +31,16 @@ int main() {
 }
 EOF
 
-rm -f $t/d.a
-(cd $t; ar rcsT d.a long-long-long-filename.o b.o `pwd`/c.o)
+rm -f "$t"/d.a
+(cd "$t"; ar rcsT d.a long-long-long-filename.o b.o "`pwd`"/c.o)
 
-clang -fuse-ld=$mold -Wl,--trace -o $t/exe $t/d.o $t/d.a > $t/log
+clang -fuse-ld="$mold" -Wl,--trace -o "$t"/exe "$t"/d.o "$t"/d.a > "$t"/log
 
-grep -Pq 'thin-archive/d.a\(.*long-long-long-filename.o\)' $t/log
-grep -Pq 'thin-archive/d.a\(.*b.o\)' $t/log
-grep -Pq 'thin-archive/d.a\(/.*/b.o\)' $t/log
-fgrep -q thin-archive/d.o $t/log
+grep -Pq 'thin-archive/d.a\(.*long-long-long-filename.o\)' "$t"/log
+grep -Pq 'thin-archive/d.a\(.*b.o\)' "$t"/log
+grep -Pq 'thin-archive/d.a\(/.*/b.o\)' "$t"/log
+fgrep -q thin-archive/d.o "$t"/log
 
-$t/exe | grep -q 15
+"$t"/exe | grep -q 15
 
 echo OK

--- a/test/elf/thread-count.sh
+++ b/test/elf/thread-count.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-no-threads
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-thread-count=1
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-threads
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-threads=1
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,--threads=1
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-no-threads
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-thread-count=1
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-threads
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-threads=1
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,--threads=1
 
 echo OK

--- a/test/elf/tls-dso.sh
+++ b/test/elf/tls-dso.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -shared -o $t/a.so -xc -
+cat <<EOF | cc -fPIC -shared -o "$t"/a.so -xc -
 extern _Thread_local int foo;
 _Thread_local int bar;
 
@@ -15,7 +15,7 @@ int get_foo1() { return foo; }
 int get_bar1() { return bar; }
 EOF
 
-cat <<EOF | cc -c -o $t/b.o -xc -
+cat <<EOF | cc -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 _Thread_local int foo;
@@ -38,7 +38,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.so $t/b.o
-$t/exe | grep -q '5 3 5 3 5 3'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.so "$t"/b.o
+"$t"/exe | grep -q '5 3 5 3 5 3'
 
 echo OK

--- a/test/elf/tls-gd.sh
+++ b/test/elf/tls-gd.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o $t/a.o -xc -
+cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 static _Thread_local int x1 = 1;
@@ -34,26 +34,26 @@ int main() {
 }
 EOF
 
-cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o $t/b.o -xc -
+cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o "$t"/b.o -xc -
 _Thread_local int x3 = 3;
 static _Thread_local int x5 = 5;
 int get_x5() { return x5; }
 EOF
 
 
-cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o $t/c.o -xc -
+cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o "$t"/c.o -xc -
 _Thread_local int x4 = 4;
 static _Thread_local int x6 = 6;
 int get_x6() { return x6; }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/d.so $t/b.o
-clang -fuse-ld=$mold -shared -o $t/e.so $t/c.o -Wl,--no-relax
+clang -fuse-ld="$mold" -shared -o "$t"/d.so "$t"/b.o
+clang -fuse-ld="$mold" -shared -o "$t"/e.so "$t"/c.o -Wl,--no-relax
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/d.so $t/e.so
-$t/exe | grep -q '1 2 3 4 5 6'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/d.so "$t"/e.so
+"$t"/exe | grep -q '1 2 3 4 5 6'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/d.so $t/e.so -Wl,-no-relax
-$t/exe | grep -q '1 2 3 4 5 6'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/d.so "$t"/e.so -Wl,-no-relax
+"$t"/exe | grep -q '1 2 3 4 5 6'
 
 echo OK

--- a/test/elf/tls-gd2.sh
+++ b/test/elf/tls-gd2.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-echo '{ global: bar; local: *; };' > $t/a.ver
+echo '{ global: bar; local: *; };' > "$t"/a.ver
 
-cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o $t/b.o -xc -
+cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o "$t"/b.o -xc -
 _Thread_local int foo;
 
 int bar() {
@@ -26,9 +26,9 @@ int bar() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/b.o -Wl,--version-script=$t/a.ver \
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/b.o -Wl,--version-script="$t"/a.ver \
   -Wl,--no-relax
 
-readelf -W --dyn-syms $t/c.so | grep -Pq 'TLS     LOCAL  DEFAULT   \d+ foo'
+readelf -W --dyn-syms "$t"/c.so | grep -Pq 'TLS     LOCAL  DEFAULT   \d+ foo'
 
 echo OK

--- a/test/elf/tls-ie.sh
+++ b/test/elf/tls-ie.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -ftls-model=initial-exec -mtls-dialect=$dialect -fPIC -c -o $t/a.o -xc -
+cat <<EOF | gcc -ftls-model=initial-exec -mtls-dialect=$dialect -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 static _Thread_local int foo;
@@ -32,9 +32,9 @@ void print() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o
 
-cat <<EOF | gcc -c -o $t/c.o -xc -
+cat <<EOF | gcc -c -o "$t"/c.o -xc -
 #include <stdio.h>
 
 _Thread_local int baz;
@@ -51,10 +51,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/b.so $t/c.o
-$t/exe | grep -q '^0 0 3 5 7$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.so "$t"/c.o
+"$t"/exe | grep -q '^0 0 3 5 7$'
 
-clang -fuse-ld=$mold -o $t/exe $t/b.so $t/c.o -Wl,-no-relax
-$t/exe | grep -q '^0 0 3 5 7$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.so "$t"/c.o -Wl,-no-relax
+"$t"/exe | grep -q '^0 0 3 5 7$'
 
 echo OK

--- a/test/elf/tls-large-tbss.sh
+++ b/test/elf/tls-large-tbss.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -x assembler -
+cat <<EOF | cc -c -o "$t"/a.o -x assembler -
 .globl x, y
 .section .tbss,"awT",@nobits
 x:
@@ -17,7 +17,7 @@ y:
 .zero 1024
 EOF
 
-cat <<EOF | cc -c -o $t/b.o -xc -
+cat <<EOF | cc -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 extern _Thread_local char x[1024000];
@@ -30,7 +30,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '^3 0 5 0 0 0$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '^3 0 5 0 0 0$'
 
 echo OK

--- a/test/elf/tls-ld.sh
+++ b/test/elf/tls-ld.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -ftls-model=local-dynamic -mtls-dialect=$dialect -fPIC -c -o $t/a.o -xc -
+cat <<EOF | gcc -ftls-model=local-dynamic -mtls-dialect=$dialect -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -33,14 +33,14 @@ int main() {
 }
 EOF
 
-cat <<EOF | gcc -ftls-model=local-dynamic -mtls-dialect=$dialect  -fPIC -c -o $t/b.o -xc -
+cat <<EOF | gcc -ftls-model=local-dynamic -mtls-dialect=$dialect  -fPIC -c -o "$t"/b.o -xc -
 _Thread_local int foo = 3;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '3 5 3 5'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-no-relax
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-no-relax
+"$t"/exe | grep -q '3 5 3 5'
 
 echo OK

--- a/test/elf/tls-le.sh
+++ b/test/elf/tls-le.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -ftls-model=local-exec -mtls-dialect=$dialect -fPIC -c -o $t/a.o -xc -
+cat <<EOF | gcc -ftls-model=local-exec -mtls-dialect=$dialect -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -33,14 +33,14 @@ int main() {
 }
 EOF
 
-cat <<EOF | gcc -ftls-model=local-exec -mtls-dialect=$dialect -fPIC -c -o $t/b.o -xc -
+cat <<EOF | gcc -ftls-model=local-exec -mtls-dialect=$dialect -fPIC -c -o "$t"/b.o -xc -
 _Thread_local int foo = 3;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '3 5 3 5'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-no-relax
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-no-relax
+"$t"/exe | grep -q '3 5 3 5'
 
 echo OK

--- a/test/elf/tls-nopic.sh
+++ b/test/elf/tls-nopic.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -mtls-dialect=$dialect -c -o $t/a.o -xc -
+cat <<EOF | gcc -mtls-dialect=$dialect -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -34,11 +34,11 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -xc -c -o $t/b.o -
+cat <<EOF | cc -xc -c -o "$t"/b.o -
 _Thread_local int foo;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '3 5 3 5'
 
 echo OK

--- a/test/elf/tls-pic.sh
+++ b/test/elf/tls-pic.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=trad
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o $t/a.o -xc -
+cat <<EOF | gcc -mtls-dialect=$dialect -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -33,11 +33,11 @@ int main() {
 }
 EOF
 
-cat <<EOF | cc -xc -c -o $t/b.o -
+cat <<EOF | cc -xc -c -o "$t"/b.o -
 _Thread_local int foo = 3;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '3 5 3 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '3 5 3 5'
 
 echo OK

--- a/test/elf/tlsdesc-import.sh
+++ b/test/elf/tlsdesc-import.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu2
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=desc
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o $t/a.o -xc -
+cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -28,12 +28,12 @@ int main() {
 }
 EOF
 
-cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -shared -o $t/b.so -xc -
+cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -shared -o "$t"/b.so -xc -
 _Thread_local int foo = 5;
 _Thread_local int bar;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.so
-$t/exe | grep -q '5 7'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.so
+"$t"/exe | grep -q '5 7'
 
 echo OK

--- a/test/elf/tlsdesc-static.sh
+++ b/test/elf/tlsdesc-static.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu2
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=desc
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o $t/a.o -xc -
+cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 extern _Thread_local int foo;
@@ -27,14 +27,14 @@ int main() {
 }
 EOF
 
-cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o $t/b.o -xc -
+cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o "$t"/b.o -xc -
 _Thread_local int foo;
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -static
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -static
+"$t"/exe | grep -q 42
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -static -Wl,-no-relax
-$t/exe | grep -q 42
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -static -Wl,-no-relax
+"$t"/exe | grep -q 42
 
 echo OK

--- a/test/elf/tlsdesc.sh
+++ b/test/elf/tlsdesc.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-if [ $(uname -m) = x86_64 ]; then
+if [ "$(uname -m)" = x86_64 ]; then
   dialect=gnu2
-elif [ $(uname -m) = aarch64 ]; then
+elif [ "$(uname -m)" = aarch64 ]; then
   dialect=desc
 else
   echo skipped
   exit 0
 fi
 
-cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o $t/a.o -xc -
+cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o "$t"/a.o -xc -
 extern _Thread_local int foo;
 
 int get_foo() {
@@ -30,7 +30,7 @@ int get_bar() {
 }
 EOF
 
-cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o $t/b.o -xc -
+cat <<EOF | gcc -fPIC -mtls-dialect=$dialect -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 _Thread_local int foo;
@@ -45,18 +45,18 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '42 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '42 5'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-no-relax
-$t/exe | grep -q '42 5'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-no-relax
+"$t"/exe | grep -q '42 5'
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/c.so
-$t/exe | grep -q '42 5'
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/c.so
+"$t"/exe | grep -q '42 5'
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o -Wl,-no-relax
-clang -fuse-ld=$mold -o $t/exe $t/b.o $t/c.so -Wl,-no-relax
-$t/exe | grep -q '42 5'
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o -Wl,-no-relax
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/b.o "$t"/c.so -Wl,-no-relax
+"$t"/exe | grep -q '42 5'
 
 echo OK

--- a/test/elf/trace-symbol.sh
+++ b/test/elf/trace-symbol.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void foo();
@@ -18,7 +18,7 @@ void bar() {
 }
 EOF
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 void foo() {}
 void bar();
 
@@ -28,10 +28,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o \
-  -Wl,--trace-symbol=foo > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o \
+  -Wl,--trace-symbol=foo > "$t"/log
 
-grep -q 'trace-symbol: .*/a.o: reference to foo' $t/log
-grep -q 'trace-symbol: .*/b.o: definition of foo' $t/log
+grep -q 'trace-symbol: .*/a.o: reference to foo' "$t"/log
+grep -q 'trace-symbol: .*/b.o: definition of foo' "$t"/log
 
 echo OK

--- a/test/elf/trace.sh
+++ b/test/elf/trace.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,7 +16,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-trace > $t/log
-grep -q '/a\.o$' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-trace > "$t"/log
+grep -q '/a\.o$' "$t"/log
 
 echo OK

--- a/test/elf/undefined.sh
+++ b/test/elf/undefined.sh
@@ -1,43 +1,43 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 .globl _start
 _start:
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -x assembler -
+cat <<EOF | cc -o "$t"/b.o -c -x assembler -
 .globl foo
 foo:
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -x assembler -
+cat <<EOF | cc -o "$t"/c.o -c -x assembler -
 .globl bar
 bar:
 EOF
 
-rm -f $t/d.a
-ar cr $t/d.a $t/b.o $t/c.o
+rm -f "$t"/d.a
+ar cr "$t"/d.a "$t"/b.o "$t"/c.o
 
-$mold -static -o $t/exe $t/a.o $t/d.a
-readelf --symbols $t/exe > $t/log
-! grep -q foo $t/log || false
-! grep -q bar $t/log || false
+"$mold" -static -o "$t"/exe "$t"/a.o "$t"/d.a
+readelf --symbols "$t"/exe > "$t"/log
+! grep -q foo "$t"/log || false
+! grep -q bar "$t"/log || false
 
-$mold -static -o $t/exe $t/a.o $t/d.a -u foo
-readelf --symbols $t/exe > $t/log
-grep -q foo $t/log
-! grep -q bar $t/log || false
+"$mold" -static -o "$t"/exe "$t"/a.o "$t"/d.a -u foo
+readelf --symbols "$t"/exe > "$t"/log
+grep -q foo "$t"/log
+! grep -q bar "$t"/log || false
 
-$mold -static -o $t/exe $t/a.o $t/d.a -u foo --undefined=bar
-readelf --symbols $t/exe > $t/log
-grep -q foo $t/log
-grep -q bar $t/log
+"$mold" -static -o "$t"/exe "$t"/a.o "$t"/d.a -u foo --undefined=bar
+readelf --symbols "$t"/exe > "$t"/log
+grep -q foo "$t"/log
+grep -q bar "$t"/log
 
 echo OK

--- a/test/elf/unique.sh
+++ b/test/elf/unique.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -x assembler -
+cat <<EOF | cc -c -o "$t"/a.o -x assembler -
 .section .data.foo.1,"aw",@progbits
 .ascii "a"
 .section .data.foo.1,"aw",@progbits
@@ -24,10 +24,10 @@ _start:
   nop
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -nostdlib -Wl,-unique='*foo*'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -nostdlib -Wl,-unique='*foo*'
 
-readelf -x .data.foo.1 $t/exe | grep -q ab
-readelf -x .data.foo.2 $t/exe | grep -q c
-readelf -x .data $t/exe | grep -q de
+readelf -x .data.foo.1 "$t"/exe | grep -q ab
+readelf -x .data.foo.2 "$t"/exe | grep -q c
+readelf -x .data "$t"/exe | grep -q de
 
 echo OK

--- a/test/elf/unresolved-symbols.sh
+++ b/test/elf/unresolved-symbols.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -xc -
+cat <<EOF | cc -c -o "$t"/a.o -xc -
 int foo();
 int main() { foo(); }
 EOF
 
-cmd="clang -fuse-ld=$mold -o $t/exe $t/a.o"
+cmd=(clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o)
 
-! $cmd 2>&1 | grep -q 'undefined.*foo'
-! $cmd -Wl,-unresolved-symbols=report-all 2>&1 | grep -q 'undefined.*foo'
+! "${cmd[@]}" 2>&1 | grep -q 'undefined.*foo'
+! "${cmd[@]}" -Wl,-unresolved-symbols=report-all 2>&1 | grep -q 'undefined.*foo'
 
-$cmd -Wl,-unresolved-symbols=ignore-all
+"${cmd[@]}" -Wl,-unresolved-symbols=ignore-all
 
-! readelf --dyn-syms $t/exe | grep -w foo || false
+! readelf --dyn-syms "$t"/exe | grep -w foo || false
 
-$cmd -Wl,-unresolved-symbols=report-all -Wl,--warn-unresolved-symbols 2>&1 | \
+"${cmd[@]}" -Wl,-unresolved-symbols=report-all -Wl,--warn-unresolved-symbols 2>&1 | \
   grep -q 'undefined.*foo'
 
-! $cmd -Wl,-unresolved-symbols=ignore-in-object-files 2>&1 | grep -q 'undefined.*foo'
-! $cmd -Wl,-unresolved-symbols=ignore-in-shared-libs 2>&1 | grep -q 'undefined.*foo'
+! "${cmd[@]}" -Wl,-unresolved-symbols=ignore-in-object-files 2>&1 | grep -q 'undefined.*foo'
+! "${cmd[@]}" -Wl,-unresolved-symbols=ignore-in-shared-libs 2>&1 | grep -q 'undefined.*foo'
 
 echo OK

--- a/test/elf/verbose.sh
+++ b/test/elf/verbose.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -xc -o $t/a.o -
+cat <<EOF | clang -c -xc -o "$t"/a.o -
 #include <stdio.h>
 
 int main() {
@@ -15,6 +15,6 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -Wl,--verbose -o $t/exe $t/a.o > /dev/null
+clang -fuse-ld="$mold" -Wl,--verbose -o "$t"/exe "$t"/a.o > /dev/null
 
 echo OK

--- a/test/elf/version-script.sh
+++ b/test/elf/version-script.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'ver_x { global: *; };' > $t/a.ver
+echo 'ver_x { global: *; };' > "$t"/a.ver
 
-cat <<EOF > $t/b.s
+cat <<EOF > "$t"/b.s
 .globl foo, bar, baz
 foo:
   nop
@@ -19,9 +19,9 @@ baz:
   nop
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/c.so -Wl,-version-script,$t/a.ver $t/b.s
-readelf --version-info $t/c.so > $t/log
+clang -fuse-ld="$mold" -shared -o "$t"/c.so -Wl,-version-script,"$t"/a.ver "$t"/b.s
+readelf --version-info "$t"/c.so > "$t"/log
 
-fgrep -q 'Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: ver_x' $t/log
+fgrep -q 'Rev: 1  Flags: none  Index: 2  Cnt: 1  Name: ver_x' "$t"/log
 
 echo OK

--- a/test/elf/version-script2.sh
+++ b/test/elf/version-script2.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.ver
+cat <<EOF > "$t"/a.ver
 ver1 {
   global: foo;
   local: *;
@@ -22,13 +22,13 @@ ver3 {
 };
 EOF
 
-cat <<EOF | clang -fuse-ld=$mold -xc -shared -o $t/b.so -Wl,-version-script,$t/a.ver -
+cat <<EOF | clang -fuse-ld="$mold" -xc -shared -o "$t"/b.so -Wl,-version-script,"$t"/a.ver -
 void foo() {}
 void bar() {}
 void baz() {}
 EOF
 
-cat <<EOF | clang -xc -c -o $t/c.o -
+cat <<EOF | clang -xc -c -o "$t"/c.o -
 void foo();
 void bar();
 void baz();
@@ -41,12 +41,12 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.so
-$t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe
 
-readelf --dyn-syms $t/exe > $t/log
-fgrep -q 'foo@ver1' $t/log
-fgrep -q 'bar@ver2' $t/log
-fgrep -q 'baz@ver3' $t/log
+readelf --dyn-syms "$t"/exe > "$t"/log
+fgrep -q 'foo@ver1' "$t"/log
+fgrep -q 'bar@ver2' "$t"/log
+fgrep -q 'baz@ver3' "$t"/log
 
 echo OK

--- a/test/elf/version-script3.sh
+++ b/test/elf/version-script3.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.ver
+cat <<EOF > "$t"/a.ver
 ver1 {
   global: f*o;
   local: *;
@@ -18,13 +18,13 @@ ver2 {
 };
 EOF
 
-cat <<EOF | clang -fuse-ld=$mold -xc -shared -o $t/b.so -Wl,-version-script,$t/a.ver -
+cat <<EOF | clang -fuse-ld="$mold" -xc -shared -o "$t"/b.so -Wl,-version-script,"$t"/a.ver -
 void foo() {}
 void bar() {}
 void baz() {}
 EOF
 
-cat <<EOF | clang -xc -c -o $t/c.o -
+cat <<EOF | clang -xc -c -o "$t"/c.o -
 void foo();
 void bar();
 void baz();
@@ -37,12 +37,12 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.so
-$t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe
 
-readelf --dyn-syms $t/exe > $t/log
-fgrep -q 'foo@ver1' $t/log
-fgrep -q 'bar@ver2' $t/log
-fgrep -q 'baz@ver2' $t/log
+readelf --dyn-syms "$t"/exe > "$t"/log
+fgrep -q 'foo@ver1' "$t"/log
+fgrep -q 'bar@ver2' "$t"/log
+fgrep -q 'baz@ver2' "$t"/log
 
 echo OK

--- a/test/elf/version-script4.sh
+++ b/test/elf/version-script4.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.ver
+cat <<EOF > "$t"/a.ver
 {
   global:
   extern "C++" {
@@ -18,7 +18,7 @@ cat <<EOF > $t/a.ver
 };
 EOF
 
-cat <<EOF | c++ -fPIC -c -o $t/b.o -x c++ -
+cat <<EOF | c++ -fPIC -c -o "$t"/b.o -x c++ -
 int bar = 5;
 namespace foo {
 int bar = 7;
@@ -29,10 +29,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/c.so -Wl,-version-script,$t/a.ver $t/b.o
+clang -fuse-ld="$mold" -shared -o "$t"/c.so -Wl,-version-script,"$t"/a.ver "$t"/b.o
 
-readelf --dyn-syms $t/c.so > $t/log
-fgrep -q _ZN3foo3barE $t/log
-! fgrep -q ' bar' $t/log || false
+readelf --dyn-syms "$t"/c.so > "$t"/log
+fgrep -q _ZN3foo3barE "$t"/log
+! fgrep -q ' bar' "$t"/log || false
 
 echo OK

--- a/test/elf/version-script5.sh
+++ b/test/elf/version-script5.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.ver
+cat <<EOF > "$t"/a.ver
 {
   extern "C" { foo };
   local: *;
 };
 EOF
 
-cat <<EOF | c++ -fPIC -c -o $t/b.o -xc -
+cat <<EOF | c++ -fPIC -c -o "$t"/b.o -xc -
 int foo = 5;
 int main() { return 0; }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/c.so -Wl,-version-script,$t/a.ver $t/b.o
+clang -fuse-ld="$mold" -shared -o "$t"/c.so -Wl,-version-script,"$t"/a.ver "$t"/b.o
 
-readelf --dyn-syms $t/c.so > $t/log
-fgrep -q foo $t/log
-! fgrep -q ' main' $t/log || false
+readelf --dyn-syms "$t"/c.so > "$t"/log
+fgrep -q foo "$t"/log
+! fgrep -q ' main' "$t"/log || false
 
 echo OK

--- a/test/elf/version-script6.sh
+++ b/test/elf/version-script6.sh
@@ -1,43 +1,43 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' > $t/a.ver
+cat <<'EOF' > "$t"/a.ver
 VER_X1 { foo; };
 VER_X2 { bar; };
 EOF
 
-cat <<EOF | c++ -fPIC -c -o $t/b.o -xc -
+cat <<EOF | c++ -fPIC -c -o "$t"/b.o -xc -
 int foo = 5;
 int bar = 6;
 EOF
 
-clang -fuse-ld=$mold -shared -Wl,--version-script=$t/a.ver \
-  -o $t/c.so $t/b.o
+clang -fuse-ld="$mold" -shared -Wl,--version-script="$t"/a.ver \
+  -o "$t"/c.so "$t"/b.o
 
-cat <<'EOF' > $t/d.ver
+cat <<'EOF' > "$t"/d.ver
 VER_Y1 { local; *; };
 VER_Y2 { baz; };
 VER_Y3 { foo; };
 EOF
 
-cat <<EOF | c++ -fPIC -c -o $t/e.o -xc -
+cat <<EOF | c++ -fPIC -c -o "$t"/e.o -xc -
 extern int foo;
 extern int bar;
 int baz() { return foo + bar; }
 EOF
 
-clang -fuse-ld=$mold -shared -Wl,-version-script,$t/d.ver \
-  -o $t/f.so $t/e.o $t/c.so
+clang -fuse-ld="$mold" -shared -Wl,-version-script,"$t"/d.ver \
+  -o "$t"/f.so "$t"/e.o "$t"/c.so
 
-readelf --dyn-syms $t/f.so > $t/log
-grep -q 'foo@VER_X1' $t/log
-grep -q 'bar@VER_X2' $t/log
-grep -q 'baz@@VER_Y2' $t/log
+readelf --dyn-syms "$t"/f.so > "$t"/log
+grep -q 'foo@VER_X1' "$t"/log
+grep -q 'bar@VER_X2' "$t"/log
+grep -q 'baz@@VER_Y2' "$t"/log
 
 echo OK

--- a/test/elf/version-script7.sh
+++ b/test/elf/version-script7.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<'EOF' > $t/a.ver
+cat <<'EOF' > "$t"/a.ver
 VER_X1 { *; };
 EOF
 
-cat <<EOF | c++ -fPIC -c -o $t/b.o -xc -
+cat <<EOF | c++ -fPIC -c -o "$t"/b.o -xc -
 extern int foo;
 int bar() { return foo; }
 EOF
 
-clang -fuse-ld=$mold -shared -Wl,--version-script=$t/a.ver -o $t/c.so $t/b.o
+clang -fuse-ld="$mold" -shared -Wl,--version-script="$t"/a.ver -o "$t"/c.so "$t"/b.o
 
-readelf --dyn-syms $t/c.so > $t/log
-grep -q 'foo$' $t/log
-grep -q 'bar@@VER_X1' $t/log
+readelf --dyn-syms "$t"/c.so > "$t"/log
+grep -q 'foo$' "$t"/log
+grep -q 'bar@@VER_X1' "$t"/log
 
 echo OK

--- a/test/elf/version-script8.sh
+++ b/test/elf/version-script8.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF > $t/a.ver
+cat <<EOF > "$t"/a.ver
 ver1 {
   global: ?oo;
   local: *;
@@ -18,13 +18,13 @@ ver2 {
 };
 EOF
 
-cat <<EOF | clang -fuse-ld=$mold -xc -shared -o $t/b.so -Wl,-version-script,$t/a.ver -
+cat <<EOF | clang -fuse-ld="$mold" -xc -shared -o "$t"/b.so -Wl,-version-script,"$t"/a.ver -
 void foo() {}
 void bar() {}
 void baz() {}
 EOF
 
-cat <<EOF | clang -xc -c -o $t/c.o -
+cat <<EOF | clang -xc -c -o "$t"/c.o -
 void foo();
 void bar();
 
@@ -35,12 +35,12 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.so
-$t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.so
+"$t"/exe
 
-readelf --dyn-syms $t/b.so > $t/log
-fgrep -q 'foo@@ver1' $t/log
-fgrep -q 'bar@@ver2' $t/log
-! fgrep -q 'baz' $t/log || false
+readelf --dyn-syms "$t"/b.so > "$t"/log
+fgrep -q 'foo@@ver1' "$t"/log
+fgrep -q 'bar@@ver2' "$t"/log
+! fgrep -q 'baz' "$t"/log || false
 
 echo OK

--- a/test/elf/version.sh
+++ b/test/elf/version.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-$mold -v | grep -q 'mold .*compatible with GNU ld and GNU gold'
-$mold --version | grep -q 'mold .*compatible with GNU ld and GNU gold'
+"$mold" -v | grep -q 'mold .*compatible with GNU ld and GNU gold'
+"$mold" --version | grep -q 'mold .*compatible with GNU ld and GNU gold'
 
-$mold -V | grep -q 'mold .*compatible with GNU ld and GNU gold'
-$mold -V | grep -q elf_x86_64
-$mold -V | grep -q elf_i386
+"$mold" -V | grep -q 'mold .*compatible with GNU ld and GNU gold'
+"$mold" -V | grep -q elf_x86_64
+"$mold" -V | grep -q elf_i386
 
-cat <<EOF | clang -c -xc -o $t/a.o -
+cat <<EOF | clang -c -xc -o "$t"/a.o -
 #include <stdio.h>
 
 int main() {
@@ -22,11 +22,11 @@ int main() {
 }
 EOF
 
-rm -f $t/exe
-clang -fuse-ld=$mold -Wl,--version -o $t/exe $t/a.o | grep -q mold
-! [ -f $t/exe ] || false
+rm -f "$t"/exe
+clang -fuse-ld="$mold" -Wl,--version -o "$t"/exe "$t"/a.o | grep -q mold
+! [ -f "$t"/exe ] || false
 
-clang -fuse-ld=$mold -Wl,-v -o $t/exe $t/a.o | grep -q mold
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -Wl,-v -o "$t"/exe "$t"/a.o | grep -q mold
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/elf/versioned-undef.sh
+++ b/test/elf/versioned-undef.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if libc is musl because musl does not fully support GNU-style
 # symbol versioning.
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc -
 int foo1() { return 1; }
 int foo2() { return 2; }
 int foo3() { return 3; }
@@ -22,10 +22,10 @@ __asm__(".symver foo2, foo@VER2");
 __asm__(".symver foo3, foo@@VER3");
 EOF
 
-echo 'VER1 { local: *; }; VER2 { local: *; }; VER3 { local: *; };' > $t/b.ver
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o -Wl,--version-script=$t/b.ver
+echo 'VER1 { local: *; }; VER2 { local: *; }; VER3 { local: *; };' > "$t"/b.ver
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o -Wl,--version-script="$t"/b.ver
 
-cat <<EOF | cc -c -o $t/d.o -xc -
+cat <<EOF | cc -c -o "$t"/d.o -xc -
 #include <stdio.h>
 
 int foo1();
@@ -42,7 +42,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/d.o $t/c.so
-$t/exe | grep -q '^1 2 3 3$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/d.o "$t"/c.so
+"$t"/exe | grep -q '^1 2 3 3$'
 
 echo OK

--- a/test/elf/warn-common.sh
+++ b/test/elf/warn-common.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fcommon -c -xc -o $t/a.o -
+cat <<EOF | clang -fcommon -c -xc -o "$t"/a.o -
 int foo;
 EOF
 
-cat <<EOF | clang -fcommon -c -xc -o $t/b.o -
+cat <<EOF | clang -fcommon -c -xc -o "$t"/b.o -
 int foo;
 
 int main() {
@@ -19,10 +19,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o > $t/log
-! fgrep -q 'multiple common symbols' $t/log || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o > "$t"/log
+! fgrep -q 'multiple common symbols' "$t"/log || false
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-warn-common 2> $t/log
-fgrep -q 'multiple common symbols' $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-warn-common 2> "$t"/log
+fgrep -q 'multiple common symbols' "$t"/log
 
 echo OK

--- a/test/elf/warn-unresolved-symbols.sh
+++ b/test/elf/warn-unresolved-symbols.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 int foo();
 int main() {
   foo();
 }
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o 2>&1 \
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o 2>&1 \
   | grep -q 'undefined symbol:.*foo'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o --warn-unresolved-symbols 2>&1 \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o --warn-unresolved-symbols 2>&1 \
   | grep -q 'undefined symbol:.*foo'
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o --warn-unresolved-symbols \
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o --warn-unresolved-symbols \
   --error-unresolved-symbols 2>&1 \
   | grep -q 'undefined symbol:.*foo'
 

--- a/test/elf/weak-export-dso.sh
+++ b/test/elf/weak-export-dso.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 __attribute__((weak)) int foo();
@@ -17,10 +17,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/b.so $t/a.o -shared
-clang -fuse-ld=$mold -o $t/c.so $t/a.o -shared -Wl,-z,defs
+clang -fuse-ld="$mold" -o "$t"/b.so "$t"/a.o -shared
+clang -fuse-ld="$mold" -o "$t"/c.so "$t"/a.o -shared -Wl,-z,defs
 
-readelf --dyn-syms $t/b.so | grep -q 'WEAK   DEFAULT  UND foo'
-readelf --dyn-syms $t/c.so | grep -q 'WEAK   DEFAULT  UND foo'
+readelf --dyn-syms "$t"/b.so | grep -q 'WEAK   DEFAULT  UND foo'
+readelf --dyn-syms "$t"/c.so | grep -q 'WEAK   DEFAULT  UND foo'
 
 echo OK

--- a/test/elf/weak-export-exe.sh
+++ b/test/elf/weak-export-exe.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -fPIC -c -o $t/a.o -xc -
+cat <<EOF | cc -fPIC -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 __attribute__((weak)) int foo();
@@ -17,8 +17,8 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-! readelf --dyn-syms $t/exe | grep -q 'WEAK   DEFAULT  UND foo' || false
-$t/exe | grep -q '^3$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+! readelf --dyn-syms "$t"/exe | grep -q 'WEAK   DEFAULT  UND foo' || false
+"$t"/exe | grep -q '^3$'
 
 echo OK

--- a/test/elf/whole-archive.sh
+++ b/test/elf/whole-archive.sh
@@ -1,42 +1,42 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -x assembler -
+cat <<EOF | cc -o "$t"/a.o -c -x assembler -
   .text
   .globl _start
 _start:
   ret
 EOF
 
-echo 'int fn1() { return 42; }' | cc -o $t/b.o -c -xc -
-echo 'int fn2() { return 42; }' | cc -o $t/c.o -c -xc -
+echo 'int fn1() { return 42; }' | cc -o "$t"/b.o -c -xc -
+echo 'int fn2() { return 42; }' | cc -o "$t"/c.o -c -xc -
 
-rm -f $t/d.a
-ar cr $t/d.a $t/b.o $t/c.o
+rm -f "$t"/d.a
+ar cr "$t"/d.a "$t"/b.o "$t"/c.o
 
-clang -fuse-ld=$mold -nostdlib -o $t/exe $t/a.o $t/d.a
+clang -fuse-ld="$mold" -nostdlib -o "$t"/exe "$t"/a.o "$t"/d.a
 
-readelf --symbols $t/exe > $t/readelf
-! grep -q fn1 $t/readelf || false
-! grep -q fn2 $t/readelf || false
+readelf --symbols "$t"/exe > "$t"/readelf
+! grep -q fn1 "$t"/readelf || false
+! grep -q fn2 "$t"/readelf || false
 
-clang -fuse-ld=$mold -nostdlib -o $t/exe $t/a.o -Wl,--whole-archive $t/d.a
+clang -fuse-ld="$mold" -nostdlib -o "$t"/exe "$t"/a.o -Wl,--whole-archive "$t"/d.a
 
-readelf --symbols $t/exe > $t/readelf
-grep -q fn1 $t/readelf
-grep -q fn2 $t/readelf
+readelf --symbols "$t"/exe > "$t"/readelf
+grep -q fn1 "$t"/readelf
+grep -q fn2 "$t"/readelf
 
-clang -fuse-ld=$mold -nostdlib -o $t/exe $t/a.o -Wl,--whole-archive \
-  -Wl,--no-whole-archive $t/d.a
+clang -fuse-ld="$mold" -nostdlib -o "$t"/exe "$t"/a.o -Wl,--whole-archive \
+  -Wl,--no-whole-archive "$t"/d.a
 
-readelf --symbols $t/exe > $t/readelf
-! grep -q fn1 $t/readelf || false
-! grep -q fn2 $t/readelf || false
+readelf --symbols "$t"/exe > "$t"/readelf
+! grep -q fn1 "$t"/readelf || false
+! grep -q fn2 "$t"/readelf || false
 
 echo OK

--- a/test/elf/wrap.sh
+++ b/test/elf/wrap.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void foo() {
@@ -15,7 +15,7 @@ void foo() {
 }
 EOF
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 void foo();
@@ -29,7 +29,7 @@ int main() {
 }
 EOF
 
-cat <<EOF | clang -c -o $t/c.o -xc -
+cat <<EOF | clang -c -o "$t"/c.o -xc -
 #include <stdio.h>
 
 void __real_foo();
@@ -39,13 +39,13 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '^foo$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '^foo$'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-wrap,foo
-$t/exe | grep -q '^wrap_foo$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-wrap,foo
+"$t"/exe | grep -q '^wrap_foo$'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/c.o -Wl,-wrap,foo
-$t/exe | grep -q '^foo$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/c.o -Wl,-wrap,foo
+"$t"/exe | grep -q '^foo$'
 
 echo OK

--- a/test/elf/z-defs.sh
+++ b/test/elf/z-defs.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -fPIC -c -o $t/a.o -xc -
+cat <<EOF | clang -fPIC -c -o "$t"/a.o -xc -
 void foo();
 void bar() { foo(); }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,nodefs
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,nodefs
 
-! clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,defs \
-  2> $t/log || false
-grep -q 'undefined symbol:.* foo' $t/log
+! clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,defs \
+  2> "$t"/log || false
+grep -q 'undefined symbol:.* foo' "$t"/log
 
-! clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-no-undefined \
-  2> $t/log || false
-grep -q 'undefined symbol:.* foo' $t/log
+! clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-no-undefined \
+  2> "$t"/log || false
+grep -q 'undefined symbol:.* foo' "$t"/log
 
-clang -fuse-ld=$mold -shared -o $t/c.so $t/a.o -Wl,-z,defs \
-  -Wl,--warn-unresolved-symbols 2> $t/log
-grep -q 'undefined symbol: .* foo$' $t/log
-readelf --dyn-syms $t/c.so | grep -q ' foo$'
+clang -fuse-ld="$mold" -shared -o "$t"/c.so "$t"/a.o -Wl,-z,defs \
+  -Wl,--warn-unresolved-symbols 2> "$t"/log
+grep -q 'undefined symbol: .* foo$' "$t"/log
+readelf --dyn-syms "$t"/c.so | grep -q ' foo$'
 
 echo OK

--- a/test/elf/z-max-page-size.sh
+++ b/test/elf/z-max-page-size.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-z,max-page-size=65536
-$t/exe | grep -q 'Hello world'
-readelf -W --segments $t/exe | grep -q 'LOAD.*R   0x10000$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-z,max-page-size=65536
+"$t"/exe | grep -q 'Hello world'
+readelf -W --segments "$t"/exe | grep -q 'LOAD.*R   0x10000$'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-zmax-page-size=$((1024*1024))
-$t/exe | grep -q 'Hello world'
-readelf -W --segments $t/exe | grep -q 'LOAD.*R   0x100000$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-zmax-page-size=$((1024*1024))
+"$t"/exe | grep -q 'Hello world'
+readelf -W --segments "$t"/exe | grep -q 'LOAD.*R   0x100000$'
 
 echo OK

--- a/test/elf/z-nodefaultlib.sh
+++ b/test/elf/z-nodefaultlib.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-z,nodefaultlib
-readelf --dynamic $t/exe | grep -q 'Flags: NODEFLIB'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-z,nodefaultlib
+readelf --dynamic "$t"/exe | grep -q 'Flags: NODEFLIB'
 
 echo OK

--- a/test/elf/z-nodump.sh
+++ b/test/elf/z-nodump.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 void foo() {}
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o
-! readelf --dynamic $t/b.so | grep -Pq 'Flags: NODUMP' || false
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o
+! readelf --dynamic "$t"/b.so | grep -Pq 'Flags: NODUMP' || false
 
-clang -fuse-ld=$mold -shared -o $t/b.so $t/a.o -Wl,-z,nodump
-readelf --dynamic $t/b.so | grep -Pq 'Flags: NODUMP'
+clang -fuse-ld="$mold" -shared -o "$t"/b.so "$t"/a.o -Wl,-z,nodump
+readelf --dynamic "$t"/b.so | grep -Pq 'Flags: NODUMP'
 
 echo OK

--- a/test/elf/z-origin.sh
+++ b/test/elf/z-origin.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 int main() {
@@ -15,9 +15,9 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-z,origin
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-z,origin
 
-readelf --dynamic $t/exe | grep -Pq '\(FLAGS\)\s+ORIGIN'
-readelf --dynamic $t/exe | grep -Pq 'Flags: ORIGIN'
+readelf --dynamic "$t"/exe | grep -Pq '\(FLAGS\)\s+ORIGIN'
+readelf --dynamic "$t"/exe | grep -Pq 'Flags: ORIGIN'
 
 echo OK

--- a/test/elf/z-separate-code.sh
+++ b/test/elf/z-separate-code.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe1 $t/a.o -Wl,-z,separate-loadable-segments
-$t/exe1 | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe1 "$t"/a.o -Wl,-z,separate-loadable-segments
+"$t"/exe1 | grep -q 'Hello world'
 
-clang -fuse-ld=$mold -o $t/exe2 $t/a.o -Wl,-z,separate-code -Wl,-z,norelro
-$t/exe2 | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe2 "$t"/a.o -Wl,-z,separate-code -Wl,-z,norelro
+"$t"/exe2 | grep -q 'Hello world'
 
-clang -fuse-ld=$mold -o $t/exe3 $t/a.o -Wl,-z,noseparate-code -Wl,-z,norelro
-$t/exe3 | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe3 "$t"/a.o -Wl,-z,noseparate-code -Wl,-z,norelro
+"$t"/exe3 | grep -q 'Hello world'
 
-readelf --segments $t/exe3 > $t/log
-! grep 'LOAD .* RW ' $t/log || false
+readelf --segments "$t"/exe3 > "$t"/log
+! grep 'LOAD .* RW ' "$t"/log || false
 
 echo OK

--- a/test/elf/z-text.sh
+++ b/test/elf/z-text.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 # Skip if libc is musl
-echo 'int main() {}' | cc -o $t/exe -xc -
-ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+ldd "$t"/exe | grep -q ld-musl && { echo OK; exit; }
 
 # Skip if target is not x86-64
-[ $(uname -m) = x86_64 ] || { echo skipped; exit; }
+[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
 
-cat <<'EOF' | clang -c -o $t/a.o -x assembler -
+cat <<'EOF' | clang -c -o "$t"/a.o -x assembler -
 .globl fn1
 fn1:
   sub $8, %rsp
@@ -24,7 +24,7 @@ fn1:
   ret
 EOF
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 #include <stdio.h>
 
 int fn1();
@@ -40,10 +40,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -pie -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q 3
+clang -fuse-ld="$mold" -pie -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q 3
 
-readelf --dynamic $t/exe | fgrep -q '(TEXTREL)'
-readelf --dynamic $t/exe | grep -q '\(FLAGS\).*TEXTREL'
+readelf --dynamic "$t"/exe | fgrep -q '(TEXTREL)'
+readelf --dynamic "$t"/exe | grep -q '\(FLAGS\).*TEXTREL'
 
 echo OK

--- a/test/elf/z-unknown.sh
+++ b/test/elf/z-unknown.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/elf/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/elf/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-$mold -z no-such-opt 2>&1 | grep -q 'unknown command line option: -z no-such-opt'
-$mold -zno-such-opt 2>&1 | grep -q 'unknown command line option: -zno-such-opt'
+"$mold" -z no-such-opt 2>&1 | grep -q 'unknown command line option: -z no-such-opt'
+"$mold" -zno-such-opt 2>&1 | grep -q 'unknown command line option: -zno-such-opt'
 
 echo OK

--- a/test/gentoo-test.sh
+++ b/test/gentoo-test.sh
@@ -51,20 +51,20 @@ build() {
   docker="docker run --rm --cap-add=SYS_PTRACE -v `pwd`:/mold -v /var/cache/ccache-gentoo:/ccache mold-gentoo timeout -v -k 15s 1h"
   dir=gentoo/$git_hash
 
-  mkdir -p $dir/success $dir/failure
+  mkdir -p "$dir"/success "$dir"/failure
 
-  $docker nice -n 19 bash -c "$cmd1 && $cmd2 && $cmd3" >& $dir/$filename.mold
+  $docker nice -n 19 bash -c "$cmd1 && $cmd2 && $cmd3" >& "$dir"/"$filename".mold
   if [ $? = 0 ]; then
-    mv $dir/$filename.mold $dir/success
+    mv "$dir"/"$filename".mold "$dir"/success
   else
-    mv $dir/$filename.mold $dir/failure
+    mv "$dir"/"$filename".mold "$dir"/failure
   fi
 
-  $docker nice -n 19 bash -c "$cmd2 && $cmd3" >& $dir/$filename.ld
+  $docker nice -n 19 bash -c "$cmd2 && $cmd3" >& "$dir"/"$filename".ld
   if [ $? = 0 ]; then
-    mv $dir/$filename.ld $dir/success
+    mv "$dir"/"$filename".ld "$dir"/success
   else
-    mv $dir/$filename.ld $dir/failure
+    mv "$dir"/"$filename".ld "$dir"/failure
   fi
 }
 

--- a/test/macho/Z.sh
+++ b/test/macho/Z.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-Z > $t/log 2>&1
-grep -q 'library not found: -lSystem' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-Z > "$t"/log 2>&1
+grep -q 'library not found: -lSystem' "$t"/log
 
 echo OK

--- a/test/macho/adhoc-codesign.sh
+++ b/test/macho/adhoc-codesign.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/exe -xc - -Wl,-adhoc_codesign
+cat <<EOF | cc -o "$t"/exe -xc - -Wl,-adhoc_codesign
 #include <stdio.h>
 
 int main() {
@@ -15,6 +15,6 @@ int main() {
 }
 EOF
 
-$t/exe | fgrep -q 'Hello world'
+"$t"/exe | fgrep -q 'Hello world'
 
 echo OK

--- a/test/macho/archive.sh
+++ b/test/macho/archive.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang -c -o $t/a.o -xc -
+cat <<EOF | clang -c -o "$t"/a.o -xc -
 #include <stdio.h>
 
 void hello() {
@@ -15,14 +15,14 @@ void hello() {
 }
 EOF
 
-cat <<EOF | clang -c -o $t/b.o -xc -
+cat <<EOF | clang -c -o "$t"/b.o -xc -
 void foo() {}
 EOF
 
-rm -f $t/c.a
-ar rcs $t/c.a $t/a.o $t/b.o
+rm -f "$t"/c.a
+ar rcs "$t"/c.a "$t"/a.o "$t"/b.o
 
-cat <<EOF | clang -c -o $t/d.o -xc -
+cat <<EOF | clang -c -o "$t"/d.o -xc -
 void hello();
 
 int main() {
@@ -30,10 +30,10 @@ int main() {
 }
 EOF
 
-clang++ -fuse-ld=$mold -o $t/exe $t/d.o $t/c.a
-$t/exe | grep -q 'Hello world'
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/d.o "$t"/c.a
+"$t"/exe | grep -q 'Hello world'
 
-otool -tv $t/exe | grep -q '^_hello:'
-! otool -tv $t/exe | grep -q '^_foo:' || false
+otool -tv "$t"/exe | grep -q '^_hello:'
+! otool -tv "$t"/exe | grep -q '^_foo:' || false
 
 echo OK

--- a/test/macho/baserel.sh
+++ b/test/macho/baserel.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 char msg[] = "Hello world\n";
@@ -18,7 +18,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/basic.sh
+++ b/test/macho/basic.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {
   return 0;
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-codesign -s- $t/exe
-$t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+codesign -s- "$t"/exe
+"$t"/exe
 
 echo OK

--- a/test/macho/bss.sh
+++ b/test/macho/bss.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 static int foo[100];
@@ -18,7 +18,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q '^0 5 '
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q '^0 5 '
 
 echo OK

--- a/test/macho/bundle.sh
+++ b/test/macho/bundle.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/bundle $t/a.o -Wl,-bundle
-file $t/exe | grep -qi bundle
+clang -fuse-ld="$mold" -o "$t"/bundle "$t"/a.o -Wl,-bundle
+file "$t"/exe | grep -qi bundle
 
 echo OK

--- a/test/macho/common-alignment.sh
+++ b/test/macho/common-alignment.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -fcommon -c -xc -
+cat <<EOF | cc -o "$t"/a.o -fcommon -c -xc -
 int foo;
 __attribute__((aligned(4096))) int bar;
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 #include <stdio.h>
 #include <stdint.h>
 
@@ -24,7 +24,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q '^0 0$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q '^0 0$'
 
 echo OK

--- a/test/macho/common.sh
+++ b/test/macho/common.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -fcommon -c -xc -
+cat <<EOF | cc -o "$t"/a.o -fcommon -c -xc -
 int foo;
 int bar;
 EOF
 
-cat <<EOF | cc -o $t/b.o -fcommon -c -xc -
+cat <<EOF | cc -o "$t"/b.o -fcommon -c -xc -
 int foo;
 int bar = 5;
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 #include <stdio.h>
 
 extern int foo;
@@ -29,7 +29,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o $t/c.o
-$t/exe | grep -q '^0 5 0$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o "$t"/c.o
+"$t"/exe | grep -q '^0 5 0$'
 
 echo OK

--- a/test/macho/dead-strip-dylibs.sh
+++ b/test/macho/dead-strip-dylibs.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/libfoo.dylib -shared -xc -
+cat <<EOF | cc -o "$t"/libfoo.dylib -shared -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -L$t -Wl,-lfoo
-otool -l $t/exe | grep -A3 LOAD_DY | grep -q libfoo.dylib
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -L"$t" -Wl,-lfoo
+otool -l "$t"/exe | grep -A3 LOAD_DY | grep -q libfoo.dylib
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -L$t -Wl,-lfoo -Wl,-dead_strip_dylibs
-otool -l $t/exe | grep -A3 LOAD_DY > $t/log
-! grep -q libfoo.dylib $t/log || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -L"$t" -Wl,-lfoo -Wl,-dead_strip_dylibs
+otool -l "$t"/exe | grep -A3 LOAD_DY > "$t"/log
+! grep -q libfoo.dylib "$t"/log || false
 
 echo OK

--- a/test/macho/dead-strip-dylibs2.sh
+++ b/test/macho/dead-strip-dylibs2.sh
@@ -1,36 +1,36 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-mkdir -p $t/Foo.framework
+mkdir -p "$t"/Foo.framework
 
-cat <<EOF | cc -o $t/Foo.framework/Foo -shared -xc -
+cat <<EOF | cc -o "$t"/Foo.framework/Foo -shared -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-cd $t
+cd "$t"
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-F. -Wl,-framework,Foo
-otool -l $t/exe | grep -A3 'cmd LC_LOAD_DYLIB' | fgrep -q Foo.framework/Foo
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-F. -Wl,-framework,Foo
+otool -l "$t"/exe | grep -A3 'cmd LC_LOAD_DYLIB' | fgrep -q Foo.framework/Foo
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-F. -Wl,-framework,Foo \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-F. -Wl,-framework,Foo \
   -Wl,-dead_strip_dylibs
-otool -l $t/exe | grep -A3 'cmd LC_LOAD_DYLIB' >& $t/log
-! fgrep -q Foo.framework/Foo $t/log || false
+otool -l "$t"/exe | grep -A3 'cmd LC_LOAD_DYLIB' >& "$t"/log
+! fgrep -q Foo.framework/Foo "$t"/log || false
 
 echo OK

--- a/test/macho/dead-strip.sh
+++ b/test/macho/dead-strip.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 char msg1[] = "Hello world";
@@ -26,10 +26,10 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-dead_strip
-$t/exe | grep -q 'Hello world'
-otool -tVj $t/exe > $t/log
-grep -q 'hello:' $t/log
-! grep -q 'howdy:' $t/log || false
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-dead_strip
+"$t"/exe | grep -q 'Hello world'
+otool -tVj "$t"/exe > "$t"/log
+grep -q 'hello:' "$t"/log
+! grep -q 'howdy:' "$t"/log || false
 
 echo OK

--- a/test/macho/dump.sh
+++ b/test/macho/dump.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo 'int main() {}' | cc -o $t/exe -xc -
-$mold -dump $t/exe > $t/log
+echo 'int main() {}' | cc -o "$t"/exe -xc -
+"$mold" -dump "$t"/exe > "$t"/log
 
-grep -q 'magic: 0xfeedfacf' $t/log
-grep -q 'segname: __PAGEZERO' $t/log
+grep -q 'magic: 0xfeedfacf' "$t"/log
+grep -q 'segname: __PAGEZERO' "$t"/log
 
 echo OK

--- a/test/macho/duplicate-error.sh
+++ b/test/macho/duplicate-error.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void hello() {}
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 void hello() {}
 int main() {}
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o 2> $t/log || false
-grep -q 'duplicate symbol: .*/b.o: .*/a.o: _hello' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o 2> "$t"/log || false
+grep -q 'duplicate symbol: .*/b.o: .*/a.o: _hello' "$t"/log
 
 echo OK

--- a/test/macho/dylib.sh
+++ b/test/macho/dylib.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -c -o $t/a.o -xc -
+cat <<EOF | cc -c -o "$t"/a.o -xc -
 #include <stdio.h>
 char world[] = "world";
 
@@ -16,9 +16,9 @@ char *hello() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/b.dylib -shared $t/a.o
+clang -fuse-ld="$mold" -o "$t"/b.dylib -shared "$t"/a.o
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 #include <stdio.h>
 
 char *hello();
@@ -29,7 +29,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o $t/b.dylib
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o "$t"/b.dylib
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/entry.sh
+++ b/test/macho/entry.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int hello() {
@@ -16,10 +16,10 @@ int hello() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-e,_hello
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-e,_hello
+"$t"/exe | grep -q 'Hello world'
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-e,no_such_symbol 2> $t/log || false
-grep -q 'undefined entry point symbol: no_such_symbol' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-e,no_such_symbol 2> "$t"/log || false
+grep -q 'undefined entry point symbol: no_such_symbol' "$t"/log
 
 echo OK

--- a/test/macho/exception.sh
+++ b/test/macho/exception.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | clang++ -c -o $t/a.o -xc++ -
+cat <<EOF | clang++ -c -o "$t"/a.o -xc++ -
 int main() {
   try {
     throw 0;
@@ -18,7 +18,7 @@ int main() {
 }
 EOF
 
-clang++ -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe
+clang++ -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe
 
 echo OK

--- a/test/macho/filepath.sh
+++ b/test/macho/filepath.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() { printf("Hello world\n"); }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 void hello();
 int main() { hello(); }
 EOF
 
-cat <<EOF > $t/filelist
+cat <<EOF > "$t"/filelist
 $t/a.o
 $t/b.o
 EOF
 
-clang -fuse-ld=$mold -o $t/exe -Wl,-filelist,$t/filelist
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe -Wl,-filelist,"$t"/filelist
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/filepath2.sh
+++ b/test/macho/filepath2.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() { printf("Hello world\n"); }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 void hello();
 int main() { hello(); }
 EOF
 
-cat <<EOF > $t/filelist
+cat <<EOF > "$t"/filelist
 a.o
 b.o
 EOF
 
-clang -fuse-ld=$mold -o $t/exe -Xlinker -filelist -Xlinker $t/filelist,$t
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe -Xlinker -filelist -Xlinker "$t"/filelist,"$t"
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/framework.sh
+++ b/test/macho/framework.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-mkdir -p $t/Foo.framework
+mkdir -p "$t"/Foo.framework
 
-cat <<EOF | cc -o $t/Foo.framework/Foo -shared -xc -
+cat <<EOF | cc -o "$t"/Foo.framework/Foo -shared -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 void hello();
 int main() {
   hello();
 }
 EOF
 
-cd $t
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-F. -Wl,-framework,Foo
-$t/exe | grep -q 'Hello world'
+cd "$t"
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-F. -Wl,-framework,Foo
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/headerpad-max-install-names.sh
+++ b/test/macho/headerpad-max-install-names.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-headerpad_max_install_names
-otool -l $t/exe | grep -A5 'sectname __text' | grep -q 'addr 0x0000000100000978'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-headerpad_max_install_names
+otool -l "$t"/exe | grep -A5 'sectname __text' | grep -q 'addr 0x0000000100000978'
 
 echo OK

--- a/test/macho/headerpad.sh
+++ b/test/macho/headerpad.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 [ "`uname -p`" = arm ] && { echo skipped; exit; }
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-headerpad,0
-otool -l $t/exe | grep -A5 'sectname __text' | grep -q 'addr 0x0000000100000570'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-headerpad,0
+otool -l "$t"/exe | grep -A5 'sectname __text' | grep -q 'addr 0x0000000100000570'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-headerpad,0x10000
-otool -l $t/exe | grep -A5 'sectname __text' | grep -q 'addr 0x0000000100010570'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-headerpad,0x10000
+otool -l "$t"/exe | grep -A5 'sectname __text' | grep -q 'addr 0x0000000100010570'
 
 echo OK

--- a/test/macho/hello.sh
+++ b/test/macho/hello.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 void hello();
 int main() {
   hello();
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/hello2.sh
+++ b/test/macho/hello2.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,7 +16,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/hello3.sh
+++ b/test/macho/hello3.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -16,7 +16,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/hello4.sh
+++ b/test/macho/hello4.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 
 int main() {
@@ -17,8 +17,8 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
-$t/exe 2> /dev/null | grep -q 'Hello world'
-$t/exe 2>&1 > /dev/null | grep -q 'Hello stderr'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
+"$t"/exe 2> /dev/null | grep -q 'Hello world'
+"$t"/exe 2>&1 > /dev/null | grep -q 'Hello stderr'
 
 echo OK

--- a/test/macho/hello5.sh
+++ b/test/macho/hello5.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 char msg[] = "Hello world\n";
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 #include <stdio.h>
 
 extern char msg[];
@@ -21,7 +21,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK

--- a/test/macho/lib1.sh
+++ b/test/macho/lib1.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/libfoo.dylib -shared -xc -
+cat <<EOF | cc -o "$t"/libfoo.dylib -shared -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -L$t -lfoo
-$t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -L"$t" -lfoo
+"$t"/exe
 
 echo OK

--- a/test/macho/map.sh
+++ b/test/macho/map.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 void hello();
 int main() {
   hello();
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o -Wl,-map,$t/map
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o -Wl,-map,"$t"/map
 
-grep -Eq '^\[  0\] .*/a.o$' $t/map
-grep -Eq '^\[  1\] .*/b.o$' $t/map
-grep -Eq '^0x[0-9A-Fa-f]+     0x[0-9A-Fa-f]+      __TEXT  __text$' $t/map
-grep -Eq '^0x[0-9A-Fa-f]+     0x[0-9A-Fa-f]+      \[  0\] _hello$' $t/map
-grep -Eq '^0x[0-9A-Fa-f]+     0x[0-9A-Fa-f]+      \[  1\] _main$' $t/map
+grep -Eq '^\[  0\] .*/a.o$' "$t"/map
+grep -Eq '^\[  1\] .*/b.o$' "$t"/map
+grep -Eq '^0x[0-9A-Fa-f]+     0x[0-9A-Fa-f]+      __TEXT  __text$' "$t"/map
+grep -Eq '^0x[0-9A-Fa-f]+     0x[0-9A-Fa-f]+      \[  0\] _hello$' "$t"/map
+grep -Eq '^0x[0-9A-Fa-f]+     0x[0-9A-Fa-f]+      \[  1\] _main$' "$t"/map
 
 echo OK

--- a/test/macho/missing-error.sh
+++ b/test/macho/missing-error.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int foo();
 
 int main() {
@@ -15,7 +15,7 @@ int main() {
 }
 EOF
 
-! clang -fuse-ld=$mold -o $t/exe $t/a.o 2> $t/log || false
-grep -q 'undefined symbol: .*\.o: _foo' $t/log
+! clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o 2> "$t"/log || false
+grep -q 'undefined symbol: .*\.o: _foo' "$t"/log
 
 echo OK

--- a/test/macho/needed-framework.sh
+++ b/test/macho/needed-framework.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-mkdir -p $t/Foo.framework
+mkdir -p "$t"/Foo.framework
 
-cat <<EOF | cc -o $t/Foo.framework/Foo -shared -xc -
+cat <<EOF | cc -o "$t"/Foo.framework/Foo -shared -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-cd $t
+cd "$t"
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-F. -Wl,-needed_framework,Foo \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-F. -Wl,-needed_framework,Foo \
   -Wl,-dead_strip_dylibs
-otool -l $t/exe | grep -A3 'cmd LC_LOAD_DYLIB' | fgrep -q Foo.framework/Foo
+otool -l "$t"/exe | grep -A3 'cmd LC_LOAD_DYLIB' | fgrep -q Foo.framework/Foo
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-F. -Wl,-framework,Foo \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-F. -Wl,-framework,Foo \
   -Wl,-dead_strip_dylibs
-otool -l $t/exe | grep -A3 'cmd LC_LOAD_DYLIB' >& $t/log
-! fgrep -q Foo.framework/Foo $t/log || false
+otool -l "$t"/exe | grep -A3 'cmd LC_LOAD_DYLIB' >& "$t"/log
+! fgrep -q Foo.framework/Foo "$t"/log || false
 
 echo OK

--- a/test/macho/needed-l.sh
+++ b/test/macho/needed-l.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/libfoo.dylib -shared -xc -
+cat <<EOF | cc -o "$t"/libfoo.dylib -shared -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -L$t -Wl,-needed-lfoo
-$t/exe
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -L"$t" -Wl,-needed-lfoo
+"$t"/exe
 
-otool -l $t/exe | grep -A3 LOAD_DY | grep -q libfoo.dylib
+otool -l "$t"/exe | grep -A3 LOAD_DY | grep -q libfoo.dylib
 
 echo OK

--- a/test/macho/objc.sh
+++ b/test/macho/objc.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xobjective-c -
+cat <<EOF | cc -o "$t"/a.o -c -xobjective-c -
 #import <Foundation/NSObject.h>
 @interface MyClass : NSObject
 @end
@@ -15,16 +15,16 @@ cat <<EOF | cc -o $t/a.o -c -xobjective-c -
 @end
 EOF
 
-ar rcs $t/b.a $t/a.o
+ar rcs "$t"/b.a "$t"/a.o
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 int main() {}
 EOF
 
-clang -o $t/exe $t/c.o $t/b.a
-! nm $t/exe | grep -q _OBJC_CLASS_ || false
+clang -o "$t"/exe "$t"/c.o "$t"/b.a
+! nm "$t"/exe | grep -q _OBJC_CLASS_ || false
 
-! clang -o $t/exe $t/c.o $t/b.a -Wl,-ObjC > $t/log 2>&1
-grep -q _OBJC_CLASS_ $t/log
+! clang -o "$t"/exe "$t"/c.o "$t"/b.a -Wl,-ObjC > "$t"/log 2>&1
+grep -q _OBJC_CLASS_ "$t"/log
 
 echo OK

--- a/test/macho/pagezero-size.sh
+++ b/test/macho/pagezero-size.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
 [ "`uname -p`" = arm ] && { echo skipped; exit; }
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 int main() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o
 
-otool -l $t/exe | grep -A5 'segname __PAGEZERO' | \
+otool -l "$t"/exe | grep -A5 'segname __PAGEZERO' | \
   grep -q 'vmsize 0x0000000100000000'
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-pagezero_size,0x10000
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-pagezero_size,0x10000
+"$t"/exe | grep -q 'Hello world'
 
-otool -l $t/exe | grep -A5 'segname __PAGEZERO' | \
+otool -l "$t"/exe | grep -A5 'segname __PAGEZERO' | \
   grep -q 'vmsize 0x0000000000010000'
 
 echo OK

--- a/test/macho/pagezero-size2.sh
+++ b/test/macho/pagezero-size2.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-! clang -fuse-ld=$mold -shared -o $t/b.dylib $t/a.o -Wl,-pagezero_size,0x1000 >& $t/log
-fgrep -q ' -pagezero_size option can only be used when linking a main executable' $t/log
+! clang -fuse-ld="$mold" -shared -o "$t"/b.dylib "$t"/a.o -Wl,-pagezero_size,0x1000 >& "$t"/log
+fgrep -q ' -pagezero_size option can only be used when linking a main executable' "$t"/log
 
 echo OK

--- a/test/macho/pagezero-size3.sh
+++ b/test/macho/pagezero-size3.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-clang -fuse-ld=$mold -shared -o $t/b.dylib $t/a.o
-otool -l $t/b.dylib > $t/log
-! grep -q 'segname: __PAGEZERO' $t/log || false
+clang -fuse-ld="$mold" -shared -o "$t"/b.dylib "$t"/a.o
+otool -l "$t"/b.dylib > "$t"/log
+! grep -q 'segname: __PAGEZERO' "$t"/log || false
 
 echo OK

--- a/test/macho/platform-version.sh
+++ b/test/macho/platform-version.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-platform_version,macos,13.5,12.0
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-platform_version,macos,13.5,12.0
 
-otool -l $t/exe > $t/log
-fgrep -q 'minos 13.5' $t/log
-fgrep -q 'sdk 12.0' $t/log
+otool -l "$t"/exe > "$t"/log
+fgrep -q 'minos 13.5' "$t"/log
+fgrep -q 'sdk 12.0' "$t"/log
 
 echo OK

--- a/test/macho/response-file.sh
+++ b/test/macho/response-file.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-echo ' -help' > $t/rsp
-$mold @$t/rsp | grep -q Usage
+echo ' -help' > "$t"/rsp
+"$mold" @"$t"/rsp | grep -q Usage
 
 echo OK

--- a/test/macho/rpath.sh
+++ b/test/macho/rpath.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 int main() {}
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o -Wl,-rpath,foo -Wl,-rpath,@bar
-otool -l $t/exe > $t/log
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o -Wl,-rpath,foo -Wl,-rpath,@bar
+otool -l "$t"/exe > "$t"/log
 
-grep -A3 'cmd LC_RPATH' $t/log | grep -q 'path foo'
-grep -A3 'cmd LC_RPATH' $t/log | grep -q 'path @bar'
+grep -A3 'cmd LC_RPATH' "$t"/log | grep -q 'path foo'
+grep -A3 'cmd LC_RPATH' "$t"/log | grep -q 'path @bar'
 
 echo OK

--- a/test/macho/search-paths-first.sh
+++ b/test/macho/search-paths-first.sh
@@ -1,43 +1,43 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void say() {
   printf("Hello\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 #include <stdio.h>
 void say() {
   printf("Howdy\n");
 }
 EOF
 
-cat <<EOF | cc -o $t/c.o -c -xc -
+cat <<EOF | cc -o "$t"/c.o -c -xc -
 void say();
 int main() {
   say();
 }
 EOF
 
-mkdir -p $t/x $t/y
+mkdir -p "$t"/x "$t"/y
 
-ar rcs $t/x/libfoo.a $t/a.o
-cc -shared -o $t/y/libfoo.dylib $t/b.o
+ar rcs "$t"/x/libfoo.a "$t"/a.o
+cc -shared -o "$t"/y/libfoo.dylib "$t"/b.o
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,-L$t/x -Wl,-L$t/y -lfoo
-$t/exe | grep -q Hello
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,-L"$t"/x -Wl,-L"$t"/y -lfoo
+"$t"/exe | grep -q Hello
 
-clang -fuse-ld=$mold -o $t/exe $t/c.o -Wl,-L$t/x -Wl,-L$t/y -lfoo \
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/c.o -Wl,-L"$t"/x -Wl,-L"$t"/y -lfoo \
  -Wl,-search_paths_first
-$t/exe | grep -q Hello
+"$t"/exe | grep -q Hello
 
 echo OK

--- a/test/macho/tls.sh
+++ b/test/macho/tls.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -shared -o $t/a.dylib -xc -
+cat <<EOF | cc -shared -o "$t"/a.dylib -xc -
 _Thread_local int a;
 EOF
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 #include <stdio.h>
 
 extern _Thread_local int a;
@@ -21,7 +21,7 @@ int main() {
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.dylib $t/b.o
-$t/exe | grep -q '^0$'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.dylib "$t"/b.o
+"$t"/exe | grep -q '^0$'
 
 echo OK

--- a/test/macho/universal.sh
+++ b/test/macho/universal.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 export LANG=
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 mold=`pwd`/../../ld64.mold
-echo -n "Testing $(basename -s .sh $0) ... "
-t=$(pwd)/../../out/test/macho/$(basename -s .sh $0)
-mkdir -p $t
+echo -n "Testing $(basename -s .sh "$0") ... "
+t=$(pwd)/../../out/test/macho/$(basename -s .sh "$0")
+mkdir -p "$t"
 
-cat <<EOF | cc -o $t/a.o -c -xc -
+cat <<EOF | cc -o "$t"/a.o -c -xc -
 #include <stdio.h>
 void hello() {
   printf("Hello world\n");
 }
 EOF
 
-lipo $t/a.o -create -output $t/fat.o
+lipo "$t"/a.o -create -output "$t"/fat.o
 
-cat <<EOF | cc -o $t/b.o -c -xc -
+cat <<EOF | cc -o "$t"/b.o -c -xc -
 void hello();
 int main() {
   hello();
 }
 EOF
 
-clang -fuse-ld=$mold -o $t/exe $t/a.o $t/b.o
-$t/exe | grep -q 'Hello world'
+clang -fuse-ld="$mold" -o "$t"/exe "$t"/a.o "$t"/b.o
+"$t"/exe | grep -q 'Hello world'
 
 echo OK


### PR DESCRIPTION
This makes it possible to build and test mold in a path that contains
whitespace characters - with the notable exception of the tests where
`LD_PRELOAD` is used. That's because `LD_PRELOAD` unconditionally treats
any whitespace as separator, regardless of quoting.

The following ShellCheck warnings are eliminated by this commit:
* SC2046: Quote this to prevent word splitting.
* SC2086: Double quote to prevent globbing and word splitting.

Signed-off-by: Christoph Erhardt <github@sicherha.de>