### PR TITLE
Use nettle for SHA256

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ endif
 
 # Use pkg-config to know where libcrypto resides.
 ifneq ($(OS), Darwin)
-  MOLD_CXXFLAGS += $(shell $(PKG_CONFIG) --cflags-only-I openssl)
-  MOLD_LDFLAGS += $(shell $(PKG_CONFIG) --libs-only-L openssl) -lcrypto
+  MOLD_CXXFLAGS += $(shell $(PKG_CONFIG) --cflags nettle)
+  MOLD_LDFLAGS += $(shell $(PKG_CONFIG) --libs nettle)
 endif
 
 # '-latomic' flag is needed building on riscv64 system

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo apt-get install -y build-essential git clang cmake libstdc++-10-dev libssl-
 #### Fedora 34 and later
 
 ```shell
-sudo dnf install -y git clang cmake openssl-devel xxhash-devel zlib-devel libstdc++-devel
+sudo dnf install -y git clang cmake nettle-devel xxhash-devel zlib-devel libstdc++-devel
 ```
 
 ### Compile mold

--- a/elf/icf.cc
+++ b/elf/icf.cc
@@ -62,12 +62,7 @@
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_sort.h>
 
-#ifdef __APPLE__
-#  define COMMON_DIGEST_FOR_OPENSSL
-#  include <CommonCrypto/CommonDigest.h>
-#else
-#  include <openssl/sha.h>
-#endif
+#include "../sha256.h"
 
 static constexpr int64_t HASH_SIZE = 16;
 
@@ -125,8 +120,7 @@ static bool is_eligible(InputSection<E> &isec) {
 
 static Digest digest_final(SHA256_CTX &sha) {
   u8 buf[SHA256_SIZE];
-  int res = SHA256_Final(buf, &sha);
-  assert(res == 1);
+  SHA256_Final(buf, &sha);
 
   Digest digest;
   memcpy(digest.data(), buf, HASH_SIZE);

--- a/elf/subprocess.cc
+++ b/elf/subprocess.cc
@@ -11,12 +11,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#ifdef __APPLE__
-#  define COMMON_DIGEST_FOR_OPENSSL
-#  include <CommonCrypto/CommonDigest.h>
-#else
-#  include <openssl/sha.h>
-#endif
+#include "../sha256.h"
 
 #define DAEMON_TIMEOUT 30
 

--- a/sha256.h
+++ b/sha256.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#ifdef __APPLE__
+#  define COMMON_DIGEST_FOR_OPENSSL
+#  include <CommonCrypto/CommonDigest.h>
+#else
+#  include <nettle/sha.h>
+
+   typedef struct sha256_ctx SHA256_CTX;
+#  define SHA256_SIZE SHA256_DIGEST_SIZE
+#  define SHA256_Init sha256_init
+#  define SHA256_Update(ctx, data, len) \
+          sha256_update((ctx), (len), reinterpret_cast<const uint8_t*>(data))
+#  define SHA256_Final(data, ctx) \
+          sha256_digest((ctx), SHA256_DIGEST_SIZE, (data))
+#endif


### PR DESCRIPTION
As mold currently uses deprecated SHA function from OpenSSL, lets just move to libnettle. This is widely available as it is used by GnuTLS as the low level crypto library.

This fixes #246 