### PR TITLE
tests: Improve the version detection of ldd

### DIFF
--- a/test/elf/hello-static-pie.sh
+++ b/test/elf/hello-static-pie.sh
@@ -18,7 +18,7 @@ echo 'int main() {}' | $CC -o $t/exe -xc -
 ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
 
 # -static-pie works only with a newer version of glibc
-ldd --version | grep -Pq 'Copyright \(C\) 202[2-9]' || { echo skipped; exit; }
+ldd --version | grep -Pq 'Copyright (\(C\)|©) 202[2-9]' || { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -fPIE
 #include <stdio.h>

--- a/test/elf/ifunc-static-pie.sh
+++ b/test/elf/ifunc-static-pie.sh
@@ -18,7 +18,7 @@ echo 'int main() {}' | $CC -o $t/exe -xc -
 ldd $t/exe | grep -q ld-musl && { echo OK; exit; }
 
 # -static-pie works only with a newer version of glibc
-ldd --version | grep -Pq 'Copyright \(C\) 202[2-9]' || { echo skipped; exit; }
+ldd --version | grep -Pq 'Copyright (\(C\)|©) 202[2-9]' || { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -fPIC
 #include <stdio.h>


### PR DESCRIPTION
When running with a different locale, the copyright symbol can be different:
```
$ LANG=fr_FR.UTF-8 ldd --version | grep -P 'Copyright'
Copyright © 2021 Free Software Foundation, Inc.
```