### PR TITLE
Make libexec symlink relocatable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ install: all
 	$(STRIP) $D$(LIBDIR)/mold/mold-wrapper.so
 
 	$(INSTALL) -d $D$(LIBEXECDIR)/mold
-	ln -sf $(BINDIR)/mold $D$(LIBEXECDIR)/mold/ld
+	ln -rsf $D$(BINDIR)/mold $D$(LIBEXECDIR)/mold/ld
 
 	$(INSTALL) -d $D$(MANDIR)/man1
 	$(INSTALL_DATA) docs/mold.1 $D$(MANDIR)/man1


### PR DESCRIPTION
Hi!

This is a slight tweak to the symlink in libexec to allow packagers to archive build artifacts, and untar the archive under different paths.

As shown in the commit message, the current link is absolute, so it will not be resolved properly (1) while mold sits in DESTDIR (2) if the build artifacts are deployed under a different PREFIX.

Thank you for your time, and let me know if you need more context about the use-case!
