### PR TITLE
mold-wrapper: Execute mold if ld.bfd is executed

### DIFF
--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -46,7 +46,7 @@ static bool is_ld(const char *path) {
     ptr--;
 
   return !strcmp(ptr, "ld") || !strcmp(ptr, "ld.lld") ||
-         !strcmp(ptr, "ld.gold");
+         !strcmp(ptr, "ld.gold") || !strcmp(ptr, "ld.bfd");
 }
 
 int execvpe(const char *file, char *const *argv, char *const *envp) {


### PR DESCRIPTION
Current `is_ld` function doesn't regard `ld.bfd` as ld.
By this change, mold will be used even if compiler is about to execute `ld.bfd`.