### PR TITLE
[elf] Align .symtab's ELF attributes with .dynsym's. 

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1247,7 +1247,7 @@ void ObjectFile<E>::compute_symtab(Context<E> &ctx) {
 }
 
 template <typename E>
-void ObjectFile<E>::write_symtab(Context<E> &ctx) {
+void ObjectFile<E>::export_to_symtab(Context<E> &ctx) {
   ElfSym<E> *symtab_base = (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset);
 
   u8 *strtab_base = ctx.buf + ctx.strtab->shdr.sh_offset;
@@ -1493,7 +1493,7 @@ void SharedFile<E>::compute_symtab(Context<E> &ctx) {
 }
 
 template <typename E>
-void SharedFile<E>::write_symtab(Context<E> &ctx) {
+void SharedFile<E>::export_to_symtab(Context<E> &ctx) {
   ElfSym<E> *symtab =
     (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->global_symtab_idx;
 

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1116,7 +1116,7 @@ public:
   void scan_relocations(Context<E> &ctx);
   void convert_common_symbols(Context<E> &ctx);
   void compute_symtab(Context<E> &ctx);
-  void write_symtab(Context<E> &ctx);
+  void export_to_symtab(Context<E> &ctx);
 
   i64 get_shndx(const ElfSym<E> &esym);
   InputSection<E> *get_section(const ElfSym<E> &esym);
@@ -1198,7 +1198,7 @@ public:
                          std::function<void(InputFile<E> *)> feeder) override;
 
   void compute_symtab(Context<E> &ctx);
-  void write_symtab(Context<E> &ctx);
+  void export_to_symtab(Context<E> &ctx);
 
   bool is_needed = false;
   std::string soname;

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1797,6 +1797,7 @@ public:
 
   bool is_absolute() const;
   bool is_relative() const;
+  bool is_local() const;
 
   InputSection<E> *get_input_section() const;
   u32 get_type() const;
@@ -2507,6 +2508,11 @@ inline bool Symbol<E>::is_absolute() const {
 template <typename E>
 inline bool Symbol<E>::is_relative() const {
   return !is_absolute();
+}
+
+template<typename E>
+inline bool Symbol<E>::is_local() const {
+  return !is_imported && !is_exported;
 }
 
 template <typename E>

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -641,6 +641,10 @@ public:
   void copy_buf(Context<E> &ctx) override;
 };
 
+template<typename E>
+void get_output_esym(Context<E> &ctx, const Symbol<E> &sym, i64 strtab_offset,
+                     ElfSym<E> &out_esym);
+
 template <typename E>
 class SymtabSection : public Chunk<E> {
 public:

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -570,11 +570,11 @@ void SymtabSection<E>::copy_buf(Context<E> &ctx) {
 
   // Copy symbols and symbol names from input files
   tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
-    file->write_symtab(ctx);
+    file->export_to_symtab(ctx);
   });
 
   tbb::parallel_for_each(ctx.dsos, [&](SharedFile<E> *file) {
-    file->write_symtab(ctx);
+    file->export_to_symtab(ctx);
   });
 }
 

--- a/test/elf/symtab.sh
+++ b/test/elf/symtab.sh
@@ -29,7 +29,7 @@ this_is_global:
 module_local:
 EOF
 
-echo '{ local: module_local; };' > $t/c.map
+echo '{ local: module_local; global: *; };' > $t/c.map
 
 ./mold -o $t/exe $t/a.o $t/b.o --version-script=$t/c.map
 
@@ -37,9 +37,9 @@ readelf --symbols $t/exe > $t/log
 
 grep -Eq '0 NOTYPE  LOCAL  DEFAULT .* local1' $t/log
 grep -Eq '0 NOTYPE  LOCAL  DEFAULT .* local2' $t/log
+grep -Eq '0 NOTYPE  LOCAL  DEFAULT .* module_local' $t/log
 grep -Eq '0 NOTYPE  GLOBAL DEFAULT .* foo' $t/log
 grep -Eq '0 NOTYPE  GLOBAL DEFAULT .* bar' $t/log
 grep -Eq '0 NOTYPE  GLOBAL DEFAULT .* this_is_global' $t/log
-grep -Eq '0 NOTYPE  GLOBAL DEFAULT .* module_local' $t/log
 
 echo OK


### PR DESCRIPTION
Plus a few related refactors.

I found that the reference values for elf/symtab.sh was actually wrong, and after updating the reference values I think it's sufficient to act as a regression test for this.

Closes: #592

Unresolved question:
- [ ] The `.dynsym` logic only writes `st_visibility` if the symbol is not absolute nor a TLS object. Is the condition safe? Or should we always carry over `st_visibility` from `sym->visibility` (which is a minimum among input files)?