### PR TITLE
Fix hanging unit test `gdb-index`

### DIFF
--- a/test/elf/gdb-index.sh
+++ b/test/elf/gdb-index.sh
@@ -43,6 +43,7 @@ $QEMU $t/exe | grep -q 'Hello world'
 
 readelf -WS $t/exe | fgrep -q .gdb_index
 
+unset DEBUGINFOD_URLS
 gdb $t/exe -ex 'b main' -ex run -ex cont -ex quit >& /dev/null
 
 echo OK


### PR DESCRIPTION
This affects Fedora >= 35, where debuginfod is enabled by default. On
such systems, gdb shows the following interactive prompt and then waits
forever:
```
This GDB supports auto-downloading debuginfo from the following URLs:
https://debuginfod.fedoraproject.org/
Enable debuginfod for this session? (y or [n])
```

Unsetting the `DEBUGINFOD_URLS` environment variable disables the prompt
as documented here: https://fedoraproject.org/wiki/Debuginfod#Disabling