### PR TITLE
Use pkg-config to know where libcrypto resides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,9 @@ ifeq ($(OS), Linux)
   LIBS += -lrt
 endif
 
+# Use pkg-config to know where libcrypto resides.
 ifneq ($(OS), Darwin)
-  LIBS += -lcrypto
+  LIBS += $(shell pkg-config --libs-only-L openssl) -lcrypto
 endif
 
 all: mold mold-wrapper.so


### PR DESCRIPTION
Let Makefile know how to link libcrypto in a directory other than the default
directories by using pkg-config. If you don't have pkg-config, then $(shell)
returns empty.

Signed-off-by: Hiroshi Takekawa <sian.ht@gmail.com>