### PR TITLE
Don't use grep -P in tests

### DIFF
--- a/test/elf/emit-relocs.sh
+++ b/test/elf/emit-relocs.sh
@@ -25,6 +25,6 @@ EOF
 $CC -B. -o $t/exe $t/a.o -Wl,-emit-relocs
 $QEMU $t/exe | grep -q 'Hello world'
 
-readelf -S $t/exe | grep -Pq 'rela?\.text'
+readelf -S $t/exe | grep -Eq 'rela?\.text'
 
 echo OK

--- a/test/elf/export-dynamic.sh
+++ b/test/elf/export-dynamic.sh
@@ -31,7 +31,7 @@ $CC -shared -fPIC -o $t/b.so -xc /dev/null
 ./mold -o $t/exe $t/a.o $t/b.so --export-dynamic
 
 readelf --dyn-syms $t/exe > $t/log
-grep -Pq 'NOTYPE  GLOBAL DEFAULT    \d+ bar' $t/log
-grep -Pq 'NOTYPE  GLOBAL DEFAULT    \d+ _start' $t/log
+grep -Eq 'NOTYPE  GLOBAL DEFAULT    [0-9]+ bar' $t/log
+grep -Eq 'NOTYPE  GLOBAL DEFAULT    [0-9]+ _start' $t/log
 
 echo OK

--- a/test/elf/gdb-index-compress-output.sh
+++ b/test/elf/gdb-index-compress-output.sh
@@ -53,8 +53,8 @@ $QEMU $t/exe | grep -q 'Hello world'
 DEBUGINFOD_URLS= gdb $t/exe -nx -batch -ex 'b main' -ex r -ex 'b trap' \
   -ex c -ex bt -ex quit >& $t/log
 
-grep -Pq 'hello \(\) at .*<stdin>:7' $t/log
-grep -Pq 'greet \(\) at .*<stdin>:11' $t/log
-grep -Pq 'main \(\) at .*<stdin>:4' $t/log
+grep -q 'hello () at .*<stdin>:7' $t/log
+grep -q 'greet () at .*<stdin>:11' $t/log
+grep -q 'main () at .*<stdin>:4' $t/log
 
 echo OK

--- a/test/elf/gdb-index-dwarf2.sh
+++ b/test/elf/gdb-index-dwarf2.sh
@@ -64,9 +64,9 @@ $QEMU $t/exe | grep -q 'Hello world'
 DEBUGINFOD_URLS= gdb $t/exe -nx -batch -ex 'b main' -ex r -ex 'b trap' \
   -ex c -ex bt -ex quit >& $t/log
 
-grep -Pq 'hello2 \(\) at .*<stdin>:7' $t/log
-grep -Pq 'hello \(\) at .*<stdin>:4' $t/log
-grep -Pq 'greet \(\) at .*<stdin>:8' $t/log
-grep -Pq 'main \(\) at .*<stdin>:4' $t/log
+grep -q 'hello2 () at .*<stdin>:7' $t/log
+grep -q 'hello () at .*<stdin>:4' $t/log
+grep -q 'greet () at .*<stdin>:8' $t/log
+grep -q 'main () at .*<stdin>:4' $t/log
 
 echo OK

--- a/test/elf/gdb-index-dwarf3.sh
+++ b/test/elf/gdb-index-dwarf3.sh
@@ -64,9 +64,9 @@ $QEMU $t/exe | grep -q 'Hello world'
 DEBUGINFOD_URLS= gdb $t/exe -nx -batch -ex 'b main' -ex r -ex 'b trap' \
   -ex c -ex bt -ex quit >& $t/log
 
-grep -Pq 'hello2 \(\) at .*<stdin>:7' $t/log
-grep -Pq 'hello \(\) at .*<stdin>:4' $t/log
-grep -Pq 'greet \(\) at .*<stdin>:8' $t/log
-grep -Pq 'main \(\) at .*<stdin>:4' $t/log
+grep -q 'hello2 () at .*<stdin>:7' $t/log
+grep -q 'hello () at .*<stdin>:4' $t/log
+grep -q 'greet () at .*<stdin>:8' $t/log
+grep -q 'main () at .*<stdin>:4' $t/log
 
 echo OK

--- a/test/elf/gdb-index-dwarf4.sh
+++ b/test/elf/gdb-index-dwarf4.sh
@@ -64,9 +64,9 @@ $QEMU $t/exe | grep -q 'Hello world'
 DEBUGINFOD_URLS= gdb $t/exe -nx -batch -ex 'b main' -ex r -ex 'b trap' \
   -ex c -ex bt -ex quit >& $t/log
 
-grep -Pq 'hello2 \(\) at .*<stdin>:7' $t/log
-grep -Pq 'hello \(\) at .*<stdin>:4' $t/log
-grep -Pq 'greet \(\) at .*<stdin>:8' $t/log
-grep -Pq 'main \(\) at .*<stdin>:4' $t/log
+grep -q 'hello2 () at .*<stdin>:7' $t/log
+grep -q 'hello () at .*<stdin>:4' $t/log
+grep -q 'greet () at .*<stdin>:8' $t/log
+grep -q 'main () at .*<stdin>:4' $t/log
 
 echo OK

--- a/test/elf/gdb-index-dwarf5.sh
+++ b/test/elf/gdb-index-dwarf5.sh
@@ -96,13 +96,13 @@ $QEMU $t/exe | grep -q 'Hello world'
 DEBUGINFOD_URLS= gdb $t/exe -nx -batch -ex 'b main' -ex r -ex 'b trap' \
   -ex c -ex bt -ex quit >& $t/log
 
-grep -Pq 'fn8 \(\) at .*/d.c:6' $t/log
-grep -Pq 'fn7 \(\) at .*/d.c:10' $t/log
-grep -Pq 'fn6 \(\) at .*/c.c:4' $t/log
-grep -Pq 'fn5 \(\) at .*/c.c:8' $t/log
-grep -Pq 'fn4 \(\) at .*/b.c:4' $t/log
-grep -Pq 'fn3 \(\) at .*/b.c:8' $t/log
-grep -Pq 'fn2 \(\) at .*/a.c:4' $t/log
-grep -Pq 'fn1 \(\) at .*/a.c:8' $t/log
+grep -q 'fn8 () at .*/d.c:6' $t/log
+grep -q 'fn7 () at .*/d.c:10' $t/log
+grep -q 'fn6 () at .*/c.c:4' $t/log
+grep -q 'fn5 () at .*/c.c:8' $t/log
+grep -q 'fn4 () at .*/b.c:4' $t/log
+grep -q 'fn3 () at .*/b.c:8' $t/log
+grep -q 'fn2 () at .*/a.c:4' $t/log
+grep -q 'fn1 () at .*/a.c:8' $t/log
 
 echo OK

--- a/test/elf/glibc-2.22-bug.sh
+++ b/test/elf/glibc-2.22-bug.sh
@@ -25,7 +25,7 @@ int main() {
 EOF
 
 $CC -B. -o $t/b.so -shared $t/a.o
-readelf -W --sections $t/b.so | grep -P -A1 '\.rela?\.dyn' | \
-  grep -Pq '\.rela?\.plt'
+readelf -W --sections $t/b.so | grep -E -A1 '\.rela?\.dyn' | \
+  grep -Eq '\.rela?\.plt'
 
 echo OK

--- a/test/elf/oformat-binary.sh
+++ b/test/elf/oformat-binary.sh
@@ -18,6 +18,6 @@ void _start() {}
 EOF
 
 ./mold -o $t/exe $t/a.o --oformat=binary -Ttext=0x4000 -Map=$t/map
-grep -Pq '^\s+0x4000\s+\d+\s+\d+\s+\.text$' $t/map
+grep -Eq '^\s+0x4000\s+[0-9]+\s+[0-9]+\s+\.text$' $t/map
 
 echo OK

--- a/test/elf/run-clang.sh
+++ b/test/elf/run-clang.sh
@@ -16,7 +16,7 @@ mkdir -p $t
 [ "$CC" = cc ] || { echo skipped; exit; }
 
 # ASAN doesn't work with LD_PRELOAD
-nm mold-wrapper.so | grep -Pq '__[at]san_init' && { echo skipped; exit; }
+nm mold-wrapper.so | grep -q '__[at]san_init' && { echo skipped; exit; }
 
 which clang >& /dev/null || { echo skipped; exit; }
 

--- a/test/elf/run.sh
+++ b/test/elf/run.sh
@@ -16,7 +16,7 @@ mkdir -p $t
 [ "$CC" = cc ] || { echo skipped; exit; }
 
 # ASAN doesn't work with LD_PRELOAD
-nm mold-wrapper.so | grep -Pq '__[at]san_init' && { echo skipped; exit; }
+nm mold-wrapper.so | grep -q '__[at]san_init' && { echo skipped; exit; }
 
 cat <<'EOF' | $CC -xc -c -o $t/a.o -
 #include <stdio.h>


### PR DESCRIPTION
The version of grep being used may not support the -P flag
(Perl-compatible regular expressions).