### PR TITLE
Use parallel sort for .dynsym

### DIFF
--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1117,7 +1117,8 @@ void DynsymSection<E>::finalize(Context<E> &ctx) {
 
   // In any symtab, local symbols must precede global symbols.
   // We also place undefined symbols before defined symbols for .gnu.hash.
-  sort(symbols.begin() + 1, symbols.end(), [&](Symbol<E> *a, Symbol<E> *b) {
+  tbb::parallel_sort(symbols.begin() + 1, symbols.end(),
+                     [&](Symbol<E> *a, Symbol<E> *b) {
     if (auto x = (is_local(a) <=> is_local(b)); x != 0)
       return x > 0;
     return a->is_exported < b->is_exported;


### PR DESCRIPTION
Prefer `tbb::parallel_sort()` over `std::sort()` in
`DynsymSection<E>::finalize()`. Although being highly
dependent from `--thread-count`, this is expected to
achieve up to ~8x speedup for huge (>20M entries)
symbol tables, as shown with `--perf`, e.g.
from:
```
  1.651    0.000    1.662        DynsymSection::finalize
```
to:
```
  0.488    0.000    0.198        DynsymSection::finalize
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>