### PR TITLE
Use pkg-config to know where openssl header files reside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ endif
 
 # Use pkg-config to know where libcrypto resides.
 ifneq ($(OS), Darwin)
+  CPPFLAGS += $(shell pkg-config --cflags-only-I openssl)
   LIBS += $(shell pkg-config --libs-only-L openssl) -lcrypto
 endif
 


### PR DESCRIPTION
Let Makefile know how to locate openssl header files in a directory other than
the default directories by using pkg-config. If you don't have pkg-config, then
$(shell) returns empty.

Signed-off-by: Hiroshi Takekawa <sian.ht@gmail.com>