### PR TITLE
Fix test failures on aarch64

### DIFF
--- a/test/elf/entry.sh
+++ b/test/elf/entry.sh
@@ -8,6 +8,19 @@ mold="$(pwd)/mold"
 t="$(pwd)/out/test/elf/$testname"
 mkdir -p "$t"
 
+case "$(uname -m)" in
+i386 | i686 | x86_64)
+  base=0x201000
+  ;;
+aarch64)
+  base=0x210000
+  ;;
+*)
+  echo skipped
+  exit 0
+  ;;
+esac
+
 cat <<EOF | cc -o "$t"/a.o -c -x assembler -
 .globl foo, bar
 foo:
@@ -18,14 +31,14 @@ EOF
 
 "$mold" -e foo -static -o "$t"/exe "$t"/a.o
 readelf -e "$t"/exe > "$t"/log
-grep -q 'Entry point address:.*0x201000' "$t"/log
+grep -q "Entry point address:.*$base" "$t"/log
 
 "$mold" -e bar -static -o "$t"/exe "$t"/a.o
 readelf -e "$t"/exe > "$t"/log
-grep -q 'Entry point address:.*0x201008' "$t"/log
+grep -q "$(printf 'Entry point address:.*0x%x' $((base + 8)))" "$t"/log
 
 "$mold" -static -o "$t"/exe "$t"/a.o
 readelf -e "$t"/exe > "$t"/log
-grep -q 'Entry point address:.*0x201000' "$t"/log
+grep -q "Entry point address:.*$base" "$t"/log
 
 echo OK

--- a/test/elf/reloc-zero.sh
+++ b/test/elf/reloc-zero.sh
@@ -8,8 +8,21 @@ mold="$(pwd)/mold"
 t="$(pwd)/out/test/elf/$testname"
 mkdir -p "$t"
 
+case "$(uname -m)" in
+i386 | i686 | x86_64)
+  jump=jmp
+  ;;
+aarch64)
+  jump=b
+  ;;
+*)
+  echo skipped
+  exit 0
+  ;;
+esac
+
 cat <<EOF | cc -o "$t"/a.o -c -x assembler -
-foo: jmp 0
+foo: $jump 0
 EOF
 
 cat <<EOF | cc -o "$t"/b.o -c -xc -


### PR DESCRIPTION
Follow-up to #249. I can confirm that be49d67 works as expected on aarch64, but there are still two test cases that need fixing.