### PR TITLE
Fix Makefile for Termux on Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PREFIX = /usr/local
+ifndef PREFIX
+  PREFIX = /usr/local
+endif
 BINDIR = $(PREFIX)/bin
 LIBDIR = $(PREFIX)/lib
 LIBEXECDIR = $(PREFIX)/libexec


### PR DESCRIPTION
Makefile was installing to nowhere on Termux, Android.
Changed first line to fix this.