### PR TITLE
Fix building on Android again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 USE_MIMALLOC = 1
 ifeq ($(OS), Darwin)
   USE_MIMALLOC = 0
-else ifneq (, $(findstring android, $(shell uname -r)))
+else ifneq (, $(findstring Android, $(shell uname -a)))
   USE_MIMALLOC = 0
 else ifeq ($(ASAN), 1)
   USE_MIMALLOC = 0


### PR DESCRIPTION
The commit 946e0c3 undid the fix from pull request #204.
There's now segmentation fault when using mold.
Since macOS's uname doesn't support the `-o` option, the better option is `-a` and not `-r`.
I'm using Termux and this change works.