### PR TITLE
Fix spelling of "support".

### DIFF
--- a/docs/mold.1
+++ b/docs/mold.1
@@ -639,8 +639,8 @@ with something else without taking an address of a function.
 needs to be used with a compiler that supports
 .Sy .llvm_addrsig
 section which contains the information as to what symbols are address-taken. \
-LLVM/Clang supports that section by default. Since GCC does not suppor it yet, \
-you cannot use
+LLVM/Clang supports that section by default. Since GCC does not support it \
+yet, you cannot use
 .Fl -icf=safe
 with GCC (it doesn't do any harm but can't optimize at all.)
 .Pp

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -884,9 +884,9 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_arg("format") || read_arg("b")) {
       if (arg == "binary")
         Fatal(ctx)
-          << "mold does not suppor `-b binary`. If you want to convert a binary"
-          << " file into an object file, use `objcopy -I binary -O default"
-          << " <input-file> <output-file.o>` instead.";
+          << "mold does not support `-b binary`. If you want to convert a"
+          << " binary file into an object file, use `objcopy -I binary -O"
+          << " default <input-file> <output-file.o>` instead.";
       Fatal(ctx) << "unknown command line option: -b " << arg;
     } else if (read_arg("auxiliary") || read_arg("f")) {
       ctx.arg.auxiliary.push_back(arg);


### PR DESCRIPTION
Two (identical) minor typos. Spotted when checking whether mold supports `-b binary` or not.