### PR TITLE
[ELF] do not add 0 addresses to .gdb_index

### DIFF
--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -2391,6 +2391,9 @@ void GdbIndexSection<E>::write_address_areas(Context<E> &ctx) {
         // Skip an empty range
         if (addrs[j] == addrs[j + 1])
           continue;
+        // Gdb crashes if there are entries with address 0.
+        if (addrs[j] == 0)
+          continue;
 
         assert(e < begin + file->num_areas);
         e->start = addrs[j];
@@ -2403,7 +2406,7 @@ void GdbIndexSection<E>::write_address_areas(Context<E> &ctx) {
 
     // Fill trailing null entries with dummy values because gdb
     // crashes if there are entries with address 0.
-    u64 filler = (e == begin) ? ctx.etext->get_addr(ctx) - 1 : e[-1].end;
+    u64 filler = (e == begin) ? ctx.etext->get_addr(ctx) - 1 : e[-1].start;
     for (; e < begin + file->num_areas; e++) {
       e->start = e->end = filler;
       e->attr = file->compunits_idx;


### PR DESCRIPTION
GDB crashes in that case in dw2_find_pc_sect_compunit_symtab() for a reason I do not understand. This is presumably what I was trying to avoid already in e0dd53b4ad3ccf39568cc50d8553ec561938463e but didn't quite manage (so reverting that part).

I don't understand the problem, but simply dropping 0 address entries seems to be consistent with the "filler" code below, and LLD also does not include the entries despite .debug_rnglists including those entries that start at 0 address.

