### PR TITLE
Install libc++dev in the Docker image to build mold

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -19,7 +19,7 @@ RUN apt-get update && \
   TZ=Europe/London apt-get install -y tzdata && \
   apt-get install -y --no-install-recommends build-essential clang lld \
     bsdmainutils file gcc-multilib git pkg-config \
-    cmake libstdc++-10-dev zlib1g-dev libssl-dev && \
+    cmake libstdc++-10-dev zlib1g-dev libssl-dev libc++-dev && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
 EOF


### PR DESCRIPTION
This PR installs `libc++-dev` in the Docker to build `mold`. I've verified that it worked on both MacOS and Ubuntu 20.04.

<img width="1647" alt="Screen Shot 2022-01-30 at 11 11 13 AM" src="https://user-images.githubusercontent.com/4816327/151713873-9148b846-f06b-47ba-80f9-07d04a95a1ec.png">

close https://github.com/rui314/mold/issues/317