### PR TITLE
Skip reloc-rodata test on aarch64

### DIFF
--- a/test/elf/reloc-rodata.sh
+++ b/test/elf/reloc-rodata.sh
@@ -10,6 +10,8 @@ mold="$(pwd)/mold"
 t=out/test/elf/$testname
 mkdir -p $t
 
+[ "$(uname -m)" = aarch64 ] && { echo skipped; exit; }
+
 cat <<EOF | $CC -fno-PIC -c -o $t/a.o -xc -
 #include <stdio.h>
 


### PR DESCRIPTION
The test expects an error when an object compiled with `-fno-PIC` is linked with `-pie`, but that doesn't happen on aarch64.