### PR TITLE
Better reporting of undefined symbols

### DIFF
--- a/elf/arch-arm32.cc
+++ b/elf/arch-arm32.cc
@@ -316,7 +316,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -370,7 +370,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-arm32.cc
+++ b/elf/arch-arm32.cc
@@ -316,7 +316,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -370,7 +370,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-arm64.cc
+++ b/elf/arch-arm64.cc
@@ -358,7 +358,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -409,7 +409,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-arm64.cc
+++ b/elf/arch-arm64.cc
@@ -358,7 +358,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -409,7 +409,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-i386.cc
+++ b/elf/arch-i386.cc
@@ -336,7 +336,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -442,7 +442,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-i386.cc
+++ b/elf/arch-i386.cc
@@ -336,7 +336,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -442,7 +442,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-riscv64.cc
+++ b/elf/arch-riscv64.cc
@@ -405,7 +405,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -526,7 +526,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-riscv64.cc
+++ b/elf/arch-riscv64.cc
@@ -405,7 +405,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -526,7 +526,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     Symbol<E> &sym = *file.symbols[rel.r_sym];
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-x86-64.cc
+++ b/elf/arch-x86-64.cc
@@ -556,7 +556,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -667,7 +667,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     u8 *loc = (u8 *)(contents.data() + rel.r_offset);
 
     if (!sym.file) {
-      report_undef(ctx, file, sym);
+      report_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/arch-x86-64.cc
+++ b/elf/arch-x86-64.cc
@@ -556,7 +556,7 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 
@@ -667,7 +667,7 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
     u8 *loc = (u8 *)(contents.data() + rel.r_offset);
 
     if (!sym.file) {
-      report_undef(ctx, file, sym, shndx, &rel);
+      add_undef(ctx, file, sym, shndx, &rel);
       continue;
     }
 

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -518,8 +518,10 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.ignore_ir_file.insert(arg);
     } else if (read_flag("demangle")) {
       ctx.arg.demangle = true;
+      opt_demangle = true;
     } else if (read_flag("no-demangle")) {
       ctx.arg.demangle = false;
+      opt_demangle = false;
     } else if (read_flag("default-symver")) {
       ctx.arg.default_symver = true;
     } else if (read_flag("noinhibit-exec")) {

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -995,7 +995,7 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
     // imported symbol, it's handled as if no symbols were found.
     if (sym.file && sym.file->is_dso &&
         (sym.visibility == STV_PROTECTED || sym.visibility == STV_HIDDEN)) {
-      report_undef(ctx, *this, sym, -1, static_cast<ElfRel<E>*>(nullptr));
+      add_undef(ctx, *this, sym, -1, static_cast<ElfRel<E>*>(nullptr));
       continue;
     }
 
@@ -1025,7 +1025,7 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
     };
 
     if (ctx.arg.unresolved_symbols == UNRESOLVED_WARN)
-      report_undef(ctx, *this, sym, -1, static_cast<ElfRel<E>*>(nullptr));
+      add_undef(ctx, *this, sym, -1, static_cast<ElfRel<E>*>(nullptr));
 
     // Convert remaining undefined symbols to dynamic symbols.
     if (ctx.arg.shared) {

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -995,7 +995,7 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
     // imported symbol, it's handled as if no symbols were found.
     if (sym.file && sym.file->is_dso &&
         (sym.visibility == STV_PROTECTED || sym.visibility == STV_HIDDEN)) {
-      report_undef(ctx, *this, sym);
+      report_undef(ctx, *this, sym, -1, static_cast<ElfRel<E>*>(nullptr));
       continue;
     }
 
@@ -1025,7 +1025,7 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
     };
 
     if (ctx.arg.unresolved_symbols == UNRESOLVED_WARN)
-      report_undef(ctx, *this, sym);
+      report_undef(ctx, *this, sym, -1, static_cast<ElfRel<E>*>(nullptr));
 
     // Convert remaining undefined symbols to dynamic symbols.
     if (ctx.arg.shared) {

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -588,6 +588,9 @@ static int elf_main(int argc, char **argv) {
   // be added to .dynsym.
   ctx.dynsym->finalize(ctx);
 
+  // Print reports about undefined symbols, if needed.
+  report_undef(ctx);
+
   // Fill .gnu.version_d section contents.
   if (ctx.verdef)
     ctx.verdef->construct(ctx);

--- a/elf/mapfile.cc
+++ b/elf/mapfile.cc
@@ -84,7 +84,6 @@ void print_map(Context<E> &ctx) {
     tbb::parallel_for((i64)0, (i64)members.size(), [&](i64 i) {
       InputSection<E> *mem = members[i];
       std::ostringstream ss;
-      opt_demangle = ctx.arg.demangle;
       u64 addr = osec->shdr.sh_addr + mem->offset;
 
       ss << std::showbase

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -332,8 +332,10 @@ private:
 };
 
 template <typename E>
-void report_undef(Context<E> &ctx, InputFile<E> &file, Symbol<E> &sym,
-                  u32 shndx, const ElfRel<E> *rel);
+void add_undef(Context<E> &ctx, InputFile<E> &file, Symbol<E> &sym,
+               u32 shndx, const ElfRel<E> *rel);
+template <typename E>
+void report_undef(Context<E> &ctx);
 
 //
 // output-chunks.cc
@@ -1639,8 +1641,16 @@ struct Context {
   std::atomic_bool has_gottp_rel = false;
   std::atomic_bool has_textrel = false;
 
-  // For --warn-once
-  tbb::concurrent_hash_map<void *, int> warned;
+  // Undefined symbols
+  struct Undefined
+  {
+    InputFile<E> &file;
+    Symbol<E> &sym;
+    u32 shndx; // -1 if invalid
+    const ElfRel<E>* rel;
+  };
+  tbb::concurrent_vector<Undefined> undefined;
+  std::atomic_bool undefined_done = false;
 
   // Output chunks
   std::unique_ptr<OutputEhdr<E>> ehdr;

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -332,7 +332,8 @@ private:
 };
 
 template <typename E>
-void report_undef(Context<E> &ctx, InputFile<E> &file, Symbol<E> &sym);
+void report_undef(Context<E> &ctx, InputFile<E> &file, Symbol<E> &sym,
+                  u32 shndx, const ElfRel<E> *rel);
 
 //
 // output-chunks.cc

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1066,6 +1066,10 @@ public:
 
   std::span<Symbol<E> *> get_global_syms();
 
+  std::string_view symbol_strtab_name( ul32 st_name ) const {
+    return symbol_strtab.data() + st_name;
+  }
+
   MappedFile<Context<E>> *mf = nullptr;
   std::span<ElfShdr<E>> elf_sections;
   std::span<ElfSym<E>> elf_syms;
@@ -1091,6 +1095,8 @@ public:
 
 protected:
   std::unique_ptr<Symbol<E>[]> local_syms;
+
+  std::string_view symbol_strtab;
 };
 
 // ObjectFile represents an input .o file.
@@ -1178,7 +1184,6 @@ private:
 
   bool has_common_symbol = false;
 
-  std::string_view symbol_strtab;
   const ElfShdr<E> *symtab_sec;
   std::span<u32> symtab_shndx_sec;
 };
@@ -1213,7 +1218,6 @@ private:
   std::vector<std::string_view> read_verdef(Context<E> &ctx);
 
   std::vector<u16> versyms;
-  std::string_view symbol_strtab;
   const ElfShdr<E> *symtab_sec;
 };
 

--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -291,6 +291,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.dead_strip_dylibs = true;
     } else if (read_flag("-demangle")) {
       ctx.arg.demangle = true;
+      opt_demangle = true;
     } else if (read_flag("-dylib")) {
       ctx.output_type = MH_DYLIB;
     } else if (read_hex("-headerpad")) {

--- a/mold.h
+++ b/mold.h
@@ -65,7 +65,7 @@ template <typename C> class OutputFile;
 
 inline char *output_tmpfile;
 inline char *socket_tmpfile;
-inline thread_local bool opt_demangle;
+inline bool opt_demangle = true;
 
 inline u8 *output_buffer_start = nullptr;
 inline u8 *output_buffer_end = nullptr;
@@ -85,7 +85,6 @@ template <typename C>
 class SyncOut {
 public:
   SyncOut(C &ctx, std::ostream &out = std::cout) : out(out) {
-    opt_demangle = ctx.arg.demangle;
   }
 
   ~SyncOut() {

--- a/test/elf/demangle.sh
+++ b/test/elf/demangle.sh
@@ -21,13 +21,13 @@ int main() {
 EOF
 
 ! $CC -B. -o $t/exe $t/a.o -Wl,-no-demangle 2> $t/log || false
-grep -q 'undefined symbol: .*: _Z3fooii' $t/log
+grep -q 'undefined symbol: _Z3fooii$' $t/log
 
 ! $CC -B. -o $t/exe $t/a.o -Wl,-demangle 2> $t/log || false
-grep -Eq 'undefined symbol: .*: foo\(int, int\)' $t/log
+grep -Eq 'undefined symbol: foo\(int, int\)$' $t/log
 
 ! $CC -B. -o $t/exe $t/a.o 2> $t/log || false
-grep -Eq 'undefined symbol: .*: foo\(int, int\)' $t/log
+grep -Eq 'undefined symbol: foo\(int, int\)$' $t/log
 
 cat <<EOF | $CC -c -o $t/b.o -xc -
 extern int Pi;
@@ -37,6 +37,6 @@ int main() {
 EOF
 
 ! $CC -B. -o $t/exe $t/b.o -Wl,-demangle 2> $t/log || false
-grep -q 'undefined symbol: .*: Pi' $t/log
+grep -q 'undefined symbol: Pi$' $t/log
 
 echo OK

--- a/test/elf/hidden-undef.sh
+++ b/test/elf/hidden-undef.sh
@@ -23,6 +23,7 @@ int main() { foo(); }
 EOF
 
 ! $CC -B. -o $t/exe $t/a.so $t/b.o >& $t/log
-grep -q 'undefined symbol: .*b.o: foo' $t/log
+grep -q 'undefined symbol: foo' $t/log
+grep -q '>>> .*b.o' $t/log
 
 echo OK

--- a/test/elf/missing-error.sh
+++ b/test/elf/missing-error.sh
@@ -22,6 +22,7 @@ int main() {
 EOF
 
 ! ./mold -o $t/exe $t/a.o 2> $t/log || false
-grep -q 'undefined symbol: .*\.o: foo' $t/log
+grep -q 'undefined symbol: foo' $t/log
+grep -q '>>> .*a\.o' $t/log
 
 echo OK

--- a/test/elf/z-defs.sh
+++ b/test/elf/z-defs.sh
@@ -31,7 +31,7 @@ grep -q 'undefined symbol:.* foo' $t/log
 
 $CC -B. -shared -o $t/c.so $t/a.o -Wl,-z,defs \
   -Wl,--warn-unresolved-symbols 2> $t/log
-grep -q 'undefined symbol: .* foo$' $t/log
+grep -q 'undefined symbol:.* foo$' $t/log
 readelf --dyn-syms $t/c.so | grep -q ' foo$'
 
 echo OK


### PR DESCRIPTION
This makes mold's reporting of undefined symbols mostly match lld output (i.e. grouped by symbol, listing the function that referenced it, limiting the size of the output, etc.). One thing that is notably missing is using debuginfo to report the exact source location, which would require interpreting .debug_line .
