### PR TITLE
ICF: explain, implement icf=safe and ignore-data-address-equality.

### DIFF
--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -87,7 +87,7 @@ Options:
   --gdb-index                 Create .gdb_index for faster gdb startup
   --hash-style [sysv,gnu,both]
                               Set hash style
-  --icf=[all,none]            Fold identical code
+  --icf=[all,safe,none]       Fold identical code
     --no-icf
   --image-base ADDR           Set the base address to a given value
   --init SYMBOL               Call SYMBOl at load-time
@@ -767,12 +767,16 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_flag("no-print-gc-sections")) {
       ctx.arg.print_gc_sections = false;
     } else if (read_arg("icf")) {
-      if (arg == "all")
+      if (arg == "all") {
         ctx.arg.icf = true;
-      else if (arg == "none")
+        ctx.arg.icf_all = true;
+      } else if (arg == "safe") {
+        ctx.arg.icf = true;
+      } else if (arg == "none") {
         ctx.arg.icf = false;
-      else
+      } else {
         Fatal(ctx) << "unknown --icf argument: " << arg;
+      }
     } else if (read_flag("no-icf")) {
       ctx.arg.icf = false;
     } else if (read_arg("image-base")) {

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -89,6 +89,8 @@ Options:
                               Set hash style
   --icf=[all,safe,none]       Fold identical code
     --no-icf
+  --ignore-data-address-equality
+                              Allow merging non-executable sections with --icf
   --image-base ADDR           Set the base address to a given value
   --init SYMBOL               Call SYMBOl at load-time
   --no-undefined              Report undefined symbols (even with --shared)
@@ -779,6 +781,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       }
     } else if (read_flag("no-icf")) {
       ctx.arg.icf = false;
+    } else if (read_flag("ignore-data-address-equality")) {
+      ctx.arg.icf_allow_data = true;
     } else if (read_arg("image-base")) {
       ctx.arg.image_base = parse_number(ctx, "image-base", arg);
     } else if (read_flag("print-icf-sections")) {

--- a/elf/elf.h
+++ b/elf/elf.h
@@ -64,6 +64,7 @@ static constexpr u32 SHT_PREINIT_ARRAY = 16;
 static constexpr u32 SHT_GROUP = 17;
 static constexpr u32 SHT_SYMTAB_SHNDX = 18;
 static constexpr u32 SHT_RELR = 19;
+static constexpr u32 SHT_LLVM_ADDRSIG = 0x6fff4c03;
 static constexpr u32 SHT_GNU_HASH = 0x6ffffff6;
 static constexpr u32 SHT_GNU_VERDEF = 0x6ffffffd;
 static constexpr u32 SHT_GNU_VERNEED = 0x6ffffffe;

--- a/elf/icf.cc
+++ b/elf/icf.cc
@@ -40,17 +40,29 @@
 // regular trees are equal. Given this formulation, we want to find as
 // many identical vertices as possible.
 //
-// Solving such problem is computationally intensive, but mold is quite fast.
-// For Chromium, mold's ICF finishes in less than 1 second with 20 threads.
-// This is contrary to lld and gold, which take about 5 and 50 seconds to
-// run ICF under the same condition, respectively.
+// Just like a lot of problems with graph, this problem doesn't have a
+// straightforward "optimal" solution, and we need to resort to heuristics.
 //
-// mold's ICF is faster because we are using a better algorithm.
-// It's actually me who developed and implemented the lld's ICF algorithm,
-// and I can say that mold's algorithm is better than that in all aspects.
-// It scales better for number of available cores, require less overall
-// computation, and has a smaller working set. So, it's better with a single
-// thread and even better with multiple threads.
+// mold approaches this problem by hashing program trees with increasing depth
+// on each iteration.
+// For example, when we start, we only hash individual functions with
+// their call into other functions omitted. From the second iteration, we
+// put the function they call into the hash by appending the hash of those
+// functions from the previous iteration. This means that the nth iteration
+// hashes call chain up to (n-1) levels deep.
+// We use a cryptographic hash function, so the unique number of hashes will
+// only monotonically increase as we take into account of deeper trees with
+// iterations (otherwise, that means we have found a hash collision). We stop
+// when the unique number of hashes stop increasing; this is based on the fact
+// that once we observe an iteration with the same amount of unique hashes as
+// the previous iteration, it will remain unchanged for further iterations.
+// This is provable, but here we omit the proof for brevity.
+//
+// When compared to other approaches, mold's approach has a relatively cheaper
+// cost per iteration, and as a bonus, is highly parallelizable.
+// For Chromium, mold's ICF finishes in less than 1 second with 20 threads,
+// whereas lld takes 5 seconds and gold takes 50 seconds under the same
+// conditions.
 
 #include "mold.h"
 #include "../sha.h"
@@ -183,6 +195,8 @@ struct LeafEq {
   }
 };
 
+// Early merge of leaf nodes, which can be processed without constructing the
+// entire graph. This reduces the vertex count and improves memory efficiency.
 template <typename E>
 static void merge_leaf_nodes(Context<E> &ctx) {
   Timer t(ctx, "merge_leaf_nodes");
@@ -355,6 +369,9 @@ compute_digests(Context<E> &ctx, std::span<InputSection<E> *> sections) {
   return digests;
 }
 
+// Build a graph, treating every function as a vertex and every function call
+// as an edge. See the description at the top for a more detailed formulation.
+// We use u32 indices here to improve cache locality.
 template <typename E>
 static void gather_edges(Context<E> &ctx,
                          std::span<InputSection<E> *> sections,
@@ -516,6 +533,11 @@ void icf_sections(Context<E> &ctx) {
   // Prepare for the propagation rounds.
   std::vector<InputSection<E> *> sections = gather_sections(ctx);
 
+  // We allocate 3 arrays to store hashes for each vertex.
+  // Index 0 and 1 are used for tree hashes from the previous iteration and the current iteration.
+  // They switch roles every iteration --- see `slot` below.
+  // Index 2 stores the initial, single-vertex hash --- this is combined with hashes from the connected vertices to
+  // form the tree hash described above.
   std::vector<std::vector<Digest>> digests(3);
   digests[0] = compute_digests<E>(ctx, sections);
   digests[1].resize(digests[0].size());
@@ -532,6 +554,17 @@ void icf_sections(Context<E> &ctx) {
     Timer t(ctx, "propagate");
     tbb::affinity_partitioner ap;
 
+    // A cheap test that the graph hasn't converged yet.
+    // The loop after this one uses a strict condition, but it's expensive
+    // as it requires sorting the entire hash collection.
+    //
+    // For nodes that have a cycle in downstream (i.e. recursive
+    // functions and functions that calls recursive functions) will always
+    // change with the iterations. Nodes that doesn't (i.e. non-recursive
+    // functions) will stop changing as soon as the propagation depth reaches
+    // the call tree depth.
+    // Here, we test whether we have reached sufficient depth for the latter,
+    // which is a necessary (but not sufficient) condition for convergence.
     i64 num_changed = -1;
     for (;;) {
       i64 n = propagate<E>(digests, edges, edge_indices, slot, ap);
@@ -540,8 +573,12 @@ void icf_sections(Context<E> &ctx) {
       num_changed = n;
     }
 
+    // Run the pass until the unique number of hashes stop increasing, at which
+    // point we have achieved convergence (proof omitted for brevity).
     i64 num_classes = -1;
     for (;;) {
+      // count_num_classes requires sorting which is O(n log n), so do a little
+      // more work beforehand to amortize that log factor.
       for (i64 i = 0; i < 10; i++)
         propagate<E>(digests, edges, edge_indices, slot, ap);
 

--- a/elf/icf.cc
+++ b/elf/icf.cc
@@ -123,7 +123,7 @@ static bool is_eligible(Context<E> &ctx, InputSection<E> &isec) {
   std::string_view name = isec.name();
 
   bool is_alloc = (shdr.sh_flags & SHF_ALLOC);
-  bool is_executable = (shdr.sh_flags & SHF_EXECINSTR);
+  bool type_allowed = ctx.arg.icf_allow_data || (shdr.sh_flags & SHF_EXECINSTR);
   bool is_relro = (name == ".data.rel.ro" ||
                    name.starts_with(".data.rel.ro."));
   bool is_readonly = !(shdr.sh_flags & SHF_WRITE) || is_relro;
@@ -134,7 +134,7 @@ static bool is_eligible(Context<E> &ctx, InputSection<E> &isec) {
   bool is_enumerable = is_c_identifier(name);
   bool is_addr_taken = !ctx.arg.icf_all && isec.address_significant;
 
-  return is_alloc && is_executable && is_readonly && !is_bss &&
+  return is_alloc && type_allowed && is_readonly && !is_bss &&
       !is_empty && !is_init && !is_fini && !is_enumerable && !is_addr_taken;
 }
 

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -475,6 +475,10 @@ static int elf_main(int argc, char **argv) {
   // Set is_import and is_export bits for each symbol.
   compute_import_export(ctx);
 
+  // Read address-significant section information.
+  if (ctx.arg.icf && !ctx.arg.icf_all)
+    mark_addrsig(ctx);
+
   // Garbage-collect unreachable sections.
   if (ctx.arg.gc_sections)
     gc_sections(ctx);

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -327,6 +327,7 @@ public:
   std::atomic_bool is_alive = true;
   u8 p2align = 0;
 
+  u8 address_significant : 1 = false;
   u8 compressed : 1 = false;
   u8 uncompressed : 1 = false;
   u8 killed_by_icf : 1 = false;
@@ -1110,6 +1111,7 @@ public:
                          std::function<void(InputFile<E> *)> feeder) override;
   void convert_undefined_weak_symbols(Context<E> &ctx);
   void resolve_comdat_groups();
+  void fill_addrsig(Context<E> &ctx);
   void eliminate_duplicate_comdat_groups();
   void claim_unresolved_symbols(Context<E> &ctx);
   void scan_relocations(Context<E> &ctx);
@@ -1150,6 +1152,9 @@ public:
   std::vector<std::vector<i32>> r_deltas;
   std::vector<std::vector<ElfRel<E>>> sorted_rels;
   std::vector<std::vector<Symbol<E> *>> sorted_symbols;
+
+  // For ICF
+  InputSection<E> *llvm_addrsig = nullptr;
 
   // For .gdb_index
   InputSection<E> *debug_info = nullptr;
@@ -1385,6 +1390,7 @@ template <typename E> void create_reloc_sections(Context<E> &);
 template <typename E> void apply_version_script(Context<E> &);
 template <typename E> void parse_symbol_version(Context<E> &);
 template <typename E> void compute_import_export(Context<E> &);
+template <typename E> void mark_addrsig(Context<E> &);
 template <typename E> void clear_padding(Context<E> &);
 template <typename E> i64 get_section_rank(Context<E> &, Chunk<E> *chunk);
 template <typename E> i64 set_osec_offsets(Context<E> &);
@@ -1577,6 +1583,7 @@ struct Context {
     bool hash_style_gnu = false;
     bool hash_style_sysv = true;
     bool icf = false;
+    bool icf_all = false;
     bool is_static = false;
     bool lto_pass2 = false;
     bool noinhibit_exec = false;

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1584,6 +1584,7 @@ struct Context {
     bool hash_style_sysv = true;
     bool icf = false;
     bool icf_all = false;
+    bool icf_allow_data = false;
     bool is_static = false;
     bool lto_pass2 = false;
     bool noinhibit_exec = false;

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -1178,6 +1178,14 @@ void compute_import_export(Context<E> &ctx) {
 }
 
 template <typename E>
+void mark_addrsig(Context<E> &ctx) {
+  Timer t(ctx, "mark_addrsig");
+  tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
+    file->fill_addrsig(ctx);
+  });
+}
+
+template <typename E>
 void clear_padding(Context<E> &ctx) {
   Timer t(ctx, "clear_padding");
 
@@ -1679,6 +1687,7 @@ void write_dependency_file(Context<E> &ctx) {
   template void apply_version_script(Context<E> &);                     \
   template void parse_symbol_version(Context<E> &);                     \
   template void compute_import_export(Context<E> &);                    \
+  template void mark_addrsig(Context<E> &);                                   \
   template void clear_padding(Context<E> &);                            \
   template i64 get_section_rank(Context<E> &, Chunk<E> *);              \
   template i64 set_osec_offsets(Context<E> &);                          \

--- a/mold.h
+++ b/mold.h
@@ -280,6 +280,10 @@ inline u64 read_uleb(u8 *&buf) {
   return val;
 }
 
+inline u64 read_uleb(u8 const*&buf) {
+  return read_uleb(const_cast<u8 *&>(buf));
+}
+
 inline i64 uleb_size(u64 val) {
   i64 i = 0;
   do {


### PR DESCRIPTION
Issue #484 and #485.

Statistics on llvm-project libclang.so.15 (@master):

<table>
<thead>
<tr>
	<td> Flags
	<td> Saved bytes
<tbody>
<tr>
	<td> --icf=all
	<td> 3530320
<tr>
	<td> --icf=safe
	<td> 3443898
<tr>
	<td> --icf=safe --ignore-data-address-equality
	<td> 4190222
</table>

LLVM test suite appears to pass.

```
Testing Time: 111.82s
  Skipped          :    39
  Unsupported      :  1637
  Passed           : 77112
  Expectedly Failed:   178
```