### PR TITLE
[ELF] the --gdb-index code does not handle .debug_types

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -234,6 +234,9 @@ void ObjectFile<E>::initialize_sections(Context<E> &ctx) {
           debug_pubtypes = isec;
           isec->is_alive = false;
         }
+
+        if (name == ".debug_types")
+          has_debug_types = true;
       }
 
       static Counter counter("regular_sections");

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1162,6 +1162,7 @@ public:
   InputSection<E> *debug_rnglists = nullptr;
   InputSection<E> *debug_pubnames = nullptr;
   InputSection<E> *debug_pubtypes = nullptr;
+  bool has_debug_types = false;
   std::vector<std::string_view> compunits;
   std::vector<GdbIndexName> gdb_names;
   i64 compunits_idx = 0;

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -2131,6 +2131,12 @@ void NotePropertySection<E>::copy_buf(Context<E> &ctx) {
 // a library such as libdwarf. But we don't use any library because we
 // don't want to add an extra run-time dependency just for --gdb-index.
 //
+// .gdb_index may contain also a mapping to type units in .debug_types,
+// which is an like .debug_info but only for types, and it is optional.
+// It also exists only in DWARF 4, has been removed in DWARF 5 and neither
+// GCC nor Clang generate it by default (-fdebug-types-section is needed).
+// As such there is probably little need to support it.
+//
 // This page explains the format of .gdb_index:
 // https://sourceware.org/gdb/onlinedocs/gdb/Index-Section-Format.html
 template <typename E>
@@ -2145,6 +2151,10 @@ void GdbIndexSection<E>::construct(Context<E> &ctx) {
 
       // Count the number of address areas contained in this file.
       file->num_areas = estimate_address_areas(ctx, *file);
+
+      if (file->has_debug_types) {
+        Fatal(ctx) << file << ": --gdb-index: .debug_types not supported";
+      }
     }
   });
 


### PR DESCRIPTION
And there is probably little need to do so, since it's DWARF4-only and requires explicit -fdebug-types-section, but at least detect and abort in this case.

I think that with this the .gdb_index support can be considered practically complete (unless somebody decides that support for either .debug_types or DWARF64 is worth the effort).
