### PR TITLE
[ELF][RISCV] add R_RISCV_SET32 in EhFrameSection

### DIFF
--- a/elf/arch-riscv64.cc
+++ b/elf/arch-riscv64.cc
@@ -183,6 +183,9 @@ void EhFrameSection<E>::apply_reloc(Context<E> &ctx, const ElfRel<E> &rel,
   case R_RISCV_SET16:
     *(ul16 *)loc = val;
     return;
+  case R_RISCV_SET32:
+    *(ul32 *)loc = val;
+    return;
   case R_RISCV_32_PCREL:
     *(ul32 *)loc = val - this->shdr.sh_addr - offset;
     return;


### PR DESCRIPTION
Hi,

Compiling llvm and mesa with mold gives some linking errors like:
```
mold: fatal: unsupported relocation in .eh_frame: R_RISCV_SET32
```
ref: https://bugs.gentoo.org/861488

From my understanding of llvm riscv backend, it will emit R_RISCV_SET32 as part of DW_CFA_advance_loc4. So is R_RISCV_SET32 missing here or intentionally avoided for some reasons?