### PR TITLE
Include only what is needed from third-party

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ CFLAGS = -O2
 CXXFLAGS = -O2
 
 MOLD_CXXFLAGS := -std=c++20 -fno-exceptions -fno-unwind-tables \
-                 -fno-asynchronous-unwind-tables -Ithird-party \
+                 -fno-asynchronous-unwind-tables \
+                 -Ithird-party/rust-demangle -Ithird-party/xxhash \
                  -DMOLD_VERSION=\"$(VERSION)\" -DLIBDIR="\"$(LIBDIR)\""
 
 MOLD_LDFLAGS := -pthread -lz -lm -ldl

--- a/demangle.cc
+++ b/demangle.cc
@@ -2,7 +2,7 @@
 
 #include <cstdlib>
 #include <cxxabi.h>
-#include <rust-demangle/rust-demangle.h>
+#include <rust-demangle.h>
 
 namespace mold {
 

--- a/mold.h
+++ b/mold.h
@@ -27,7 +27,7 @@
 #include <vector>
 
 #define XXH_INLINE_ALL 1
-#include <xxhash/xxhash.h>
+#include <xxhash.h>
 
 #ifdef NDEBUG
 #  define unreachable() __builtin_unreachable()


### PR DESCRIPTION
Both rust-demangle and xxhash provide usage instructions with include
paths that do not have an extra directory component. This patch fixes
uses of these libraries in the code and avoids including the third-party
directory wholesale.

Found by https://github.com/rui314/mold/pull/571#discussion_r937135058