### PR TITLE
Allow overriding the default target architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,14 @@ ifeq ($(LTO), 1)
   LDFLAGS  += -flto
 endif
 
+# Allow overriding the default ELF emulation and the default Mach-O architecture
+ifdef DEFAULT_ELF_EMULATION
+  CPPFLAGS += -DDEFAULT_ELF_EMULATION=$(DEFAULT_ELF_EMULATION)
+endif
+ifdef DEFAULT_MACHO_ARCH
+  CPPFLAGS += -DDEFAULT_MACHO_ARCH=$(DEFAULT_MACHO_ARCH)
+endif
+
 # By default, we want to use mimalloc as a memory allocator. mimalloc
 # is disabled when ASAN or TSAN is on, as they are not compatible.
 # It's also disabled on macOS and Android because it didn't work on

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -346,6 +346,8 @@ static int elf_main(int argc, char **argv) {
     switch (ctx.arg.emulation) {
     case EM_386:
       return elf_main<I386>(argc, argv);
+    case EM_X86_64:
+      return elf_main<X86_64>(argc, argv);
     case EM_AARCH64:
       return elf_main<ARM64>(argc, argv);
     }

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -29,6 +29,10 @@
 #include <vector>
 #include <xxh3.h>
 
+#ifndef DEFAULT_ELF_EMULATION
+#  define DEFAULT_ELF_EMULATION EM_X86_64
+#endif
+
 template<>
 class tbb::tbb_hash_compare<std::string_view> {
 public:
@@ -1264,7 +1268,7 @@ struct Context {
     bool z_relro = true;
     bool z_text = false;
     u16 default_version = VER_NDX_GLOBAL;
-    i64 emulation = EM_X86_64;
+    i64 emulation = DEFAULT_ELF_EMULATION;
     i64 filler = -1;
     i64 spare_dynamic_tags = 5;
     i64 thread_count = 0;

--- a/macho/main.cc
+++ b/macho/main.cc
@@ -373,8 +373,12 @@ static int do_main(int argc, char **argv) {
   parse_nonpositional_args(ctx, file_args);
 
   if (ctx.arg.arch != E::cputype) {
-    if (ctx.arg.arch == CPU_TYPE_X86_64)
+    switch (ctx.arg.arch) {
+    case CPU_TYPE_X86_64:
       return do_main<X86_64>(argc, argv);
+    case CPU_TYPE_ARM64:
+      return do_main<ARM64>(argc, argv);
+    }
   }
 
   read_input_files(ctx, file_args);

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -11,6 +11,10 @@
 #include <unordered_map>
 #include <variant>
 
+#ifndef DEFAULT_MACHO_ARCH
+#  define DEFAULT_MACHO_ARCH CPU_TYPE_ARM64
+#endif
+
 namespace mold::macho {
 
 static constexpr i64 COMMON_PAGE_SIZE = 0x4000;
@@ -775,7 +779,7 @@ struct Context {
     bool dynamic = true;
     bool fatal_warnings = false;
     bool trace = false;
-    i64 arch = CPU_TYPE_ARM64;
+    i64 arch = DEFAULT_MACHO_ARCH;
     i64 headerpad = 256;
     i64 pagezero_size = 0;
     i64 platform = PLATFORM_MACOS;

--- a/test/elf/entry.sh
+++ b/test/elf/entry.sh
@@ -8,6 +8,19 @@ mold="$(pwd)/mold"
 t="$(pwd)/out/test/elf/$testname"
 mkdir -p "$t"
 
+case "$(uname -m)" in
+i386 | i686 | x86_64)
+  base=0x201000
+  ;;
+aarch64)
+  base=0x210000
+  ;;
+*)
+  echo skipped
+  exit 0
+  ;;
+esac
+
 cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 .globl foo, bar
 foo:
@@ -18,14 +31,14 @@ EOF
 
 "$mold" -e foo -static -o "$t"/exe "$t"/a.o
 readelf -e "$t"/exe > "$t"/log
-grep -q 'Entry point address:.*0x201000' "$t"/log
+grep -q "Entry point address:.*$base" "$t"/log
 
 "$mold" -e bar -static -o "$t"/exe "$t"/a.o
 readelf -e "$t"/exe > "$t"/log
-grep -q 'Entry point address:.*0x201008' "$t"/log
+grep -q "$(printf 'Entry point address:.*0x%x' $((base + 8)))" "$t"/log
 
 "$mold" -static -o "$t"/exe "$t"/a.o
 readelf -e "$t"/exe > "$t"/log
-grep -q 'Entry point address:.*0x201000' "$t"/log
+grep -q "Entry point address:.*$base" "$t"/log
 
 echo OK

--- a/test/elf/reloc-zero.sh
+++ b/test/elf/reloc-zero.sh
@@ -8,8 +8,21 @@ mold="$(pwd)/mold"
 t="$(pwd)/out/test/elf/$testname"
 mkdir -p "$t"
 
+case "$(uname -m)" in
+i386 | i686 | x86_64)
+  jump=jmp
+  ;;
+aarch64)
+  jump=b
+  ;;
+*)
+  echo skipped
+  exit 0
+  ;;
+esac
+
 cat <<EOF | cc -o "$t"/a.o -c -x assembler -
-foo: jmp 0
+foo: $jump 0
 EOF
 
 cat <<EOF | cc -o "$t"/b.o -c -xc -


### PR DESCRIPTION
I'm packaging mold for Fedora.

I tripped over the fact that mold currently hardcodes the default ELF emulation to `EM_X86_64` (and the default Mach-O architecture to `CPU_TYPE_ARM64`). As a consequence, an aarch64 build of mold would default to producing x86_64 binaries unless overridden by `-m`.

This patch allows distributions to select the desired defaults when building mold. It is controlled through the make options `DEFAULT_ELF_EMULATION` and `DEFAULT_MACHO_ARCH`.
In the process, I've also added a patch to fix two unit tests that fail on aarch64.

I have seen that lld is really clever: it automatically selects the target architecture based on the input files it receives. Is such a feature planned for mold as well?