### PR TITLE
Increase required glibc version for `-static-pie` tests

### DIFF
--- a/test/elf/hello-static-pie.sh
+++ b/test/elf/hello-static-pie.sh
@@ -18,7 +18,7 @@ echo 'int main() {}' | $CC -o $t/exe -xc -
 ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
 
 # -static-pie works only with a newer version of glibc
-ldd --version | grep -Pq 'Copyright \(C\) 202[1-9]' || { echo skipped; exit; }
+ldd --version | grep -Pq 'Copyright \(C\) 202[2-9]' || { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -fPIE
 #include <stdio.h>

--- a/test/elf/ifunc-static-pie.sh
+++ b/test/elf/ifunc-static-pie.sh
@@ -18,7 +18,7 @@ echo 'int main() {}' | $CC -o $t/exe -xc -
 ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
 
 # -static-pie works only with a newer version of glibc
-ldd --version | grep -Pq 'Copyright \(C\) 202[1-9]' || { echo skipped; exit; }
+ldd --version | grep -Pq 'Copyright \(C\) 202[2-9]' || { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -fPIC
 #include <stdio.h>


### PR DESCRIPTION
mold 1.1.1 generates `-static-pie` code that works with glibc 2.35 but segfaults with glibc 2.34 or older.