### PR TITLE
Fix double git installation in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: rui314/setup-mold@staging
     - name: apt-get
-      run: sudo apt-get update && sudo apt-get install git build-essential libstdc++-10-dev cmake clang libssl-dev zlib1g-dev libtbb-dev git bsdmainutils dwarfdump
+      run: sudo apt-get update && sudo apt-get install git build-essential libstdc++-10-dev cmake clang libssl-dev zlib1g-dev libtbb-dev bsdmainutils dwarfdump
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
     - name: make test


### PR DESCRIPTION
The CI job `build-clang` has duplicated `git` installation.

Signed-off-by: Zhong Ruoyu <zhongruoyu@outlook.com>