### PR TITLE
Improve compatibility with NetBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CFLAGS += $(COMMON_FLAGS) $(EXTRA_CFLAGS)
 CXXFLAGS ?= -O2
 CXXFLAGS += $(COMMON_FLAGS) $(EXTRA_CXXFLAGS) -std=c++20 -fno-exceptions
 CXXFLAGS += -DMOLD_VERSION=\"1.0.1\" -DLIBDIR="\"$(LIBDIR)\""
-LIBS = -pthread -lz -ldl -lm
+LIBS = -pthread -lz $(DL_LIBS) -lm
 
 SRCS=$(wildcard *.cc elf/*.cc macho/*.cc)
 HEADERS=$(wildcard *.h elf/*.h macho/*.h)
@@ -134,6 +134,12 @@ ifeq ($(IS_ANDROID), 1)
   CXXFLAGS += -Wno-c++11-narrowing
 endif
 
+ifeq ($(OS), NetBSD)
+DL_LIBS =
+else
+DL_LIBS = -ldl
+endif
+
 all: mold mold-wrapper.so
 
 mold: $(OBJS) $(MIMALLOC_LIB) $(TBB_LIB) $(XXHASH_LIB)
@@ -142,7 +148,7 @@ mold: $(OBJS) $(MIMALLOC_LIB) $(TBB_LIB) $(XXHASH_LIB)
 	ln -sf mold ld64.mold
 
 mold-wrapper.so: elf/mold-wrapper.c Makefile
-	$(CC) $(CFLAGS) -fPIC -shared -o $@ $(LDFLAGS) $< -ldl
+	$(CC) $(CFLAGS) -fPIC -shared -o $@ $(LDFLAGS) $< $(DL_LIBS)
 
 out/%.o: %.cc $(HEADERS) Makefile out/elf/.keep out/macho/.keep
 	$(CXX) $(CXXFLAGS) -c -o $@ $<

--- a/docs/mold.1
+++ b/docs/mold.1
@@ -802,7 +802,9 @@ Mark object to interpose all DSOs but executable.
 .It Fl O Ns Ar number
 .It Fl -allow-shlib-undefined
 .It Fl -color-diagnostics
+.It Fl -dc
 .It Fl -disable-new-dtags
+.It Fl -dp
 .It Fl -enable-new-dtags
 .It Fl -end-group
 .It Fl -fatal-warnings

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -60,10 +60,12 @@ Options:
   --color-diagnostics         Alias for --color-diagnostics=always
   --compress-debug-sections [none,zlib,zlib-gabi,zlib-gnu]
                               Compress .debug_* sections
+  --dc                        Ignored
   --defsym=SYMBOL=VALUE       Define a symbol alias
   --demangle                  Demangle C++ symbols in log messages (default)
     --no-demangle
   --disable-new-dtags         Ignored
+  --dp                        Ignored
   --dynamic-list              Read a list of dynamic symbols
   --eh-frame-hdr              Create .eh_frame_hdr section
     --no-eh-frame-hdr
@@ -834,6 +836,8 @@ void parse_nonpositional_args(Context<E> &ctx,
     } else if (read_flag(args, "no-undefined-version")) {
     } else if (read_arg(ctx, args, arg, "sort-section")) {
     } else if (read_flag(args, "sort-common")) {
+    } else if (read_flag(args, "dc")) {
+    } else if (read_flag(args, "dp")) {
     } else if (read_flag(args, "fix-cortex-a53-843419")) {
     } else if (read_flag(args, "EL")) {
     } else if (read_flag(args, "warn-once")) {

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -346,9 +346,8 @@ void ObjectFile<E>::read_ehframe(Context<E> &ctx, InputSection<E> &isec) {
   for (std::string_view data = contents; !data.empty();) {
     i64 size = *(u32 *)data.data();
     if (size == 0) {
-      if (data.size() != 4)
-        Fatal(ctx) << isec << ": garbage at end of section";
-      break;
+      data = data.substr(4);
+      continue;
     }
 
     i64 begin_offset = data.data() - contents.data();


### PR DESCRIPTION
NetBSD still uses BFD ld. It is freaking slow and eats up all the memory. So I was looking for a good alternative and found mold. Mold looked great. **It looked really great.** Except it didn't work on NetBSD so here are my patches to make it compatible with the OS.