### PR TITLE
Fix run.sh failure on musl

### DIFF
--- a/test/elf/run.sh
+++ b/test/elf/run.sh
@@ -39,7 +39,8 @@ grep -q mold $t/log
 ./mold -run /usr/bin/ld.gold --version | grep -q mold
 
 rm -f $t/ld $t/ld.lld $t/ld.gold $t/foo.ld
-touch $t/ld $t/ld.lld $t/ld.gold $t/foo.ld
+touch $t/ld $t/ld.lld $t/ld.gold
+echo "#!/bin/sh" >$t/foo.ld
 chmod 755 $t/ld $t/ld.lld $t/ld.gold $t/foo.ld
 
 ./mold -run $t/ld --version | grep -q mold


### PR DESCRIPTION
The command "mold -run foo.ld" can fail when foo.ld is an empty file.
The musl execvp() call fails with "Exec format error" when the script
to be executed is empty. The fix is to create foo.ld with a valid
Unix shebang.