### PR TITLE
[PERF] Use std::call_once to arrange timer record stop

### DIFF
--- a/mold.h
+++ b/mold.h
@@ -543,12 +543,12 @@ struct TimerRecord {
 
   std::string name;
   TimerRecord *parent;
+  std::once_flag once;
   tbb::concurrent_vector<TimerRecord *> children;
   i64 start;
   i64 end;
   i64 user;
   i64 sys;
-  bool stopped = false;
 };
 
 void

--- a/perf.cc
+++ b/perf.cc
@@ -46,16 +46,14 @@ TimerRecord::TimerRecord(std::string name, TimerRecord *parent)
 }
 
 void TimerRecord::stop() {
-  if (stopped)
-    return;
-  stopped = true;
+  std::call_once(once, [&]() {
+    struct rusage usage;
+    getrusage(RUSAGE_SELF, &usage);
 
-  struct rusage usage;
-  getrusage(RUSAGE_SELF, &usage);
-
-  end = now_nsec();
-  user = to_nsec(usage.ru_utime) - user;
-  sys = to_nsec(usage.ru_stime) - sys;
+    end = now_nsec();
+    user = to_nsec(usage.ru_utime) - user;
+    sys = to_nsec(usage.ru_stime) - sys;
+  });
 }
 
 static void print_rec(TimerRecord &rec, i64 indent) {


### PR DESCRIPTION
Prefer `std::once_flag` and `std::call_once()` over plain
C-style flag to arrange (the body of) `TimerRecord::stop()`
to execute just once, adjust related code.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>