### PR TITLE
armv6 needs linking with libatomic as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ ifeq ($(NEEDS_LIBCRYPTO), 1)
   MOLD_LDFLAGS += -lcrypto
 endif
 
-# '-latomic' flag is needed building on riscv64 system.
+# '-latomic' flag is needed building on armv6/riscv64 systems.
 # Seems like '-atomic' would be better but not working.
-ifeq ($(ARCH), riscv64)
+ifneq (,$(filter armv6% riscv64, $(ARCH)))
   MOLD_LDFLAGS += -latomic
 endif
 


### PR DESCRIPTION
```
mold: error: undefined symbol: __atomic_fetch_add_8
>>> referenced by compress.cc
>>>               out/compress.o:(void tbb::detail::d1::fold_tree<tbb::detail::d1::tree_node>(tbb::detail::d1::node*, tbb::detail::d1::execution_data const&))>>> referenced by arch-arm64.cc
>>>               out/elf/arch-arm64.o:(tbb::detail::d2::for_each_root_task_base<__gnu_cxx::__normal_iterator<mold::elf::InputSection<mold::elf::ARM64>**, std::span<mold::elf::InputSection<mold::elf::ARM64>*, 4294967295u> >, mold::elf::create_range_extension_thunks(mold::elf::Context<mold::elf::ARM64>&, mold::elf::OutputSection<mold::elf::ARM64>&)::{lambda(mold::elf::InputSection<mold::elf::ARM64>*)#2}, mold::elf::InputSection<mold::elf::ARM64>*>::cancel(tbb::detail::d1::execution_data&))>>> referenced by arch-arm64.cc
>>>               out/elf/arch-arm64.o:(tbb::detail::d2::for_each_root_task_base<__gnu_cxx::__normal_iterator<mold::elf::InputSection<mold::elf::ARM64>**, std::span<mold::elf::InputSection<mold::elf::ARM64>*, 4294967295u> >, mold::elf::create_range_extension_thunks(mold::elf::Context<mold::elf::ARM64>&, mold::elf::OutputSection<mold::elf::ARM64>&)::{lambda(mold::elf::InputSection<mold::elf::ARM64>*)#4}, mold::elf::InputSection<mold::elf::ARM64>*>::cancel(tbb::detail::d1::execution_data&))>>> referenced 971 more times

mold: error: undefined symbol: __atomic_load_8
>>> referenced by main.cc
>>>               out/elf/main.o:(mold::elf::Context<mold::elf::X86_64>::~Context())>>> referenced by output-chunks.cc
>>>               out/macho/output-chunks.o:(mold::macho::ExportEncoder::finish())>>> referenced by main.cc
>>>               out/elf/main.o:(mold::elf::Context<mold::elf::I386>::~Context())>>> referenced 3 more times
```