### PR TITLE
Fix assembler warnings for a testcase.

### DIFF
--- a/test/elf/execstack-if-needed.sh
+++ b/test/elf/execstack-if-needed.sh
@@ -20,7 +20,7 @@ cat <<EOF | $CC -c -xassembler -o $t/a.o -
 .globl main
 main:
   ret
-.section .note.GNU-stack, "ax", @note
+.section .note.GNU-stack, "x", @progbits
 EOF
 
 $CC -B. -o $t/exe $t/a.o >& /dev/null


### PR DESCRIPTION
Fixes:

Testing execstack-if-needed ... {standard input}: Assembler messages:
{standard input}:4: Warning: setting incorrect section type for .note.GNU-stack
{standard input}:4: Warning: setting incorrect section attributes for .note.GNU-stack