### PR TITLE
Fix build error on riscv64 (#222)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 STRIP ?= strip
 
 OS ?= $(shell uname -s)
+ARCH ?= $(shell uname -m)
 
 # Used for both C and C++
 COMMON_FLAGS = -pthread -fPIE -fno-unwind-tables -fno-asynchronous-unwind-tables
@@ -112,6 +113,13 @@ endif
 
 ifneq ($(OS), Darwin)
   LIBS += -lcrypto
+endif
+
+# '-latomic' flag is needed building on riscv64 system
+# RV32 system doesn't tested yet
+# seems like '-atomic' would be better but not working.
+ifeq ($(ARCH), riscv64)
+  LIBS += -latomic
 endif
 
 all: mold mold-wrapper.so

--- a/third-party/tbb/src/tbb/tools_api/ittnotify_config.h
+++ b/third-party/tbb/src/tbb/tools_api/ittnotify_config.h
@@ -147,6 +147,10 @@
 #  define ITT_ARCH_IA32E 2
 #endif /* ITT_ARCH_IA32E */
 
+#ifndef ITT_ARCH_IA64
+#  define ITT_ARCH_IA64 3
+#endif /* ITT_ARCH_IA64 */
+
 #ifndef ITT_ARCH_ARM
 #  define ITT_ARCH_ARM  4
 #endif /* ITT_ARCH_ARM */


### PR DESCRIPTION
Patch from this PR: https://github.com/oneapi-src/oneTBB/pull/550
Thank you, @felixonmars

Build works with this patch, but does not support elf64lriscv. So, test fails.

Fix: #222 