### PR TITLE
Fix more compiler warnings

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -61,7 +61,7 @@ std::vector<std::string_view> expand_response_files(C &ctx, char **argv) {
   return vec;
 }
 
-static std::string_view string_trim(std::string_view str) {
+static inline std::string_view string_trim(std::string_view str) {
   size_t pos = str.find_first_not_of(" \t");
   if (pos == str.npos)
     return "";

--- a/elf/lto.cc
+++ b/elf/lto.cc
@@ -620,7 +620,6 @@ std::vector<ObjectFile<E> *> do_lto(Context<E> &ctx) {
       return;
 
     for (i64 i = file->first_global; i < file->symbols.size(); i++) {
-      ElfSym<E> &esym = file->elf_syms[i];
       Symbol<E> &sym = *file->symbols[i];
 
       if (sym.file && !sym.file->is_dso &&

--- a/macho/lto.h
+++ b/macho/lto.h
@@ -62,9 +62,9 @@ struct LTOPlugin {
   void *dlopen_handle = nullptr;
   ~LTOPlugin();
 
-  const char (*get_version)();
+  char (*get_version)();
 
-  const char (*get_error_message)();
+  char (*get_error_message)();
 
   bool (*module_is_object_file)(const char *path);
 

--- a/macho/macho.h
+++ b/macho/macho.h
@@ -20,8 +20,8 @@ typedef int16_t i16;
 typedef int32_t i32;
 typedef int64_t i64;
 
-class ARM64;
-class X86_64;
+struct ARM64;
+struct X86_64;
 
 template <typename E>
 std::string rel_to_string(u8 r_type);

--- a/mold.h
+++ b/mold.h
@@ -311,7 +311,7 @@ inline u64 read_uleb(u8 const*&buf) {
 }
 
 inline i64 uleb_size(u64 val) {
-#pragma unroll
+#pragma GCC unroll 8
   for (int i = 1; i < 9; i++)
     if (val < ((u64)1 << (7 * i)))
       return i;

--- a/third-party/tbb/include/oneapi/tbb/detail/_segment_table.h
+++ b/third-party/tbb/include/oneapi/tbb/detail/_segment_table.h
@@ -542,8 +542,8 @@ protected:
     }
 
     segment_table_allocator_type my_segment_table_allocator;
-    std::atomic<segment_table_type> my_segment_table;
     atomic_segment my_embedded_table[pointers_per_embedded_table];
+    std::atomic<segment_table_type> my_segment_table;
     // Number of segments in first block
     std::atomic<size_type> my_first_block;
     // Number of elements in table


### PR DESCRIPTION
In the long run, I would like to enable `-Wall -Wextra` by default to catch such issues in advance. Unfortunately, we're not there yet - among other things, GCC gives a bunch of warnings about calling `memset()` to initialise a non-trivial object type.