### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/macho/lto.cc
+++ b/macho/lto.cc
@@ -75,7 +75,7 @@ static void do_load_plugin(Context<E> &ctx) {
 
 template <typename E>
 void load_lto_plugin(Context<E> &ctx) {
-  std:call_once(ctx.lto_plugin_loaded, [&]() { do_load_plugin(ctx); });
+  std::call_once(ctx.lto_plugin_loaded, [&]() { do_load_plugin(ctx); });
 }
 
 template <typename E>

--- a/macho/main.cc
+++ b/macho/main.cc
@@ -1,6 +1,5 @@
 #include "mold.h"
 #include "../archive-file.h"
-#include "../cmdline.h"
 #include "../output-file.h"
 #include "../sha.h"
 
@@ -349,8 +348,6 @@ static void merge_cstring_sections(Context<E> &ctx) {
 
   // Decide who will become the owner for each subsection.
   tbb::parallel_for((i64)0, (i64)ctx.objs.size(), [&](i64 i) {
-    ObjectFile<E> *file = ctx.objs[i];
-
     for (i64 j = 0; j < vec[i].size(); j++) {
       SubsecRef &ref = vec[i][j];
       if (ref.ent->owner != &ref.subsec) {

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -944,7 +944,7 @@ template <typename E>
 void ExportSection<E>::compute_size(Context<E> &ctx) {
   for (ObjectFile<E> *file : ctx.objs)
     for (Symbol<E> *sym : file->syms)
-      if (sym && sym->file == file & sym->scope == SCOPE_EXTERN)
+      if (sym && sym->file == file && sym->scope == SCOPE_EXTERN)
         enc.entries.push_back({
             sym->name,
             sym->is_weak ? EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION : 0,


### PR DESCRIPTION
```
macho/lto.cc:78:3: warning: label 'std' defined but not used [-Wunused-label]

macho/../cmdline.h:64:25: warning: 'std::string_view mold::string_trim(std::string_view)' defined but not used [-Wunused-function]

macho/main.cc:352:20: warning: unused variable 'file' [-Wunused-variable]

macho/output-chunks.cc:947:28: warning: suggest parentheses around comparison in operand of '&' [-Wparentheses]
```