### PR TITLE
[Mach-O] Fatal if no input files are given

### DIFF
--- a/macho/main.cc
+++ b/macho/main.cc
@@ -350,6 +350,9 @@ static void read_input_files(Context<E> &ctx, std::span<std::string> args) {
       args = args.subspan(1);
     }
   }
+
+  if (ctx.objs.empty())
+    Fatal(ctx) << "no input files";
 }
 
 template <typename E>


### PR DESCRIPTION
Follow the same behavior in the ELF version of read_input_files and
fatal in case no input files are given. This avoids a segfault in
successive functions when running `./ld64.mold` without any arguments.