### PR TITLE
fix build with libc++

### DIFF
--- a/strerror.cc
+++ b/strerror.cc
@@ -2,7 +2,7 @@
 // In this file, we explicitly undefine _GNU_SOURCE to always
 // use the POSIX version.
 
-#define _POSIX_C_SOURCE 200112L
+#define _POSIX_C_SOURCE 200809L
 #undef _GNU_SOURCE
 
 #include <cstring>


### PR DESCRIPTION
Otherwise fails with:

/usr/include/c++/v1/__threading_support:370:43: error: use of undeclared identifier 'PTHREAD_MUTEX_RECURSIVE'

200809L triggers __USE_XOPEN2K8 to be defined which enables pthread.h to define the missing identifier.