### PR TITLE
[ELF] Fix issues caught by UBSan

### DIFF
--- a/elf/main.cc
+++ b/elf/main.cc
@@ -589,7 +589,8 @@ static int elf_main(int argc, char **argv) {
   ctx.dynsym->finalize(ctx);
 
   // Fill .gnu.version_d section contents.
-  ctx.verdef->construct(ctx);
+  if (ctx.verdef)
+    ctx.verdef->construct(ctx);
 
   // Fill .gnu.version_r section contents.
   ctx.verneed->construct(ctx);

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1073,7 +1073,7 @@ private:
   uncompress_contents(Context<E> &ctx, const ElfShdr<E> &shdr,
                       std::string_view name);
 
-  bool has_common_symbol;
+  bool has_common_symbol = false;
 
   std::string_view symbol_strtab;
   const ElfShdr<E> *symtab_sec;


### PR DESCRIPTION
While running tests on UBSan instrumented mold binary 2 separated problems are reported:

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior elf/main.cc:592:15 in
elf/output-chunks.cc:1866:24: runtime error: member call on null pointer of type 'mold::elf::VerdefSection<mold::elf::X86_64> *'

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior elf/output-chunks.cc:1866:24 in
elf/input-files.cc:1000:8: runtime error: load of value 190, which is not a valid value for type 'bool'

This change fixes both of them.

Signed-off-by: Dawid Jurczak <dawid_jurek@vp.pl>