### PR TITLE
[MACHO] add method to check whether an input file is shared object

### DIFF
--- a/macho/arch-arm64.cc
+++ b/macho/arch-arm64.cc
@@ -159,7 +159,7 @@ void Subsection<ARM64>::scan_relocations(Context<ARM64> &ctx) {
       break;
     }
 
-    if (sym->file && sym->file->is_dylib) {
+    if (sym->file && sym->file->is_dylib()) {
       sym->flags |= NEEDS_STUB;
       ((DylibFile<ARM64> *)sym->file)->is_needed = true;
     }

--- a/macho/arch-x86-64.cc
+++ b/macho/arch-x86-64.cc
@@ -138,19 +138,19 @@ void Subsection<X86_64>::scan_relocations(Context<X86_64> &ctx) {
 
     switch (r.type) {
     case X86_64_RELOC_GOT_LOAD:
-      if (sym->file && sym->file->is_dylib)
+      if (sym->file && sym->file->is_dylib())
         sym->flags |= NEEDS_GOT;
       break;
     case X86_64_RELOC_GOT:
       sym->flags |= NEEDS_GOT;
       break;
     case X86_64_RELOC_TLV:
-      if (sym->file && sym->file->is_dylib)
+      if (sym->file && sym->file->is_dylib())
         sym->flags |= NEEDS_THREAD_PTR;
       break;
     }
 
-    if (sym->file && sym->file->is_dylib) {
+    if (sym->file && sym->file->is_dylib()) {
       sym->flags |= NEEDS_STUB;
       ((DylibFile<X86_64> *)sym->file)->is_needed = true;
     }

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -60,9 +60,10 @@ public:
   MappedFile<Context<E>> *mf = nullptr;
   std::vector<Symbol<E> *> syms;
   i64 priority = 0;
-  bool is_dylib = false;
   std::atomic_bool is_alive = false;
   std::string archive_name;
+
+  virtual bool is_dylib() const = 0;
 
 protected:
   InputFile() = default;
@@ -75,6 +76,7 @@ public:
 
   static ObjectFile *create(Context<E> &ctx, MappedFile<Context<E>> *mf,
                             std::string archive_name);
+  bool is_dylib() const override { return false; }
   void parse(Context<E> &ctx);
   Subsection<E> *find_subsection(Context<E> &ctx, u32 addr);
   void parse_compact_unwind(Context<E> &ctx, MachSection &hdr);
@@ -121,13 +123,14 @@ public:
   i64 dylib_idx = 0;
   std::atomic_bool is_needed = false;
 
+  bool is_dylib() const override { return true; }
+
 private:
   void parse_dylib(Context<E> &ctx);
   void read_trie(Context<E> &ctx, u8 *start, i64 offset = 0,
                  const std::string &prefix = "");
 
   DylibFile() {
-    this->is_dylib = true;
     this->is_alive = true;
   }
 };

--- a/macho/object-file.cc
+++ b/macho/object-file.cc
@@ -344,7 +344,7 @@ static u64 get_rank(InputFile<E> *file, MachSym &msym, bool is_lazy) {
     return (6 << 24) + file->priority;
   if (is_lazy)
     return (5 << 24) + file->priority;
-  if (file->is_dylib)
+  if (file->is_dylib())
     return (3 << 24) + file->priority;
   return (1 << 24) + file->priority;
 }
@@ -358,7 +358,7 @@ static u64 get_rank(Symbol<E> &sym) {
     return (6 << 24) + file->priority;
   if (!file->archive_name.empty())
     return (5 << 24) + file->priority;
-  if (file->is_dylib)
+  if (file->is_dylib())
     return (3 << 24) + file->priority;
   return (1 << 24) + file->priority;
 }

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -563,12 +563,12 @@ void OutputRebaseSection<E>::compute_size(Context<E> &ctx) {
             ctx.data_seg->cmd.vmaddr);
 
   for (Symbol<E> *sym : ctx.got.syms)
-    if (!sym->file->is_dylib)
+    if (!sym->file->is_dylib())
       enc.add(ctx.data_const_seg->seg_idx,
               sym->get_got_addr(ctx) - ctx.data_const_seg->cmd.vmaddr);
 
   for (Symbol<E> *sym : ctx.thread_ptrs.syms)
-    if (!sym->file->is_dylib)
+    if (!sym->file->is_dylib())
       enc.add(ctx.data_seg->seg_idx,
               sym->get_tlv_addr(ctx) - ctx.data_seg->cmd.vmaddr);
 
@@ -637,13 +637,13 @@ void OutputBindSection<E>::compute_size(Context<E> &ctx) {
   BindEncoder enc;
 
   for (Symbol<E> *sym : ctx.got.syms)
-    if (sym->file->is_dylib)
+    if (sym->file->is_dylib())
       enc.add(((DylibFile<E> *)sym->file)->dylib_idx, sym->name, 0,
               ctx.data_const_seg->seg_idx,
               sym->get_got_addr(ctx) - ctx.data_const_seg->cmd.vmaddr);
 
   for (Symbol<E> *sym : ctx.thread_ptrs.syms)
-    if (sym->file->is_dylib)
+    if (sym->file->is_dylib())
       enc.add(((DylibFile<E> *)sym->file)->dylib_idx, sym->name, 0,
               ctx.data_seg->seg_idx,
               sym->get_tlv_addr(ctx) - ctx.data_seg->cmd.vmaddr);
@@ -894,15 +894,15 @@ void OutputSymtabSection<E>::copy_buf(Context<E> &ctx) {
     Symbol<E> &sym = *ent.sym;
 
     msym.stroff = ent.stroff;
-    msym.type = (sym.file->is_dylib ? N_UNDF : N_SECT);
+    msym.type = (sym.file->is_dylib() ? N_UNDF : N_SECT);
     msym.ext = sym.is_extern;
 
-    if (!sym.file->is_dylib)
+    if (!sym.file->is_dylib())
       msym.value = sym.get_addr(ctx);
     if (sym.subsec)
       msym.sect = sym.subsec->isec.osec.sect_idx;
 
-    if (sym.file->is_dylib)
+    if (sym.file->is_dylib())
       msym.desc = ((DylibFile<E> *)sym.file)->dylib_idx << 8;
     else if (sym.referenced_dynamically)
       msym.desc = REFERENCED_DYNAMICALLY;
@@ -1240,7 +1240,7 @@ template <typename E>
 void GotSection<E>::copy_buf(Context<E> &ctx) {
   u64 *buf = (u64 *)(ctx.buf + this->hdr.offset);
   for (i64 i = 0; i < syms.size(); i++)
-    if (!syms[i]->file->is_dylib)
+    if (!syms[i]->file->is_dylib())
       buf[i] = syms[i]->get_addr(ctx);
 }
 
@@ -1265,7 +1265,7 @@ template <typename E>
 void ThreadPtrsSection<E>::copy_buf(Context<E> &ctx) {
   u64 *buf = (u64 *)(ctx.buf + this->hdr.offset);
   for (i64 i = 0; i < syms.size(); i++)
-    if (!syms[i]->file->is_dylib)
+    if (!syms[i]->file->is_dylib())
       buf[i] = syms[i]->get_addr(ctx);
 }
 


### PR DESCRIPTION
Prefer pure virtual `mold::macho::InputFile::is_dylib()` (actually
implemented in `mold::macho::ObjectFile` and `mold::macho::DylibFile`)
over the field of the same name, adjust related code. This is Mach-O
counterpart of 249c331117f8fcbe0525d7e100b6a8ce2e90fd35.

Signed-off-by: Dmitry Antipov dantipov@cloudlinux.com