### PR TITLE
Fix -Wmissing-field-initializers

### DIFF
--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1112,6 +1112,8 @@ class GlobPattern {
     Kind kind;
     std::string str;
     std::vector<bool> bitmap;
+
+    Element(Kind k) : kind(k), str(std::string()), bitmap({}) {}
   };
 
 public:

--- a/macho/object-file.cc
+++ b/macho/object-file.cc
@@ -109,6 +109,8 @@ template <typename E>
 struct SplitInfo {
   InputSection<E> *isec = nullptr;
   std::vector<SplitRegion> regions;
+
+  SplitInfo(InputSection<E> *i) : isec(i), regions({}) {}
 };
 
 template <typename E>


### PR DESCRIPTION
Add `mold::elf::GlobPattern::Element` and `mold::macho::SplitInfo`
trivial constructors to fix all `-Wmissing-field-initializers` as
reported both by g++ and clang++.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>