### PR TITLE
Fix skip check in i386-mergable-strings.sh

### DIFF
--- a/test/elf/i386-mergeable-strings.sh
+++ b/test/elf/i386-mergeable-strings.sh
@@ -8,7 +8,8 @@ mold="$(pwd)/mold"
 t="$(pwd)/out/test/elf/$testname"
 mkdir -p "$t"
 
-[ "$(uname -m)" = x86_64 ] || { echo skipped; exit; }
+echo 'int main() {}' | cc -m32 -o "$t"/exe -xc - >& /dev/null \
+  || { echo skipped; exit; }
 
 cat <<'EOF' | cc -o "$t"/a.o -c -x assembler -m32 -
   .text


### PR DESCRIPTION
Check for the ability to build 32-bit binaries like in the other i386
test cases.