### PR TITLE
[ELF][ARM64] Support R_AARCH64_LD_PREL_LO19 relocations

### DIFF
--- a/elf/arch-arm64.cc
+++ b/elf/arch-arm64.cc
@@ -233,7 +233,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       *(u32 *)loc |= (val >> 2) & 0x3ffffff;
       continue;
     }
-    case R_AARCH64_CONDBR19: {
+    case R_AARCH64_CONDBR19:
+    case R_AARCH64_LD_PREL_LO19: {
       i64 val = S + A - P;
       overflow_check(val, -((i64)1 << 20), (i64)1 << 20);
       *(u32 *)loc |= bits(val, 20, 2) << 5;
@@ -452,6 +453,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     case R_AARCH64_ADD_ABS_LO12_NC:
     case R_AARCH64_ADR_PREL_LO21:
     case R_AARCH64_CONDBR19:
+    case R_AARCH64_LD_PREL_LO19:
     case R_AARCH64_LDST16_ABS_LO12_NC:
     case R_AARCH64_LDST32_ABS_LO12_NC:
     case R_AARCH64_LDST64_ABS_LO12_NC:


### PR DESCRIPTION
Implement support for the R_AARCH64_LD_PREL_LO19 relocation type. Since
this actually behaves the same way as R_AARCH64_CONDBR19, reuse the
relevant code.

Signed-off-by: Alois Wohlschlager <alois1@gmx-topmail.de>