### PR TITLE
[macho] Fix checking for absolute address symbol type

### DIFF
--- a/macho/macho.h
+++ b/macho/macho.h
@@ -235,7 +235,7 @@ static constexpr u32 DICE_KIND_JUMP_TABLE32 = 4;
 static constexpr u32 DICE_KIND_ABS_JUMP_TABLE32 = 5;
 
 static constexpr u32 N_UNDF = 0;
-static constexpr u32 N_ABS = 1;
+static constexpr u32 N_ABS = 2;
 static constexpr u32 N_INDR = 5;
 static constexpr u32 N_PBUD = 6;
 static constexpr u32 N_SECT = 7;


### PR DESCRIPTION
MachO has the following struct for [NListType](https://llvm.org/doxygen/BinaryFormat_2MachO_8h_source.html#l00308):

```c
enum NListType : uint8_t {
  // Constants for the "n_type & N_TYPE" llvm::MachO::nlist and
  // llvm::MachO::nlist_64
  N_UNDF = 0x0u, // 0b0000 => 0 for mold
  N_ABS = 0x2u, // 0b0010 => 2 for mold
  N_SECT = 0xeu, // 0b1110 => 7 for mold
  N_PBUD = 0xcu, // 0b1100 => 6 for mold
  N_INDR = 0xau // 0b1010 => 5 for mold
};
```
Not sure how we would go about writing a test for this or if we even need a test for this.

