### PR TITLE
[MACHO] add compiler-suggested virtual destructor

### DIFF
--- a/macho/mold.h
+++ b/macho/mold.h
@@ -67,6 +67,7 @@ public:
 
 protected:
   InputFile() = default;
+  virtual ~InputFile() = default;
 };
 
 template <typename E>


### PR DESCRIPTION
Add `mold::macho::InputFile()::~InputFile()` as suggested by
`clang++-13`'s `-Wdelete-non-abstract-non-virtual-dtor`:
```
/usr/include/c++/11/bits/unique_ptr.h:85:2: warning: delete
called on non-final 'mold::macho::ObjectFile<mold::macho::ARM64>'
that has virtual functions but non-virtual destructor
[-Wdelete-non-abstract-non-virtual-dtor]
```
Signed-off-by: Dmitry Antipov dantipov@cloudlinux.com