### PR TITLE
[ELF] Fix -Wunused-variable warnings

### DIFF
--- a/elf/input-sections.cc
+++ b/elf/input-sections.cc
@@ -113,7 +113,6 @@ template <typename E>
 void InputSection<E>::dispatch(Context<E> &ctx, Action table[3][4], i64 i,
                                const ElfRel<E> &rel, Symbol<E> &sym) {
   Action action = table[get_output_type(ctx)][get_sym_type(sym)];
-  bool is_code = (shdr().sh_flags & SHF_EXECINSTR);
   bool is_writable = (shdr().sh_flags & SHF_WRITE);
 
   auto error = [&] {


### PR DESCRIPTION
Fix the following `-Wunused-variable` warnings as reported by `gcc`:
```
elf/input-sections.cc:116:8: warning: unused variable ‘is_code’
[-Wunused-variable]
  116 |   bool is_code = (shdr().sh_flags & SHF_EXECINSTR);
```
```
elf/lto.cc:514:16: warning: unused variable ‘st’ [-Wunused-variable]
  514 |   PluginStatus st = claim_file_hook(file, &claimed);
```
Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>