### PR TITLE
system mimalloc: link statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 ifeq ($(USE_MIMALLOC), 1)
   ifdef SYSTEM_MIMALLOC
     MOLD_CXXFLAGS += -DUSE_SYSTEM_MIMALLOC
-    MOLD_LDFLAGS += -lmimalloc
+    MOLD_LDFLAGS += -Wl,-whole-archive -l:libmimalloc.a -Wl,-no-whole-archive
   else
     MIMALLOC_LIB = out/mimalloc/libmimalloc.a
     MOLD_CXXFLAGS += -Ithird-party/mimalloc/include


### PR DESCRIPTION
`-lmimalloc` results in dynamic linking by default, but static linking is what we want.

Maybe it would be better to make `mold` a CMake project, given that it's already using `cmake` from `make` anyways, and two of its dependencies have cmake config files?

Edit, just found https://github.com/rui314/mold/pull/49#issuecomment-882649529, sounds good.