### PR TITLE
[ELF] add method to check whether an input file is shared object

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -15,8 +15,6 @@ InputFile<E>::InputFile(Context<E> &ctx, MappedFile<Context<E>> *mf)
     Fatal(ctx) << *this << ": not an ELF file";
 
   ElfEhdr<E> &ehdr = *(ElfEhdr<E> *)mf->data;
-  is_dso = (ehdr.e_type == ET_DYN);
-
   ElfShdr<E> *sh_begin = (ElfShdr<E> *)(mf->data + ehdr.e_shoff);
 
   // e_shnum contains the total number of sections in an object file.
@@ -728,7 +726,7 @@ void ObjectFile<E>::parse(Context<E> &ctx) {
 template <typename E>
 static u64 get_rank(InputFile<E> *file, const ElfSym<E> &esym, bool is_lazy) {
   if (esym.is_common()) {
-    assert(!file->is_dso);
+    assert(!file->is_dso());
     if (is_lazy)
       return (6 << 24) + file->priority;
     return (5 << 24) + file->priority;
@@ -744,7 +742,7 @@ static u64 get_rank(InputFile<E> *file, const ElfSym<E> &esym, bool is_lazy) {
   // often disabled by default though.
   bool is_weak = (esym.st_bind == STB_WEAK || esym.st_bind == STB_GNU_UNIQUE);
 
-  if (file->is_dso || is_lazy) {
+  if (file->is_dso() || is_lazy) {
     if (is_weak)
       return (4 << 24) + file->priority;
     return (3 << 24) + file->priority;
@@ -904,7 +902,7 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
 
     // If a protected/hidden undefined symbol is resolved to an
     // imported symbol, it's handled as if no symbols were found.
-    if (sym.file && sym.file->is_dso &&
+    if (sym.file && sym.file->is_dso() &&
         (sym.visibility == STV_PROTECTED || sym.visibility == STV_HIDDEN)) {
       report_undef(ctx, *this, sym);
       continue;
@@ -919,7 +917,7 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
     std::string_view key = symbol_strtab.data() + esym.st_name;
     if (i64 pos = key.find('@'); pos != key.npos) {
       Symbol<E> *sym2 = get_symbol(ctx, key.substr(0, pos));
-      if (sym2->file && sym2->file->is_dso &&
+      if (sym2->file && sym2->file->is_dso() &&
           sym2->get_version() == key.substr(pos + 1)) {
         this->symbols[i] = sym2;
         continue;
@@ -1164,7 +1162,7 @@ bool is_c_identifier(std::string_view name) {
 
 template <typename E>
 std::ostream &operator<<(std::ostream &out, const InputFile<E> &file) {
-  if (file.is_dso) {
+  if (file.is_dso()) {
     out << path_clean(file.filename);
     return out;
   }

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -947,7 +947,7 @@ template <typename E>
 class InputFile {
 public:
   InputFile(Context<E> &ctx, MappedFile<Context<E>> *mf);
-  InputFile() : filename("<internal>") {}
+  InputFile() : mf(nullptr), filename("<internal>") {}
 
   virtual ~InputFile() = default;
 
@@ -960,8 +960,10 @@ public:
   std::string_view get_string(Context<E> &ctx, const ElfShdr<E> &shdr);
   std::string_view get_string(Context<E> &ctx, i64 idx);
 
-  ElfEhdr<E> &get_ehdr() { return *(ElfEhdr<E> *)mf->data; }
-  ElfPhdr<E> *get_phdr() { return (ElfPhdr<E> *)(mf->data + get_ehdr().e_phoff); }
+  ElfEhdr<E> &get_ehdr() const { return *(ElfEhdr<E> *)mf->data; }
+  ElfPhdr<E> *get_phdr() const {
+    return (ElfPhdr<E> *)(mf->data + get_ehdr().e_phoff);
+  }
 
   ElfShdr<E> *find_section(i64 type);
 
@@ -972,6 +974,8 @@ public:
   mark_live_objects(Context<E> &ctx,
                     std::function<void(InputFile<E> *)> feeder) = 0;
 
+  virtual bool is_dso() const = 0;
+
   std::span<Symbol<E> *> get_global_syms();
 
   MappedFile<Context<E>> *mf;
@@ -981,7 +985,6 @@ public:
   i64 first_global = 0;
 
   std::string filename;
-  bool is_dso = false;
   u32 priority;
   std::atomic_bool is_alive = false;
   std::string_view shstrtab;
@@ -1057,6 +1060,12 @@ public:
   std::vector<std::vector<ElfRel<E>>> sorted_rels;
   std::vector<std::vector<Symbol<E> *>> sorted_symbols;
 
+  inline virtual bool is_dso() const override {
+    if (this->mf)
+      assert(this->get_ehdr().e_type == ET_REL);
+    return false;
+  }
+
 private:
   ObjectFile(Context<E> &ctx, MappedFile<Context<E>> *mf,
              std::string archive_name, bool is_in_lib);
@@ -1105,6 +1114,11 @@ public:
   std::string soname;
   std::vector<std::string_view> version_strings;
   std::vector<ElfSym<E>> elf_syms2;
+
+  inline virtual bool is_dso() const override {
+    assert(this->get_ehdr().e_type == ET_DYN);
+    return true;
+  }
 
 private:
   SharedFile(Context<E> &ctx, MappedFile<Context<E>> *mf);
@@ -2209,7 +2223,7 @@ inline bool Symbol<E>::has_got(Context<E> &ctx) const {
 
 template <typename E>
 inline bool Symbol<E>::is_absolute() const {
-  if (file->is_dso)
+  if (file->is_dso())
     return esym().is_abs();
   return !is_imported && !get_frag() && !shndx && !input_section;
 }
@@ -2221,14 +2235,14 @@ inline bool Symbol<E>::is_relative() const {
 
 template <typename E>
 inline u32 Symbol<E>::get_type() const {
-  if (esym().st_type == STT_GNU_IFUNC && file->is_dso)
+  if (esym().st_type == STT_GNU_IFUNC && file->is_dso())
     return STT_FUNC;
   return esym().st_type;
 }
 
 template <typename E>
 inline std::string_view Symbol<E>::get_version() const {
-  if (file->is_dso)
+  if (file->is_dso())
     return ((SharedFile<E> *)file)->version_strings[ver_idx];
   return "";
 }
@@ -2240,7 +2254,7 @@ inline const ElfSym<E> &Symbol<E>::esym() const {
 
 template <typename E>
 inline SectionFragment<E> *Symbol<E>::get_frag() const {
-  if (!file || file->is_dso)
+  if (!file || file->is_dso())
     return nullptr;
   return ((ObjectFile<E> *)file)->sym_fragments[sym_idx].frag;
 }

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1230,7 +1230,7 @@ void DynsymSection<E>::copy_buf(Context<E> &ctx) {
       esym.st_bind = STB_LOCAL;
     else if (sym.is_weak)
       esym.st_bind = STB_WEAK;
-    else if (sym.file->is_dso)
+    else if (sym.file->is_dso())
       esym.st_bind = STB_GLOBAL;
     else
       esym.st_bind = sym.esym().st_bind;
@@ -1242,7 +1242,7 @@ void DynsymSection<E>::copy_buf(Context<E> &ctx) {
       esym.st_shndx = sym.copyrel_readonly
         ? ctx.copyrel_relro->shndx : ctx.copyrel->shndx;
       esym.st_value = sym.get_addr(ctx);
-    } else if (sym.file->is_dso || sym.esym().is_undef()) {
+    } else if (sym.file->is_dso() || sym.esym().is_undef()) {
       esym.st_shndx = SHN_UNDEF;
       esym.st_size = 0;
       if (sym.has_plt(ctx) && !ctx.arg.pic && sym.is_imported) {
@@ -1687,7 +1687,7 @@ void CopyrelSection<E>::add_symbol(Context<E> &ctx, Symbol<E> *sym) {
     return;
 
   assert(!ctx.arg.shared);
-  assert(sym->file->is_dso);
+  assert(sym->file->is_dso());
 
   this->shdr.sh_size = align_to(this->shdr.sh_size, this->shdr.sh_addralign);
   sym->value = this->shdr.sh_size;
@@ -1737,7 +1737,7 @@ void VerneedSection<E>::construct(Context<E> &ctx) {
                                 ctx.dynsym->symbols.end());
 
   std::erase_if(syms, [](Symbol<E> *sym) {
-    return !sym->file->is_dso || sym->ver_idx <= VER_NDX_LAST_RESERVED;
+    return !sym->file->is_dso() || sym->ver_idx <= VER_NDX_LAST_RESERVED;
   });
 
   if (syms.empty())

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -663,7 +663,7 @@ void scan_rels(Context<E> &ctx) {
       ctx.got->add_tlsdesc_symbol(ctx, sym);
 
     if (sym->flags & NEEDS_COPYREL) {
-      assert(sym->file->is_dso);
+      assert(sym->file->is_dso());
       SharedFile<E> *file = (SharedFile<E> *)sym->file;
       sym->copyrel_readonly = file->is_readonly(ctx, sym);
 
@@ -772,7 +772,7 @@ void apply_version_script(Context<E> &ctx) {
   if (is_simple()) {
     for (VersionPattern &v : ctx.version_patterns)
       if (Symbol<E> *sym = get_symbol(ctx, v.pattern);
-          sym->file && !sym->file->is_dso)
+          sym->file && !sym->file->is_dso())
         sym->ver_idx = v.ver_idx;
     return;
   }
@@ -860,7 +860,8 @@ void compute_import_export(Context<E> &ctx) {
   if (!ctx.arg.shared) {
     tbb::parallel_for_each(ctx.dsos, [&](SharedFile<E> *file) {
       for (Symbol<E> *sym : file->symbols) {
-        if (sym->file && !sym->file->is_dso && sym->visibility != STV_HIDDEN) {
+        if (sym->file && !sym->file->is_dso() &&
+            sym->visibility != STV_HIDDEN) {
           std::scoped_lock lock(sym->mu);
           sym->is_exported = true;
         }
@@ -874,7 +875,7 @@ void compute_import_export(Context<E> &ctx) {
           sym->ver_idx == VER_NDX_LOCAL)
         continue;
 
-      if (sym->file != file && sym->file->is_dso) {
+      if (sym->file != file && sym->file->is_dso()) {
         sym->is_imported = true;
         continue;
       }


### PR DESCRIPTION
Prefer pure virtual `mold::elf::InputFile::is_dso()` (actually
implemented in `mold::elf::ObjectFile` and `mold::elf::SharedFile`)
over the field of the same name, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>