### PR TITLE
Add UBSan support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-# If you want to enable ASAN, run `make` with the following options:
+# If you want to enable ASAN and UBSan, run `make` with the following options:
 #
-# make CXXFLAGS='-fsanitize=address -g' LDFLAGS=-fsanitize=address USE_MIMALLOC=0
+# make CXXFLAGS="-fsanitize=address -fsanitize=undefined -g" \
+#      LDFLAGS="-fsanitize=address -fsanitize=undefined" USE_MIMALLOC=0
 
 VERSION = 1.2.1
 

--- a/elf/arch-arm64.cc
+++ b/elf/arch-arm64.cc
@@ -104,7 +104,7 @@ void EhFrameSection<E>::apply_reloc(Context<E> &ctx, ElfRel<E> &rel,
     *(u64 *)loc = val;
     return;
   case R_AARCH64_PREL32:
-    *(u32 *)loc = val - this->shdr.sh_addr - offset;
+    *(Packed<u32, 1> *)loc = val - this->shdr.sh_addr - offset;
     return;
   case R_AARCH64_PREL64:
     *(u64 *)loc = val - this->shdr.sh_addr - offset;
@@ -153,14 +153,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     switch (rel.r_type) {
     case R_AARCH64_ABS64:
       if (sym.is_absolute() || !ctx.arg.pic) {
-        *(u64 *)loc = S + A;
+        *(Packed<u64, 1> *)loc = S + A;
       } else if (sym.is_imported) {
         *dynrel++ = {P, R_AARCH64_ABS64, (u32)sym.get_dynsym_idx(ctx), A};
         *(u64 *)loc = A;
       } else {
         if (!is_relr_reloc(ctx, rel))
           *dynrel++ = {P, R_AARCH64_RELATIVE, 0, (i64)(S + A)};
-        *(u64 *)loc = S + A;
+        *(Packed<u64, 1> *)loc = S + A;
       }
       continue;
     case R_AARCH64_LDST8_ABS_LO12_NC:
@@ -370,12 +370,12 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     switch (rel.r_type) {
     case R_AARCH64_ABS64:
       if (std::optional<u64> val = get_tombstone(sym))
-        *(u64 *)loc = *val;
+        *(Packed<u64, 1> *)loc = *val;
       else
-        *(u64 *)loc = S + A;
+        *(Packed<u64, 1> *)loc = S + A;
       continue;
     case R_AARCH64_ABS32:
-      *(u32 *)loc = S + A;
+      *(Packed<u32, 1> *)loc = S + A;
       continue;
     default:
       Fatal(ctx) << *this << ": invalid relocation for non-allocated sections: "

--- a/elf/arch-x86-64.cc
+++ b/elf/arch-x86-64.cc
@@ -18,7 +18,7 @@ static void write_compact_plt(Context<E> &ctx) {
   for (Symbol<E> *sym : ctx.plt->symbols) {
     u8 *ent = buf + sym->get_plt_idx(ctx) * ctx.plt_size;
     memcpy(ent, data, sizeof(data));
-    *(u32 *)(ent + 2) = sym->get_gotplt_addr(ctx) - sym->get_plt_addr(ctx) - 6;
+    *(pu32 *)(ent + 2) = sym->get_gotplt_addr(ctx) - sym->get_plt_addr(ctx) - 6;
   }
 }
 
@@ -51,7 +51,7 @@ static void write_ibtplt(Context<E> &ctx) {
 
   memcpy(buf, plt0, sizeof(plt0));
   *(u32 *)(buf + 8) = ctx.gotplt->shdr.sh_addr - ctx.plt->shdr.sh_addr - 4;
-  *(u32 *)(buf + 14) = ctx.gotplt->shdr.sh_addr - ctx.plt->shdr.sh_addr - 2;
+  *(pu32 *)(buf + 14) = ctx.gotplt->shdr.sh_addr - ctx.plt->shdr.sh_addr - 2;
 
   // Write PLT entries
   i64 relplt_idx = 0;
@@ -65,7 +65,7 @@ static void write_ibtplt(Context<E> &ctx) {
   for (Symbol<E> *sym : ctx.plt->symbols) {
     u8 *ent = buf + ctx.plt_hdr_size + sym->get_plt_idx(ctx) * ctx.plt_size;
     memcpy(ent, data, sizeof(data));
-    *(u32 *)(ent + 6) = relplt_idx++;
+    *(pu32 *)(ent + 6) = relplt_idx++;
     *(u32 *)(ent + 12) = sym->get_gotplt_addr(ctx) - sym->get_plt_addr(ctx) - 16;
   }
 }
@@ -82,7 +82,7 @@ static void write_plt(Context<E> &ctx) {
   };
 
   memcpy(buf, plt0, sizeof(plt0));
-  *(u32 *)(buf + 2) = ctx.gotplt->shdr.sh_addr - ctx.plt->shdr.sh_addr + 2;
+  *(pu32 *)(buf + 2) = ctx.gotplt->shdr.sh_addr - ctx.plt->shdr.sh_addr + 2;
   *(u32 *)(buf + 8) = ctx.gotplt->shdr.sh_addr - ctx.plt->shdr.sh_addr + 4;
 
   // Write PLT entries
@@ -97,8 +97,8 @@ static void write_plt(Context<E> &ctx) {
   for (Symbol<E> *sym : ctx.plt->symbols) {
     u8 *ent = buf + ctx.plt_hdr_size + sym->get_plt_idx(ctx) * ctx.plt_size;
     memcpy(ent, data, sizeof(data));
-    *(u32 *)(ent + 2) = sym->get_gotplt_addr(ctx) - sym->get_plt_addr(ctx) - 6;
-    *(u32 *)(ent + 7) = relplt_idx++;
+    *(pu32 *)(ent + 2) = sym->get_gotplt_addr(ctx) - sym->get_plt_addr(ctx) - 6;
+    *(Packed<u32, 1> *)(ent + 7) = relplt_idx++;
     *(u32 *)(ent + 12) = ctx.plt->shdr.sh_addr - sym->get_plt_addr(ctx) - 16;
   }
 }
@@ -125,7 +125,7 @@ void PltGotSection<E>::copy_buf(Context<E> &ctx) {
   for (Symbol<E> *sym : symbols) {
     u8 *ent = buf + sym->get_pltgot_idx(ctx) * X86_64::pltgot_size;
     memcpy(ent, data, sizeof(data));
-    *(u32 *)(ent + 2) = sym->get_got_addr(ctx) - sym->get_plt_addr(ctx) - 6;
+    *(pu32 *)(ent + 2) = sym->get_got_addr(ctx) - sym->get_plt_addr(ctx) - 6;
   }
 }
 
@@ -144,10 +144,10 @@ void EhFrameSection<E>::apply_reloc(Context<E> &ctx, ElfRel<E> &rel,
     *(u64 *)loc = val;
     return;
   case R_X86_64_PC32:
-    *(u32 *)loc = val - this->shdr.sh_addr - offset;
+    *(Packed<u32, 1> *)loc = val - this->shdr.sh_addr - offset;
     return;
   case R_X86_64_PC64:
-    *(u64 *)loc = val - this->shdr.sh_addr - offset;
+    *(Packed<u64, 1> *)loc = val - this->shdr.sh_addr - offset;
     return;
   }
   unreachable();
@@ -271,26 +271,26 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
 
     auto write16 = [&](u64 val) {
       overflow_check(val, 0, 1 << 16);
-      *(u16 *)loc = val;
+      *(Packed<u16, 1> *)loc = val;
     };
 
     auto write16s = [&](u64 val) {
       overflow_check(val, -(1 << 15), 1 << 15);
-      *(u16 *)loc = val;
+      *(Packed<u16, 1> *)loc = val;
     };
 
     auto write32 = [&](u64 val) {
       overflow_check(val, 0, (i64)1 << 32);
-      *(u32 *)loc = val;
+      *(Packed<u32, 1> *)loc = val;
     };
 
     auto write32s = [&](u64 val) {
       overflow_check(val, -((i64)1 << 31), (i64)1 << 31);
-      *(u32 *)loc = val;
+      *(Packed<u32, 1> *)loc = val;
     };
 
     auto write64 = [&](u64 val) {
-      *(u64 *)loc = val;
+      *(Packed<u64, 1> *)loc = val;
     };
 
 #define S   (frag_ref ? frag_ref->frag->get_addr(ctx) : sym.get_addr(ctx))
@@ -404,7 +404,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
             0x48, 0x8d, 0x80, 0,    0,    0, 0,       // lea 0(%rax), %rax
           };
           memcpy(loc - 4, insn, sizeof(insn));
-          *(u32 *)(loc + 8) = val;
+          *(Packed<u32, 1> *)(loc + 8) = val;
           break;
         }
         case R_X86_64_PLTOFF64: {
@@ -414,7 +414,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
             0x66, 0x0f, 0x1f, 0x44, 0x00, 0x00,       // nop
           };
           memcpy(loc - 3, insn, sizeof(insn));
-          *(u32 *)(loc + 9) = val;
+          *(Packed<u32, 1> *)(loc + 9) = val;
           break;
         }
         default:
@@ -583,7 +583,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
 
     auto write32 = [&](u64 val) {
       overflow_check(val, 0, (i64)1 << 32);
-      *(u32 *)loc = val;
+      *(Packed<u32, 1> *)loc = val;
     };
 
     auto write32s = [&](u64 val) {
@@ -609,9 +609,9 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       break;
     case R_X86_64_64:
       if (std::optional<u64> val = get_tombstone(sym))
-        *(u64 *)loc = *val;
+        *(Packed<u64, 1> *)loc = *val;
       else
-        *(u64 *)loc = S + A;
+        *(Packed<u64, 1> *)loc = S + A;
       break;
     case R_X86_64_DTPOFF32:
       if (std::optional<u64> val = get_tombstone(sym))

--- a/elf/dwarf.cc
+++ b/elf/dwarf.cc
@@ -65,15 +65,15 @@ std::vector<GdbIndexName> read_pubnames(Context<E> &ctx, ObjectFile<E> &file) {
       if (contents.size() < 14)
         Fatal(ctx) << isec << ": corrupted header";
 
-      u32 len = *(u32 *)contents.data() + 4;
-      u32 debug_info_offset = *(u32 *)(contents.data() + 6);
+      u32 len = *(Packed<u32, 1> *)contents.data() + 4;
+      u32 debug_info_offset = *(Packed<u32, 1> *)(contents.data() + 6);
       u32 cu_idx = get_cu_idx(isec, debug_info_offset);
 
       std::string_view data = contents.substr(14, len - 14);
       contents = contents.substr(len);
 
       while (!data.empty()) {
-        u32 offset = *(u32 *)data.data();
+        u32 offset = *(Packed<u32, 1> *)data.data();
         data = data.substr(4);
         if (offset == 0)
           break;
@@ -125,7 +125,7 @@ static std::tuple<u8 *, u8 *, u32>
 find_compunit(Context<E> &ctx, ObjectFile<E> &file, i64 offset) {
   // Read .debug_info to find the record at a given offset.
   u8 *cu = get_buffer(ctx, ctx.debug_info) + offset;
-  u32 dwarf_version = *(u16 *)(cu + 4);
+  u32 dwarf_version = *(Packed<u16, 1> *)(cu + 4);
   u32 abbrev_offset;
 
   // Skip a header.
@@ -133,14 +133,14 @@ find_compunit(Context<E> &ctx, ObjectFile<E> &file, i64 offset) {
   case 2:
   case 3:
   case 4:
-    abbrev_offset = *(u32 *)(cu + 6);
+    abbrev_offset = *(Packed<u32, 1> *)(cu + 6);
     if (u32 address_size = cu[10]; address_size != E::word_size)
       Fatal(ctx) << file << ": --gdb-index: unsupported address size "
                  << address_size;
     cu += 11;
     break;
   case 5: {
-    abbrev_offset = *(u32 *)(cu + 8);
+    abbrev_offset = *(Packed<u32, 1> *)(cu + 8);
     if (u32 address_size = cu[7]; address_size != E::word_size)
       Fatal(ctx) << file << ": --gdb-index: unsupported address size "
                  << address_size;
@@ -276,19 +276,19 @@ inline u64 DebugInfoReader<E>::read(u64 form) {
   case DW_FORM_strx4:
   case DW_FORM_addrx4:
   case DW_FORM_ref4: {
-    u64 val = *(u32 *)cu;
+    u64 val = *(Packed<u32, 1> *)cu;
     cu += 4;
     return val;
   }
   case DW_FORM_data8:
   case DW_FORM_ref8: {
-    u64 val = *(u64 *)cu;
+    u64 val = *(Packed<u64, 1> *)cu;
     cu += 8;
     return val;
   }
   case DW_FORM_addr:
   case DW_FORM_ref_addr: {
-    u64 val = *(typename E::WordTy *)cu;
+    u64 val = *(Packed<typename E::WordTy, 1> *)cu;
     cu += E::word_size;
     return val;
   }
@@ -313,7 +313,7 @@ inline u64 DebugInfoReader<E>::read(u64 form) {
 // (until an end of list entry).
 template <typename E>
 static std::vector<u64>
-read_debug_range(Context<E> &ctx, ObjectFile<E> &file, typename E::WordTy *range) {
+read_debug_range(Context<E> &ctx, ObjectFile<E> &file, Packed<typename E::WordTy, 1> *range) {
   std::vector<u64> vec;
   u64 base = 0;
 
@@ -368,7 +368,7 @@ read_rnglist_range(Context<E> &ctx, ObjectFile<E> &file, u8 *rnglist,
       rnglist += E::word_size;
       break;
     case DW_RLE_start_length:
-      vec.push_back(*(typename E::WordTy *)rnglist);
+      vec.push_back(*(Packed<typename E::WordTy, 1> *)rnglist);
       rnglist += E::word_size;
       vec.push_back(vec.back() + read_uleb(rnglist));
       break;
@@ -436,8 +436,8 @@ read_address_areas(Context<E> &ctx, ObjectFile<E> &file, i64 offset) {
   // Handle non-contiguous address ranges.
   if (ranges.form) {
     if (dwarf_version <= 4) {
-      typename E::WordTy *range_begin =
-        (typename E::WordTy *)(get_buffer(ctx, ctx.debug_ranges) + ranges.value);
+       Packed<typename E::WordTy, 1> *range_begin =
+        (Packed<typename E::WordTy, 1> *)(get_buffer(ctx, ctx.debug_ranges) + ranges.value);
       return read_debug_range(ctx, file, range_begin);
     }
 

--- a/elf/elf.h
+++ b/elf/elf.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../packed.h"
 #include <cstdint>
 #include <ostream>
 #include <string>
@@ -15,6 +16,14 @@ typedef int8_t i8;
 typedef int16_t i16;
 typedef int32_t i32;
 typedef int64_t i64;
+
+using pu8 = u8;
+using pu16 = Packed<u16, 2>;
+using pu32 = Packed<u32, 2>;
+using pu64 = Packed<u64, 2>;
+using pi32 = Packed<i32, 2>;
+using pi64 = Packed<i64, 2>;
+using pu24 = Packed<u32, 1, 3>;
 
 struct X86_64;
 struct I386;
@@ -1133,13 +1142,13 @@ struct Elf64Sym {
     return st_shndx == SHN_UNDEF && st_bind == STB_WEAK;
   }
 
-  u32 st_name;
-  u8 st_type : 4;
-  u8 st_bind : 4;
-  u8 st_visibility : 2;
-  u16 st_shndx;
-  u64 st_value;
-  u64 st_size;
+  pu32 st_name;
+  pu8 st_type : 4;
+  pu8 st_bind : 4;
+  pu8 st_visibility : 2;
+  pu16 st_shndx;
+  pu64 st_value;
+  pu64 st_size;
 };
 
 struct Elf32Sym {
@@ -1157,114 +1166,118 @@ struct Elf32Sym {
     return st_shndx == SHN_UNDEF && st_bind == STB_WEAK;
   }
 
-  u32 st_name;
-  u32 st_value;
-  u32 st_size;
-  u8 st_type : 4;
-  u8 st_bind : 4;
-  u8 st_visibility : 2;
-  u16 st_shndx;
+  pu32 st_name;
+  pu32 st_value;
+  pu32 st_size;
+  pu8 st_type : 4;
+  pu8 st_bind : 4;
+  pu8 st_visibility : 2;
+  pu16 st_shndx;
 };
 
 struct Elf64Shdr {
-  u32 sh_name;
-  u32 sh_type;
-  u64 sh_flags;
-  u64 sh_addr;
-  u64 sh_offset;
-  u64 sh_size;
-  u32 sh_link;
-  u32 sh_info;
-  u64 sh_addralign;
-  u64 sh_entsize;
+  pu32 sh_name;
+  pu32 sh_type;
+  pu64 sh_flags;
+  pu64 sh_addr;
+  pu64 sh_offset;
+  pu64 sh_size;
+  pu32 sh_link;
+  pu32 sh_info;
+  pu64 sh_addralign;
+  pu64 sh_entsize;
 };
 
 struct Elf32Shdr {
-  u32 sh_name;
-  u32 sh_type;
-  u32 sh_flags;
-  u32 sh_addr;
-  u32 sh_offset;
-  u32 sh_size;
-  u32 sh_link;
-  u32 sh_info;
-  u32 sh_addralign;
-  u32 sh_entsize;
+  pu32 sh_name;
+  pu32 sh_type;
+  pu32 sh_flags;
+  pu32 sh_addr;
+  pu32 sh_offset;
+  pu32 sh_size;
+  pu32 sh_link;
+  pu32 sh_info;
+  pu32 sh_addralign;
+  pu32 sh_entsize;
 };
 
 struct Elf64Ehdr {
-  u8 e_ident[16];
-  u16 e_type;
-  u16 e_machine;
-  u32 e_version;
-  u64 e_entry;
-  u64 e_phoff;
-  u64 e_shoff;
-  u32 e_flags;
-  u16 e_ehsize;
-  u16 e_phentsize;
-  u16 e_phnum;
-  u16 e_shentsize;
-  u16 e_shnum;
-  u16 e_shstrndx;
+  pu8 e_ident[16];
+  pu16 e_type;
+  pu16 e_machine;
+  pu32 e_version;
+  pu64 e_entry;
+  pu64 e_phoff;
+  pu64 e_shoff;
+  pu32 e_flags;
+  pu16 e_ehsize;
+  pu16 e_phentsize;
+  pu16 e_phnum;
+  pu16 e_shentsize;
+  pu16 e_shnum;
+  pu16 e_shstrndx;
 };
 
 struct Elf32Ehdr {
-  u8 e_ident[16];
-  u16 e_type;
-  u16 e_machine;
-  u32 e_version;
-  u32 e_entry;
-  u32 e_phoff;
-  u32 e_shoff;
-  u32 e_flags;
-  u16 e_ehsize;
-  u16 e_phentsize;
-  u16 e_phnum;
-  u16 e_shentsize;
-  u16 e_shnum;
-  u16 e_shstrndx;
+  pu8 e_ident[16];
+  pu16 e_type;
+  pu16 e_machine;
+  pu32 e_version;
+  pu32 e_entry;
+  pu32 e_phoff;
+  pu32 e_shoff;
+  pu32 e_flags;
+  pu16 e_ehsize;
+  pu16 e_phentsize;
+  pu16 e_phnum;
+  pu16 e_shentsize;
+  pu16 e_shnum;
+  pu16 e_shstrndx;
 };
 
 struct Elf64Phdr {
-  u32 p_type;
-  u32 p_flags;
-  u64 p_offset;
-  u64 p_vaddr;
-  u64 p_paddr;
-  u64 p_filesz;
-  u64 p_memsz;
-  u64 p_align;
+  pu32 p_type;
+  pu32 p_flags;
+  pu64 p_offset;
+  pu64 p_vaddr;
+  pu64 p_paddr;
+  pu64 p_filesz;
+  pu64 p_memsz;
+  pu64 p_align;
 };
 
 struct Elf32Phdr {
-  u32 p_type;
-  u32 p_offset;
-  u32 p_vaddr;
-  u32 p_paddr;
-  u32 p_filesz;
-  u32 p_memsz;
-  u32 p_flags;
-  u32 p_align;
+  pu32 p_type;
+  pu32 p_offset;
+  pu32 p_vaddr;
+  pu32 p_paddr;
+  pu32 p_filesz;
+  pu32 p_memsz;
+  pu32 p_flags;
+  pu32 p_align;
 };
 
 struct Elf64Rel {
-  u64 r_offset;
-  u32 r_type;
-  u32 r_sym;
+  pu64 r_offset;
+  pu32 r_type;
+  pu32 r_sym;
 };
 
 struct Elf32Rel {
-  u32 r_offset;
-  u32 r_type : 8;
-  u32 r_sym : 24;
+  Elf32Rel(u64 offset, u32 type, u32 sym) : r_offset(offset), r_type(type), r_sym(sym) {}
+
+  pu32 r_offset;
+  pu8 r_type;
+  pu24 r_sym;
 };
 
 struct Elf64Rela {
-  u64 r_offset;
-  u32 r_type;
-  u32 r_sym;
-  i64 r_addend;
+  Elf64Rela(u64 offset, u32 type, u32 sym, i64 addend) : r_offset(offset), r_type(type), r_sym(sym), r_addend(addend) {}
+
+  pu64 r_offset;
+  pu32 r_type;
+  pu32 r_sym;
+  pi64 r_addend;
 };
 
 struct Elf32Rela {
@@ -1329,9 +1342,9 @@ struct Elf32Chdr {
 };
 
 struct ElfNhdr {
-  u32 n_namesz;
-  u32 n_descsz;
-  u32 n_type;
+  pu32 n_namesz;
+  pu32 n_descsz;
+  pu32 n_type;
 };
 
 struct X86_64 {
@@ -1361,7 +1374,9 @@ template <> struct ElfSym<X86_64> : public Elf64Sym {};
 template <> struct ElfShdr<X86_64> : public Elf64Shdr {};
 template <> struct ElfEhdr<X86_64> : public Elf64Ehdr {};
 template <> struct ElfPhdr<X86_64> : public Elf64Phdr {};
-template <> struct ElfRel<X86_64> : public Elf64Rela {};
+template <> struct ElfRel<X86_64> : public Elf64Rela {
+  ElfRel(u64 offset, u32 type, u32 sym, i64 addend) : Elf64Rela(offset, type, sym, addend) {}
+};
 template <> struct ElfDyn<X86_64> : public Elf64Dyn {};
 template <> struct ElfChdr<X86_64> : public Elf64Chdr {};
 
@@ -1392,7 +1407,9 @@ template <> struct ElfSym<I386> : public Elf32Sym {};
 template <> struct ElfShdr<I386> : public Elf32Shdr {};
 template <> struct ElfEhdr<I386> : public Elf32Ehdr {};
 template <> struct ElfPhdr<I386> : public Elf32Phdr {};
-template <> struct ElfRel<I386> : public Elf32Rel {};
+template <> struct ElfRel<I386> : public Elf32Rel {
+  ElfRel(u64 offset, u32 type, u32 sym) : Elf32Rel(offset, type, sym) {}
+};
 template <> struct ElfDyn<I386> : public Elf32Dyn {};
 template <> struct ElfChdr<I386> : public Elf32Chdr {};
 
@@ -1423,7 +1440,9 @@ template <> struct ElfSym<ARM64> : public Elf64Sym {};
 template <> struct ElfShdr<ARM64> : public Elf64Shdr {};
 template <> struct ElfEhdr<ARM64> : public Elf64Ehdr {};
 template <> struct ElfPhdr<ARM64> : public Elf64Phdr {};
-template <> struct ElfRel<ARM64> : public Elf64Rela {};
+template <> struct ElfRel<ARM64> : public Elf64Rela {
+  ElfRel(u64 offset, u32 type, u32 sym, i64 addend) : Elf64Rela(offset, type, sym, addend) {}
+};
 template <> struct ElfDyn<ARM64> : public Elf64Dyn {};
 template <> struct ElfChdr<ARM64> : public Elf64Chdr {};
 
@@ -1454,7 +1473,9 @@ template <> struct ElfSym<ARM32> : public Elf32Sym {};
 template <> struct ElfShdr<ARM32> : public Elf32Shdr {};
 template <> struct ElfEhdr<ARM32> : public Elf32Ehdr {};
 template <> struct ElfPhdr<ARM32> : public Elf32Phdr {};
-template <> struct ElfRel<ARM32> : public Elf32Rel {};
+template <> struct ElfRel<ARM32> : public Elf32Rel {
+  ElfRel(u64 offset, u32 type, u32 sym) : Elf32Rel(offset, type, sym) {}
+};
 template <> struct ElfDyn<ARM32> : public Elf32Dyn {};
 template <> struct ElfChdr<ARM32> : public Elf32Chdr {};
 
@@ -1484,7 +1505,9 @@ template <> struct ElfSym<RISCV64> : public Elf64Sym {};
 template <> struct ElfShdr<RISCV64> : public Elf64Shdr {};
 template <> struct ElfEhdr<RISCV64> : public Elf64Ehdr {};
 template <> struct ElfPhdr<RISCV64> : public Elf64Phdr {};
-template <> struct ElfRel<RISCV64> : public Elf64Rela {};
+template <> struct ElfRel<RISCV64> : public Elf64Rela {
+  ElfRel(u64 offset, u32 type, u32 sym, i64 addend) : Elf64Rela(offset, type, sym, addend) {}
+};
 template <> struct ElfDyn<RISCV64> : public Elf64Dyn {};
 template <> struct ElfChdr<RISCV64> : public Elf64Chdr {};
 

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -171,7 +171,7 @@ struct CieRecord {
       rel_idx(rel_idx), rels(rels), contents(file.get_string(ctx, isec.shdr())) {}
 
   i64 size() const {
-    return *(u32 *)(contents.data() + input_offset) + 4;
+    return *(pu32 *)(contents.data() + input_offset) + 4;
   }
 
   std::string_view get_contents() const {
@@ -2074,7 +2074,7 @@ std::ostream &operator<<(std::ostream &out, const Symbol<E> &sym) {
 
 template <typename E>
 inline i64 FdeRecord<E>::size(ObjectFile<E> &file) const {
-  return *(u32 *)(file.cies[cie_idx].contents.data() + input_offset) + 4;
+  return *(pu32 *)(file.cies[cie_idx].contents.data() + input_offset) + 4;
 }
 
 template <typename E>
@@ -2165,7 +2165,7 @@ inline i64 InputSection<I386>::get_addend(const ElfRel<I386> &rel) const {
   case R_386_TLS_LDO_32:
   case R_386_SIZE32:
   case R_386_TLS_GOTDESC:
-    return *(u32 *)loc;
+    return *(Packed<u32, 1> *)loc;
   }
   unreachable();
 }

--- a/macho/arch-x86-64.cc
+++ b/macho/arch-x86-64.cc
@@ -13,7 +13,7 @@ void StubsSection<X86_64>::copy_buf(Context<X86_64> &ctx) {
     static_assert(X86_64::stub_size == 6);
     buf[i * 6] = 0xff;
     buf[i * 6 + 1] = 0x25;
-    *(u32 *)(buf + i * 6 + 2) =
+    *(pu32 *)(buf + i * 6 + 2) =
       ctx.lazy_symbol_ptr.hdr.addr + i * X86_64::word_size -
       (this->hdr.addr + i * 6 + 6);
   }
@@ -34,9 +34,9 @@ void StubHelperSection<X86_64>::copy_buf(Context<X86_64> &ctx) {
   static_assert(sizeof(insn0) == X86_64::stub_helper_hdr_size);
 
   memcpy(buf, insn0, sizeof(insn0));
-  *(u32 *)(buf + 3) =
+  *(pu32 *)(buf + 3) =
     get_symbol(ctx, "__dyld_private")->get_addr(ctx) - this->hdr.addr - 7;
-  *(u32 *)(buf + 11) =
+  *(pu32 *)(buf + 11) =
     get_symbol(ctx, "dyld_stub_binder")->get_got_addr(ctx) - this->hdr.addr - 15;
 
   buf += 16;
@@ -50,8 +50,8 @@ void StubHelperSection<X86_64>::copy_buf(Context<X86_64> &ctx) {
     static_assert(sizeof(insn) == X86_64::stub_helper_size);
 
     memcpy(buf, insn, sizeof(insn));
-    *(u32 *)(buf + 1) = ctx.stubs.bind_offsets[i];
-    *(u32 *)(buf + 6) = start - buf - 10;
+    *(pu32 *)(buf + 1) = ctx.stubs.bind_offsets[i];
+    *(pu32 *)(buf + 6) = start - buf - 10;
     buf += 10;
   }
 }
@@ -71,7 +71,7 @@ static i64 get_reloc_addend(u32 type) {
 
 static i64 read_addend(u8 *buf, const MachRel &r) {
   if (r.p2size == 2)
-    return *(i32 *)(buf + r.offset) + get_reloc_addend(r.type);
+    return *(pi32 *)(buf + r.offset) + get_reloc_addend(r.type);
   if (r.p2size == 3)
     return *(i64 *)(buf + r.offset) + get_reloc_addend(r.type);
   unreachable();
@@ -211,7 +211,7 @@ void Subsection<X86_64>::apply_reloc(Context<X86_64> &ctx, u8 *buf) {
       val -= get_addr(ctx) + r.offset + 4 + get_reloc_addend(r.type);
 
     if (r.p2size == 2)
-      *(u32 *)(buf + r.offset) = val;
+      *(pu32 *)(buf + r.offset) = val;
     else if (r.p2size == 3)
       *(u64 *)(buf + r.offset) = val;
     else

--- a/macho/macho.h
+++ b/macho/macho.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../big-endian.h"
+#include "../packed.h"
 
 #include <cassert>
 #include <cstdint>
@@ -18,6 +19,9 @@ typedef int8_t i8;
 typedef int16_t i16;
 typedef int32_t i32;
 typedef int64_t i64;
+
+using pi32 = Packed<i32, 1>;
+using pu32 = Packed<u32, 1>;
 
 static constexpr u32 FAT_MAGIC = 0xcafebabe;
 
@@ -354,8 +358,8 @@ struct MachHeader {
 };
 
 struct LoadCommand {
-  u32 cmd;
-  u32 cmdsize;
+  pu32 cmd;
+  pu32 cmdsize;
 };
 
 struct SegmentCommand {

--- a/packed.h
+++ b/packed.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstring>
+#include <cstdint>
+#include <type_traits>
+
+namespace mold {
+
+template<class ValueType, std::size_t Alignment, std::size_t Sizeof = sizeof(ValueType)>
+class Packed {
+  static_assert(std::is_integral_v<ValueType>, "Integral ValueType is required");
+public:
+  Packed() : value({}) {}
+
+  operator ValueType() const {
+    return read(value.buffer);
+  }
+
+  explicit Packed(const ValueType &other) {
+    write(value.buffer, other);
+  }
+
+  void operator=(ValueType new_value) {
+    write(value.buffer, new_value);
+  }
+
+  Packed &operator+=(ValueType new_value) {
+    *this = *this + new_value;
+    return *this;
+  }
+
+  Packed &operator-=(ValueType new_value) {
+    *this = *this - new_value;
+    return *this;
+  }
+
+  Packed& operator++() {
+    *this = *this + 1;
+    return *this;
+  }
+
+  Packed operator++(int) {
+    Packed old_value = *this;
+    operator++();
+    return old_value;
+  }
+
+  Packed &operator|=(ValueType new_value) {
+    *this = *this | new_value;
+    return *this;
+  }
+private:
+  struct {
+    alignas(Alignment) uint8_t buffer[Sizeof];
+  } value;
+
+  static ValueType read(const void *ptr) {
+    ValueType result = 0;
+    std::memcpy(&result, ptr, Sizeof);
+    return result;
+  }
+
+  static void write(void *ptr, ValueType new_value) {
+    std::memcpy(ptr, &new_value, Sizeof);
+  }
+};
+
+}


### PR DESCRIPTION
Core part of this change is cleaning up Mold from UBSan alignment errors.
Following approach inspired by LLVM's ELFTypes is done here:

    1. Introduce generic Packed class acting as proxy for unaligned aggregated value.
       Every access to such value through proxy is secured by memcpy call.
    2. Replace plain struct members with Packed members wherever it matters.
    3. Use explicit castings through Packed type for misaligned loads.

For more background please check: https://github.com/rui314/mold/discussions/477

Signed-off-by: Dawid Jurczak <dawid_jurek@vp.pl>