### PR TITLE
Use libsodium for SHA256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: apt-get
-      run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install build-essential libstdc++-10-dev cmake clang libssl-dev zlib1g-dev libxxhash-dev libtbb-dev git bsdmainutils dwarfdump libc6-dev:i386 lib32gcc-10-dev libstdc++-10-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
+      run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install build-essential libstdc++-10-dev cmake clang libsodium-dev zlib1g-dev libxxhash-dev libtbb-dev git bsdmainutils dwarfdump libc6-dev:i386 lib32gcc-10-dev libstdc++-10-dev-arm64-cross gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
     - name: make
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: apt-get
-      run: dpkg --add-architecture i386 && apt-get update && apt-get install -y sudo libssl-dev zlib1g-dev libxxhash-dev cmake clang dwarfdump bsdextrautils libgcc-9-dev gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev:i386 lib32gcc-10-dev qemu-user
+      run: dpkg --add-architecture i386 && apt-get update && apt-get install -y sudo libsodium-dev zlib1g-dev libxxhash-dev cmake clang dwarfdump bsdextrautils libgcc-9-dev gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev:i386 lib32gcc-10-dev qemu-user
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
     - name: make
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: brew
-      run: brew install xxhash
+      run: brew install xxhash libsodium
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
     - name: make

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ endif
 
 # Use pkg-config to know where libcrypto resides.
 ifneq ($(OS), Darwin)
-  MOLD_CXXFLAGS += $(shell $(PKG_CONFIG) --cflags-only-I openssl)
-  MOLD_LDFLAGS += $(shell $(PKG_CONFIG) --libs-only-L openssl) -lcrypto
+  MOLD_CXXFLAGS += $(shell $(PKG_CONFIG) --cflags libsodium)
+  MOLD_LDFLAGS += $(shell $(PKG_CONFIG) --libs libsodium)
 endif
 
 # '-latomic' flag is needed building on riscv64 system

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ you can build mold by the following commands.
 
 ```shell
 sudo apt-get update
-sudo apt-get install -y build-essential git clang cmake libstdc++-10-dev libssl-dev libxxhash-dev zlib1g-dev pkg-config
+sudo apt-get install -y build-essential git clang cmake libstdc++-10-dev libsodium-dev libxxhash-dev zlib1g-dev pkg-config
 ```
 
 #### Fedora 34 and later
 
 ```shell
-sudo dnf install -y git clang cmake openssl-devel xxhash-devel zlib-devel libstdc++-devel
+sudo dnf install -y git clang cmake libsodium-devel xxhash-devel zlib-devel libstdc++-devel
 ```
 
 ### Compile mold

--- a/build-static.sh
+++ b/build-static.sh
@@ -19,7 +19,7 @@ RUN apt-get update && \
   TZ=Europe/London apt-get install -y tzdata && \
   apt-get install -y --no-install-recommends build-essential clang lld \
     bsdmainutils file gcc-multilib git pkg-config \
-    cmake libstdc++-10-dev zlib1g-dev libssl-dev && \
+    cmake libstdc++-10-dev zlib1g-dev libsodium23 libsodium-dev && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*
 EOF

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -43,7 +43,7 @@ public:
 
 namespace mold::elf {
 
-static constexpr i32 SHA256_SIZE = 32;
+static constexpr i32 crypto_hash_sha256_BYTES = 32;
 
 template <typename E> class InputFile;
 template <typename E> class InputSection;

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -14,7 +14,7 @@
 namespace mold::macho {
 
 static constexpr i64 COMMON_PAGE_SIZE = 0x4000;
-static constexpr i64 SHA256_SIZE = 32;
+static constexpr i64 crypto_hash_sha256_BYTES = 32;
 
 template <typename E> class Chunk;
 template <typename E> class InputSection;

--- a/main.cc
+++ b/main.cc
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <signal.h>
+#include <sodium.h>
 
 namespace mold {
 
@@ -34,6 +35,7 @@ void install_signal_handler() {
 } // namespace mold
 
 int main(int argc, char **argv) {
+  sodium_init();
   std::string cmd = mold::filepath(argv[0]).filename();
 
   if (cmd == "ld64" || cmd == "ld64.mold")

--- a/sha.h
+++ b/sha.h
@@ -1,8 +1,0 @@
-#ifdef __APPLE__
-#  define COMMON_DIGEST_FOR_OPENSSL
-#  include <CommonCrypto/CommonDigest.h>
-#  define SHA256(data, len, md) CC_SHA256(data, len, md)
-#else
-#  define OPENSSL_SUPPRESS_DEPRECATED 1
-#  include <openssl/sha.h>
-#endif


### PR DESCRIPTION
Currently, mold uses deprecated SHA functions from OpenSSL.
If or when they are no longer usable, mold should migrate to libsodium instead.
Not only is it widely available, it also has blake2b functionality.
Furthermore, libsodium has blake3 on its 1.0.x roadmap.

This fixes #246