### PR TITLE
Compatibility for libc++ < 14, plus two additional fixes 

### DIFF
--- a/elf/subprocess.cc
+++ b/elf/subprocess.cc
@@ -300,6 +300,7 @@ void process_run_subcommand(Context<E> &ctx, int argc, char **argv) {
     std::vector<char *> args;
     args.push_back(argv[0]);
     args.insert(args.end(), argv + 3, argv + argc);
+    args.push_back(nullptr);
     execv(self.c_str(), args.data());
     Fatal(ctx) << "mold -run failed: " << self << ": " << errno_string();
   }

--- a/main.cc
+++ b/main.cc
@@ -8,8 +8,15 @@ namespace mold {
 
 std::string_view errno_string() {
   static thread_local char buf[200];
-  strerror_r(errno, buf, sizeof(buf));
-  return buf;
+#if _GNU_SOURCE
+  // The GNU version of strerror_r() returns a char * and may completely ignore
+  // buf
+  return strerror_r(errno, buf, sizeof(buf));
+#else
+  // The POSIX.1-2001-compliant version of strerror_r() returns an int and
+  // writes the string into buf
+  return !strerror_r(errno, buf, sizeof(buf)) ? buf : "Unknown error";
+#endif
 }
 
 #ifdef GIT_HASH

--- a/mold.h
+++ b/mold.h
@@ -434,12 +434,7 @@ private:
 
 template <typename T>
 std::filesystem::path filepath(const T &path) {
-#if __APPLE__
-  // Xcode 13.1 does not seem to define `generic_format`.
-  return {path};
-#else
-  return {path, std::filesystem::path::generic_format};
-#endif
+  return {path, std::filesystem::path::format::generic_format};
 }
 
 std::string get_realpath(std::string_view path);


### PR DESCRIPTION
* Improve Xcode 13.1 workaround (caused by a libc++ bug)
* Fix `errno_string()` returning an empty string on GNU
* Terminate `argv` array with `nullptr`