### PR TITLE
[ELF][MACHO] Remove unused data structures

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -76,9 +76,7 @@ template <typename E>
 ObjectFile<E> *
 ObjectFile<E>::create(Context<E> &ctx, MappedFile<Context<E>> *mf,
                       std::string archive_name, bool is_in_lib) {
-  ObjectFile<E> *obj = new ObjectFile<E>(ctx, mf, archive_name, is_in_lib);
-  ctx.obj_pool.push_back(std::unique_ptr<ObjectFile<E>>(obj));
-  return obj;
+  return new ObjectFile<E>(ctx, mf, archive_name, is_in_lib);
 }
 
 template <typename E>
@@ -1178,9 +1176,7 @@ std::ostream &operator<<(std::ostream &out, const InputFile<E> &file) {
 template <typename E>
 SharedFile<E> *
 SharedFile<E>::create(Context<E> &ctx, MappedFile<Context<E>> *mf) {
-  SharedFile<E> *obj = new SharedFile(ctx, mf);
-  ctx.dso_pool.push_back(std::unique_ptr<SharedFile<E>>(obj));
-  return obj;
+  return new SharedFile(ctx, mf);
 }
 
 template <typename E>

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1530,8 +1530,6 @@ struct Context {
   tbb::concurrent_vector<std::unique_ptr<TimerRecord>> timer_records;
   tbb::concurrent_vector<std::function<void()>> on_exit;
 
-  tbb::concurrent_vector<std::unique_ptr<ObjectFile<E>>> obj_pool;
-  tbb::concurrent_vector<std::unique_ptr<SharedFile<E>>> dso_pool;
   tbb::concurrent_vector<std::unique_ptr<u8[]>> string_pool;
   tbb::concurrent_vector<std::unique_ptr<MappedFile<Context<E>>>> mf_pool;
   tbb::concurrent_vector<std::vector<ElfRel<E>>> rel_pool;

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -273,7 +273,6 @@ static std::optional<u64> parse_defsym_addr(std::string_view s) {
 template <typename E>
 ObjectFile<E> *create_internal_file(Context<E> &ctx) {
   ObjectFile<E> *obj = new ObjectFile<E>;
-  ctx.obj_pool.push_back(std::unique_ptr<ObjectFile<E>>(obj));
 
   // Create linker-synthesized symbols.
   auto *esyms = new std::vector<ElfSym<E>>(1);

--- a/macho/main.cc
+++ b/macho/main.cc
@@ -23,7 +23,6 @@ split_string(std::string_view str, char sep) {
 template <typename E>
 static void create_internal_file(Context<E> &ctx) {
   ObjectFile<E> *obj = new ObjectFile<E>;
-  ctx.obj_pool.push_back(std::unique_ptr<ObjectFile<E>>(obj));
   ctx.objs.push_back(obj);
 
   auto add = [&](std::string_view name) {

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -806,8 +806,6 @@ struct Context {
   std::unique_ptr<OutputFile<E>> output_file;
   u8 *buf;
 
-  tbb::concurrent_vector<std::unique_ptr<ObjectFile<E>>> obj_pool;
-  tbb::concurrent_vector<std::unique_ptr<DylibFile<E>>> dylib_pool;
   tbb::concurrent_vector<std::unique_ptr<u8[]>> string_pool;
   tbb::concurrent_vector<std::unique_ptr<MappedFile<Context<E>>>> mf_pool;
   std::vector<std::unique_ptr<OutputSection<E>>> osec_pool;

--- a/macho/object-file.cc
+++ b/macho/object-file.cc
@@ -21,7 +21,6 @@ ObjectFile<E>::create(Context<E> &ctx, MappedFile<Context<E>> *mf,
   obj->mf = mf;
   obj->archive_name = archive_name;
   obj->is_alive = archive_name.empty();
-  ctx.obj_pool.push_back(std::unique_ptr<ObjectFile<E>>(obj));
   return obj;
 };
 
@@ -523,7 +522,6 @@ template <typename E>
 DylibFile<E> *DylibFile<E>::create(Context<E> &ctx, MappedFile<Context<E>> *mf) {
   DylibFile<E> *dylib = new DylibFile<E>;
   dylib->mf = mf;
-  ctx.dylib_pool.push_back(std::unique_ptr<DylibFile<E>>(dylib));
   return dylib;
 };
 


### PR DESCRIPTION
Drop unused (older leftovers?) `mold::elf::Context::obj_pool`,
`mold::elf::Context::dso_pool`, `mold::macho::Context::obj_pool`
and `mold::macho::Context::dylib_pool`, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>