### PR TITLE
Fix memory leak caught by Memcheck

### DIFF
--- a/mold.h
+++ b/mold.h
@@ -611,8 +611,10 @@ MappedFile<C> *MappedFile<C>::open(C &ctx, std::string path) {
     path = ctx.arg.chroot + "/" + path_clean(path);
 
   i64 fd = ::open(path.c_str(), O_RDONLY);
-  if (fd == -1)
+  if (fd == -1) {
+    delete mf;
     return nullptr;
+  }
 
   ctx.mf_pool.push_back(std::unique_ptr<MappedFile>(mf));
 


### PR DESCRIPTION
This patch fix memory leak reported by Memcheck while running some tests.
The problem happen even with --no-quick-exit option.
Before change there are blocks definitely and indirectly lost seen in Memcheck summary:

==1202== LEAK SUMMARY:
==1202==    definitely lost: 1,120 bytes in 14 blocks
==1202==    indirectly lost: 633 bytes in 12 blocks
==1202==      possibly lost: 56,408 bytes in 46 blocks
==1202==    still reachable: 128 bytes in 1 blocks
==1202==         suppressed: 0 bytes in 0 blocks

After change number of such blocks drops to zero:

==2137== LEAK SUMMARY:
==2137==    definitely lost: 0 bytes in 0 blocks
==2137==    indirectly lost: 0 bytes in 0 blocks
==2137==      possibly lost: 56,408 bytes in 46 blocks
==2137==    still reachable: 128 bytes in 1 blocks
==2137==         suppressed: 0 bytes in 0 blocks

Signed-off-by: Dawid Jurczak <dawid_jurek@vp.pl>