### PR TITLE
Use C++20 bit-twiddling functions

### DIFF
--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -641,7 +641,7 @@ void parse_nonpositional_args(Context<E> &ctx,
       ctx.arg.z_execstack = true;
     } else if (read_z_arg(ctx, args, arg, "max-page-size")) {
       ctx.page_size = parse_number(ctx, "-z max-page-size", arg);
-      if (__builtin_popcountll(ctx.page_size) != 1)
+      if (std::popcount<u64>(ctx.page_size) != 1)
         Fatal(ctx) << "-z max-page-size " << arg << ": value must be a power of 2";
     } else if (read_z_flag(args, "noexecstack")) {
       ctx.arg.z_execstack = false;

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -382,7 +382,7 @@ public:
   OutputLazyBindSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__LINKEDIT", "__lazy_binding") {
     this->is_hidden = true;
-    this->hdr.p2align = __builtin_ctz(8);
+    this->hdr.p2align = std::countr_zero(8U);
   }
 
   void add(Context<E> &ctx, Symbol<E> &sym, i64 flags);
@@ -462,7 +462,7 @@ public:
   OutputSymtabSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__LINKEDIT", "__symbol_table") {
     this->is_hidden = true;
-    this->hdr.p2align = __builtin_ctz(8);
+    this->hdr.p2align = std::countr_zero(8U);
   }
 
   void compute_size(Context<E> &ctx) override;
@@ -484,7 +484,7 @@ public:
   OutputStrtabSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__LINKEDIT", "__string_table") {
     this->is_hidden = true;
-    this->hdr.p2align = __builtin_ctz(8);
+    this->hdr.p2align = std::countr_zero(8U);
   }
 
   i64 add_string(std::string_view str);
@@ -522,7 +522,7 @@ public:
   CodeSignatureSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__LINKEDIT", "__code_signature") {
     this->is_hidden = true;
-    this->hdr.p2align = __builtin_ctz(16);
+    this->hdr.p2align = std::countr_zero(16U);
   }
 
   void compute_size(Context<E> &ctx) override;
@@ -537,7 +537,7 @@ public:
   DataInCodeSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__LINKEDIT", "__data_in_code") {
     this->is_hidden = true;
-    this->hdr.p2align = __builtin_ctz(alignof(DataInCodeEntry));
+    this->hdr.p2align = std::countr_zero(alignof(DataInCodeEntry));
   }
 
   void compute_size(Context<E> &ctx) override;
@@ -550,7 +550,7 @@ template <typename E>
 class StubsSection : public Chunk<E> {
 public:
   StubsSection(Context<E> &ctx) : Chunk<E>(ctx, "__TEXT", "__stubs") {
-    this->hdr.p2align = __builtin_ctz(2);
+    this->hdr.p2align = std::countr_zero(2U);
     this->hdr.type = S_SYMBOL_STUBS;
     this->hdr.attr = S_ATTR_SOME_INSTRUCTIONS | S_ATTR_PURE_INSTRUCTIONS;
     this->hdr.reserved2 = E::stub_size;
@@ -568,7 +568,7 @@ class StubHelperSection : public Chunk<E> {
 public:
   StubHelperSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__TEXT", "__stub_helper") {
-    this->hdr.p2align = __builtin_ctz(4);
+    this->hdr.p2align = std::countr_zero(4U);
     this->hdr.attr = S_ATTR_SOME_INSTRUCTIONS | S_ATTR_PURE_INSTRUCTIONS;
   }
 
@@ -594,7 +594,7 @@ class UnwindInfoSection : public Chunk<E> {
 public:
   UnwindInfoSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__TEXT", "__unwind_info") {
-    this->hdr.p2align = __builtin_ctz(4);
+    this->hdr.p2align = std::countr_zero(4U);
   }
 
   void compute_size(Context<E> &ctx) override;
@@ -607,7 +607,7 @@ template <typename E>
 class GotSection : public Chunk<E> {
 public:
   GotSection(Context<E> &ctx) : Chunk<E>(ctx, "__DATA_CONST", "__got") {
-    this->hdr.p2align = __builtin_ctz(8);
+    this->hdr.p2align = std::countr_zero(8U);
     this->hdr.type = S_NON_LAZY_SYMBOL_POINTERS;
   }
 
@@ -622,7 +622,7 @@ class LazySymbolPtrSection : public Chunk<E> {
 public:
   LazySymbolPtrSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__DATA", "__la_symbol_ptr") {
-    this->hdr.p2align = __builtin_ctz(8);
+    this->hdr.p2align = std::countr_zero(8U);
     this->hdr.type = S_LAZY_SYMBOL_POINTERS;
   }
 
@@ -634,7 +634,7 @@ class ThreadPtrsSection : public Chunk<E> {
 public:
   ThreadPtrsSection(Context<E> &ctx)
     : Chunk<E>(ctx, "__DATA", "__thread_ptrs") {
-    this->hdr.p2align = __builtin_ctz(8);
+    this->hdr.p2align = std::countr_zero(8U);
     this->hdr.type = S_THREAD_LOCAL_VARIABLE_POINTERS;
   }
 

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -1011,7 +1011,7 @@ void CodeSignatureSection<E>::write_signature(Context<E> &ctx) {
   dir.code_limit = this->hdr.offset;
   dir.hash_size = SHA256_SIZE;
   dir.hash_type = CS_HASHTYPE_SHA256;
-  dir.page_size = __builtin_ctz(BLOCK_SIZE);
+  dir.page_size = std::countr_zero<u64>(BLOCK_SIZE);
   dir.exec_seg_base = ctx.text_seg->cmd.fileoff;
   dir.exec_seg_limit = ctx.text_seg->cmd.filesize;
   if (ctx.output_type == MH_EXECUTE)
@@ -1175,13 +1175,13 @@ u32 UnwindEncoder<E>::encode_personality(Context<E> &ctx, Symbol<E> *sym) {
 
   for (i64 i = 0; i < personalities.size(); i++)
     if (personalities[i] == sym)
-      return (i + 1) << __builtin_ctz(UNWIND_PERSONALITY_MASK);
+      return (i + 1) << std::countr_zero(UNWIND_PERSONALITY_MASK);
 
   if (personalities.size() == 3)
     Fatal(ctx) << ": too many personality functions";
 
   personalities.push_back(sym);
-  return personalities.size() << __builtin_ctz(UNWIND_PERSONALITY_MASK);
+  return personalities.size() << std::countr_zero(UNWIND_PERSONALITY_MASK);
 }
 
 template <typename E>

--- a/mold.h
+++ b/mold.h
@@ -160,12 +160,12 @@ private:
 inline u64 align_to(u64 val, u64 align) {
   if (align == 0)
     return val;
-  assert(__builtin_popcount(align) == 1);
+  assert(std::popcount(align) == 1);
   return (val + align - 1) & ~(align - 1);
 }
 
 inline u64 align_down(u64 val, u64 align) {
-  assert(__builtin_popcount(align) == 1);
+  assert(std::popcount(align) == 1);
   return val & ~(align - 1);
 }
 
@@ -173,7 +173,7 @@ inline u64 next_power_of_two(u64 val) {
   assert(val >> 63 == 0);
   if (val == 0 || val == 1)
     return 1;
-  return (u64)1 << (64 - __builtin_clzl(val - 1));
+  return (u64)1 << (64 - std::countl_zero(val - 1));
 }
 
 template <typename T, typename Compare = std::less<T>>
@@ -312,7 +312,7 @@ public:
     if (!keys)
       return {nullptr, false};
 
-    assert(__builtin_popcount(nbuckets) == 1);
+    assert(std::popcount<u64>(nbuckets) == 1);
     i64 idx = hash & (nbuckets - 1);
     i64 retry = 0;
 
@@ -430,7 +430,7 @@ public:
   HyperLogLog() : buckets(NBUCKETS) {}
 
   void insert(u32 hash) {
-    update_maximum(buckets[hash & (NBUCKETS - 1)], __builtin_clz(hash) + 1);
+    update_maximum(buckets[hash & (NBUCKETS - 1)], std::countl_zero(hash) + 1);
   }
 
   i64 get_cardinality() const;


### PR DESCRIPTION
This replaces the GCC builtins with their portable C++20 counterparts.

Note that the C++ functions are only defined for unsigned types, so we
need to explicitly specify the appropriate template type argument in
some instances.