### PR TITLE
fix wording in readme to speed compared to cp

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ on a simulated 8-core 16-threads machine.
 | Clang 13 (3.18 GiB)           | 64.12s   | 5.82s    | 2.90s
 | Firefox 89 libxul (1.64 GiB)  | 32.95s   | 6.80s    | 1.42s
 
-mold is so fast that it is only 2x _slower_ than `cp` on the same
+mold is so fast that it only takes twice as long to run as running `cp` takes on the same
 machine. Feel free to [file a bug](https://github.com/rui314/mold/issues)
 if you find mold is not faster than other linkers.
 


### PR DESCRIPTION
"2x slower than" is not really wording that makes sense, if you think about it.
I'm even just guessing in my correction of it, that this is what you meant, because it's ambiguous.

Firstly, you just measure the time something takes, and not its "slowness", so the term is kind of confusing as being "slow" is subjective and only makes sense when compared to something else, but in this case you are saying both `mold` and `cp` are slow.

Secondly, if some object is 1cm long, and another is 3cm long, you could say the second one is 3x as big as the first one or the second one is 2x bigger than the first one (1cm + 2 * (1cm) = 3cm).

So, saying it's "2x slower than" would, by this logic mean, if you take "slowness" as "the time it takes to run", that it would take 3x as much time, which I don't think is what you meant.