### PR TITLE
Ignore unknown --warn-* options

### DIFF
--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -873,6 +873,9 @@ void parse_nonpositional_args(Context<E> &ctx,
       remaining.push_back("-push-state");
     } else if (read_flag(args, "pop-state")) {
       remaining.push_back("-pop-state");
+    } else if (args[0].starts_with("--warn-") && args[0].size() > 7) {
+      Warn(ctx) << "unknown command line option: --warn-* " << args[0];
+      args = args.subspan(1);
     } else if (args[0].starts_with("-z") && args[0].size() > 2) {
       Warn(ctx) << "unknown command line option: " << args[0];
       args = args.subspan(1);


### PR DESCRIPTION
Building llvm-project-13.0.0 we encounter an error:

[4131/6160] Linking C shared library lib/libomp.so
FAILED: lib/libomp.so
(snip)
mold: unknown command line option: --warn-shared-textrel
collect2: error: ld returned 1 exit status

There're several --warn-* options implemented in ld.bfd from newer binutils.
When configuration stage we use 'ld' not necessarily mold, but ld.bfd, to
figure out what options 'ld' understands. Then unknown options are passed to
mold. Just ignore --warn-* that mold doesn't understand. --warn-* would be safe
to ignore.

Signed-off-by: Hiroshi Takekawa <sian.ht@gmail.com>