### PR TITLE
archive-file: Work-around when strtab.data() returns NULL

### DIFF
--- a/archive-file.h
+++ b/archive-file.h
@@ -96,6 +96,8 @@ read_fat_archive_members(C &ctx, MappedFile<C> *mf) {
       body += namelen;
     } else if (hdr.ar_name[0] == '/') {
       const char *start = strtab.data() + atoi(hdr.ar_name + 1);
+      if (!start)
+        continue;
       name = {start, (const char *)strstr(start, "/\n")};
     } else {
       char *end = (char *)memchr(hdr.ar_name, '/', sizeof(hdr.ar_name));


### PR DESCRIPTION
Under certain environment, strtab.data() could return NULL, and link would
fail. See the ASAN output below.

AddressSanitizer:DEADLYSIGNAL
=================================================================
==1022==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7ffff6e9455d bp 0x000000000000 sp 0x7fffffff9aa8 T0)
==1022==The signal is caused by a READ memory access.
==1022==Hint: address points to the zero page.
    #0 0x7ffff6e9455d in __strstr_sse2_unaligned (/lib/libc.so.6+0xb755d)
    #1 0x7ffff7659b20 in __interceptor_strstr ../../../../gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:595
    #2 0x7ffff7659b20 in __interceptor_strstr ../../../../gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:590
    #3 0x555555b7d28c in std::vector<mold::MappedFile<mold::elf::Context<mold::elf::X86_64> >*, std::allocator<mold::MappedFile<mold::elf::Context<mold::elf::X86_64> >*> > mold::read_fat_archive_members<mold::elf::Context<mold::elf::X86_64> >(mold::elf::Context<mold::elf::X86_64>&, mold::MappedFile<mold::elf::Context<mold::elf::X86_64> >*) elf/../archive-file.h:99

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/lib/libc.so.6+0xb755d) in __strstr_sse2_unaligned
==1022==ABORTING

Signed-off-by: Hiroshi Takekawa <sian.ht@gmail.com>