### PR TITLE
Allow shlib undefined attempt 2

### DIFF
--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -55,6 +55,8 @@ Options:
   --Tdata                     Set address to .data
   --Ttext                     Set address to .text
   --allow-multiple-definition Allow multiple definitions
+  --allow-shlib-undefined     Allow undefined symbols in shared libraries (default for --shared)
+    --no-allow-shlib-undefined
   --as-needed                 Only set DT_NEEDED if used
     --no-as-needed
   --build-id [none,md5,sha1,sha256,uuid,HEXSTRING]
@@ -331,6 +333,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
 
   bool version_shown = false;
   bool warn_shared_textrel = false;
+  std::optional<bool> allow_shlib_undefined;
 
   // RISC-V object files contains lots of local symbols, so by default
   // we discard them. This is compatible with GNU ld.
@@ -909,7 +912,9 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_flag("disable-new-dtags")) {
     } else if (read_flag("nostdlib")) {
     } else if (read_flag("allow-shlib-undefined")) {
+      allow_shlib_undefined = true;
     } else if (read_flag("no-allow-shlib-undefined")) {
+      allow_shlib_undefined = false;
     } else if (read_flag("no-add-needed")) {
     } else if (read_flag("no-call-graph-profile-sort")) {
     } else if (read_flag("no-copy-dt-needed-entries")) {
@@ -1044,6 +1049,12 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
   // object file.
   if (ctx.arg.shared)
     ctx.overwrite_output_file = false;
+
+  // By default, this is set to true when building shared objects
+  if (allow_shlib_undefined.has_value())
+    ctx.arg.allow_shlib_undefined = *allow_shlib_undefined;
+  else
+    ctx.arg.allow_shlib_undefined = ctx.arg.shared;
 
   if (version_shown && remaining.empty())
     exit(0);

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -509,6 +509,9 @@ static int elf_main(int argc, char **argv) {
       if (file->needs_executable_stack)
         ctx.arg.z_execstack = true;
 
+  if (!ctx.arg.allow_shlib_undefined)
+    report_shlib_undefined(ctx);
+
   // If we are linking a .so file, remaining undefined symbols does
   // not cause a linker error. Instead, they are treated as if they
   // were imported symbols.

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1198,10 +1198,14 @@ public:
   void compute_symtab(Context<E> &ctx);
   void write_symtab(Context<E> &ctx);
   void report_undefs(Context<E> &ctx);
+  void load_needed(Context<E> &ctx);
 
   bool is_needed = false;
   std::string soname;
+  std::vector<std::string> expanded_paths;
+  std::vector<std::string_view> runpath;
   std::vector<std::string_view> version_strings;
+  std::vector<SharedFile<E> *> needed;
   std::vector<ElfSym<E>> elf_syms2;
 
 private:
@@ -1600,6 +1604,8 @@ struct Context {
   std::vector<std::unique_ptr<OutputSection<E>>> output_sections;
   FileCache<E, ObjectFile<E>> obj_cache;
   FileCache<E, SharedFile<E>> dso_cache;
+
+  tbb::concurrent_hash_map<std::string_view, SharedFile<E> *, HashCmp> needed_dso;
 
   tbb::concurrent_vector<std::unique_ptr<TimerRecord>> timer_records;
   tbb::concurrent_vector<std::function<void()>> on_exit;

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1064,6 +1064,8 @@ public:
   std::span<Symbol<E> *> get_global_syms();
   std::string_view get_source_name() const;
 
+  void report_undef(Context<E> &ctx, const Symbol<E> &sym) const;
+
   MappedFile<Context<E>> *mf = nullptr;
   std::span<ElfShdr<E>> elf_sections;
   std::span<ElfSym<E>> elf_syms;
@@ -1195,6 +1197,7 @@ public:
 
   void compute_symtab(Context<E> &ctx);
   void write_symtab(Context<E> &ctx);
+  void report_undefs(Context<E> &ctx);
 
   bool is_needed = false;
   std::string soname;
@@ -1312,6 +1315,7 @@ template <typename E> void shuffle_sections(Context<E> &);
 template <typename E> std::vector<Chunk<E> *>
 collect_output_sections(Context<E> &);
 template <typename E> void compute_section_sizes(Context<E> &);
+template <typename E> void report_shlib_undefined(Context<E> &);
 template <typename E> void claim_unresolved_symbols(Context<E> &);
 template <typename E> void scan_rels(Context<E> &);
 template <typename E> void construct_relr(Context<E> &);
@@ -1473,6 +1477,7 @@ struct Context {
     bool Bsymbolic = false;
     bool Bsymbolic_functions = false;
     bool allow_multiple_definition = false;
+    bool allow_shlib_undefined;
     bool color_diagnostics = false;
     bool default_symver = false;
     bool demangle = true;

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -867,6 +867,14 @@ void compute_section_sizes(Context<E> &ctx) {
 }
 
 template <typename E>
+void report_shlib_undefined(Context<E> &ctx) {
+  Timer t(ctx, "report_shlib_undefined");
+  tbb::parallel_for_each(ctx.dsos, [&](SharedFile<E> *file) {
+    file->report_undefs(ctx);
+  });
+}
+
+template <typename E>
 void claim_unresolved_symbols(Context<E> &ctx) {
   Timer t(ctx, "claim_unresolved_symbols");
   tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
@@ -1705,6 +1713,7 @@ void write_dependency_file(Context<E> &ctx) {
   template void shuffle_sections(Context<E> &);                         \
   template std::vector<Chunk<E> *> collect_output_sections(Context<E> &); \
   template void compute_section_sizes(Context<E> &);                    \
+  template void report_shlib_undefined(Context<E> &);                   \
   template void claim_unresolved_symbols(Context<E> &);                 \
   template void scan_rels(Context<E> &);                                \
   template void create_reloc_sections(Context<E> &);                    \

--- a/test/elf/shlib-undefined.sh
+++ b/test/elf/shlib-undefined.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+export LC_ALL=C
+set -e
+CC="${TEST_CC:-cc}"
+CXX="${TEST_CXX:-c++}"
+GCC="${TEST_GCC:-gcc}"
+GXX="${TEST_GXX:-g++}"
+OBJDUMP="${OBJDUMP:-objdump}"
+MACHINE="${MACHINE:-$(uname -m)}"
+testname=$(basename "$0" .sh)
+echo -n "Testing $testname ... "
+cd "$(dirname "$0")"/../..
+t=out/test/elf/$testname
+mkdir -p $t
+
+# DSO with an undefined symbol that is referenced
+cat <<'EOF' | $CC -shared -fPIC -o $t/liba.so -xc -
+void fn2();
+void fn1() { fn2(); }
+void fn3() {}
+EOF
+
+# call a function from `liba.so` which uses an undefined symbol
+cat <<'EOF' > $t/b.c
+extern void fn1();
+int main() {
+  fn1();
+  return 0;
+}
+EOF
+
+# default is `--allow-shlib-undefined` for `-shared`
+$CC -B. -shared -fPIC -o $t/libb.so $t/b.c -Wl,-allow-shlib-undefined $t/liba.so
+
+# default is `--no-allow-shlib-undefined` for executables
+output=$($CC -B. -o $t/b $t/b.c -Wl,--no-allow-shlib-undefined $t/liba.so 2>&1 || :)
+echo $output | grep -Eq 'undefined symbol: fn2'
+
+# fails because `fn2` is undefined in `liba.so`
+output=$($CC -B. -shared -fPIC -o $t/libb.so $t/b.c -Wl,--no-allow-shlib-undefined $t/liba.so 2>&1 || :)
+echo $output | grep -Eq 'undefined symbol: fn2'
+
+$CC -B. -o $t/b $t/b.c -Wl,--allow-shlib-undefined $t/liba.so
+
+# DSO with an undefined symbol that is not referenced
+cat <<'EOF' | $CC -shared -fPIC -o $t/liba2.so -xc -
+void fn2();
+void fn1() {}
+void fn3() {}
+EOF
+
+# works because even though `fn2` is undefined, `b.o` doesn't reference it
+$CC -B. -o $t/b $t/b.c $t/liba2.so
+
+echo OK


### PR DESCRIPTION
This PR reverts 33494650fad94111e612a19295762aaf011f37c7 and implements the missing functionality required to fix #559 (also closes #526).

I also checked [this](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=998687) bug out and it looks like the current behavior is the same as gold's and lld's.