### PR TITLE
[Mach-O] Match block and page size in code directory blob

### DIFF
--- a/macho/mold.h
+++ b/macho/mold.h
@@ -585,7 +585,7 @@ public:
   void compute_size(Context<E> &ctx) override;
   void write_signature(Context<E> &ctx);
 
-  static constexpr i64 BLOCK_SIZE = 4096;
+  static constexpr i64 BLOCK_SIZE = 0x4000;
 };
 
 template <typename E>

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -1084,7 +1084,7 @@ void CodeSignatureSection<E>::compute_size(Context<E> &ctx) {
 }
 
 // A __code_signature section is optional for x86 macOS but mandatory
-// for ARM macOS. The section contains a cryptographic hash for each 4
+// for ARM macOS. The section contains a cryptographic hash for each 16
 // KiB block of an executable or a dylib file. The program loader
 // verifies the hash values on the initial execution of a binary and
 // will reject it if a hash value does not match.


### PR DESCRIPTION
While setting the `BLOCK_SIZE` to `0x2000` does indeed cause a kernel panic (still not fixed in Monterey, verified a minute ago), setting it to page size used by macOS with arm64 (i.e., 16KB), works just fine. I'm also happy to report that this has done in Zig's in-house linker for a few releases now, and we had no reports of spurious crashes or kernel panics.

I don't really have any pre-compiled, large projects to check if this makes a huge difference to startup times and doesn't require the startup trick introduced in f3e1f728d3a307c8269c6aeab926310580c7590f; however, it definitely does reduce the binary bloat, even for small programs. The biggest gains will be for large programs however when the program spans multiple page sizes on disk.

Some example numbers:

```
test/macho/hello.sh

BEFORE: 50144 bytes
AFTER: 49856 bytes
```