### PR TITLE
-no-keep-memory breaks mold, passthrough

### DIFF
--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -961,6 +961,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_z_flag("combreloc")) {
     } else if (read_z_flag("nocombreloc")) {
     } else if (read_z_arg("common-page-size")) {
+    } else if (read_flag("no-keep-memory")) {
     } else if (read_arg("version-script")) {
       remaining.push_back("--version-script=" + std::string(arg));
     } else if (read_arg("dynamic-list")) {


### PR DESCRIPTION
existing build systems using -no-keep-memory break when run with mold
PR just adds a pass-through to the cmdline for elf for this