### PR TITLE
Use explicit mimalloc new/delete overrides if SYSTEM_MIMALLOC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ endif
 
 ifeq ($(USE_MIMALLOC), 1)
   ifdef SYSTEM_MIMALLOC
+    MOLD_CXXFLAGS += -DSYSTEM_MIMALLOC=1
     MOLD_LDFLAGS += -lmimalloc
   else
     MIMALLOC_LIB = out/mimalloc/libmimalloc.a

--- a/main.cc
+++ b/main.cc
@@ -1,3 +1,7 @@
+#if defined(SYSTEM_MIMALLOC)
+#include <mimalloc-new-delete.h>
+#endif
+
 #include "elf/mold.h"
 #include "macho/mold.h"
 


### PR DESCRIPTION
When building with `SYSTEM_MIMALLOC=1`, linking with (assuming
shared) `-lmimalloc` is not enough to override C++ new/delete
with `mimalloc` versions, and `mimalloc-new-delete.h` should be
included from one (and the only) translation unit as well.

Signed-off-by: Dmitry Antipov <dantipov@cloudlinux.com>