### PR TITLE
[ELF] handle DW_FORM_implicit_const in .debug_abbrev

### DIFF
--- a/elf/dwarf.cc
+++ b/elf/dwarf.cc
@@ -163,11 +163,15 @@ find_compunit(Context<E> &ctx, ObjectFile<E> &file, i64 offset) {
     }
 
     // Skip an uninteresting record
+    read_uleb(abbrev); // tag
+    abbrev++; // has_children byte
     for (;;) {
       u64 name = read_uleb(abbrev);
       u64 form = read_uleb(abbrev);
       if (name == 0 && form == 0)
         break;
+      if (form == DW_FORM_implicit_const)
+        read_uleb(abbrev);
     }
   }
 


### PR DESCRIPTION
This one form has an extra uleb field directly in .debug_abbrev, so it needs to be skipped too. This is not a problem with Clang, as that one seems to always put DW_TAG_compile_unit first in .debug_abbrev, but GCC with DWARF5 doesn't and this code didn't find it.
Another stylistic minor problem in this code was that abbrev_code and has_children weren't skipped over, although that got silently handled by the first iteration where the 1-byte has_children flag was read as 1-byte uleb.
