### PR TITLE
Support derivative OSes when installing dependencies

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -33,16 +33,16 @@ test_id_version() {
     pacman -S --needed --noconfirm base-devel zlib openssl cmake util-linux git
     ;;
   *)
+    echo "Error: don't know anything about build dependencies on $1 $2"
     return 1
     ;;
   esac
 }
 
 if ! test_id_version "$ID" "$VERSION_ID" ; then
-  echo "Error: don't know anything about build dependencies on $ID $VERSION_ID"
   echo "Testing related OS"
   if ! test_id_version "${ID_LIKE%% *}" "$VERSION_ID" ; then
-    echo "Error: don't know anything about build dependencies on ${ID_LIKE%% *} $VERSION_ID"
+    echo "Error: Failed to find matching dependencies for the system"
     exit 1
   fi
 fi

--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -4,35 +4,45 @@ source /etc/os-release
 
 # The first line for each distro installs a build dependency.
 # The second line installs extra packages for `make test`.
+test_id_version() {
+  case "$1$2" in
+  ubuntu20.*)
+    apt-get install -y git cmake libssl-dev zlib1g-dev gcc g++ g++-10
+    apt-get install -y file bsdmainutils
+    ;;
+  ubuntu22.* | debian11)
+    apt-get install -y git cmake libssl-dev zlib1g-dev gcc g++
+    apt-get install -y file bsdmainutils
+    ;;
+  fedora*)
+    dnf install -y git gcc-g++ cmake openssl-devel zlib-devel
+    dnf install -y glibc-static file libstdc++-static diffutils
+    ;;
+  opensuse-leap*)
+    zypper install -y git make cmake zlib-devel libopenssl-devel gcc-c++ gcc11-c++
+    zypper install -y glibc-devel-static tar diffutils util-linux
+    ;;
+  opensuse-tumbleweed*)
+    zypper install -y git make cmake zlib-devel libopenssl-devel gcc-c++
+    zypper install -y glibc-devel-static tar diffutils util-linux
+    ;;
+  gentoo*)
+    emerge dev-vcs/git dev-util/cmake sys-libs/zlib
+    ;;
+  arch*)
+    pacman -S --needed --noconfirm base-devel zlib openssl cmake util-linux git
+    ;;
+  *)
+    return 1
+    ;;
+  esac
+}
 
-case "$ID$VERSION_ID" in
-ubuntu20.*)
-  apt-get install -y git cmake libssl-dev zlib1g-dev gcc g++ g++-10
-  apt-get install -y file bsdmainutils
-  ;;
-ubuntu22.* | debian11)
-  apt-get install -y git cmake libssl-dev zlib1g-dev gcc g++
-  apt-get install -y file bsdmainutils
-  ;;
-fedora*)
-  dnf install -y git gcc-g++ cmake openssl-devel zlib-devel
-  dnf install -y glibc-static file libstdc++-static diffutils
-  ;;
-opensuse-leap*)
-  zypper install -y git make cmake zlib-devel libopenssl-devel gcc-c++ gcc11-c++
-  zypper install -y glibc-devel-static tar diffutils util-linux
-  ;;
-opensuse-tumbleweed*)
-  zypper install -y git make cmake zlib-devel libopenssl-devel gcc-c++
-  zypper install -y glibc-devel-static tar diffutils util-linux
-  ;;
-gentoo*)
-  emerge dev-vcs/git dev-util/cmake sys-libs/zlib
-  ;;
-arch*)
-  pacman -S --needed --noconfirm base-devel zlib openssl cmake util-linux git
-  ;;
-*)
+if ! test_id_version "$ID" "$VERSION_ID" ; then
   echo "Error: don't know anything about build dependencies on $ID $VERSION_ID"
-  exit 1
-esac
+  echo "Testing related OS"
+  if ! test_id_version "${ID_LIKE%% *}" "$VERSION_ID" ; then
+    echo "Error: don't know anything about build dependencies on ${ID_LIKE%% *} $VERSION_ID"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
This PR expands `install-build-deps.sh` to support derivative OSes that set the ID_LIKE variable in `/etc/os-release`.

These changes, in summary, move the existing work into a function, and proceed to call that function with the original "$ID$VERSION_ID" string. If that fails to install dependencies, we check again with the first OS listed in the ID_LIKE variable.