### PR TITLE
Initial Windows fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,12 @@ endif()
 add_executable(mold)
 target_compile_features(mold PRIVATE cxx_std_20)
 target_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS})
-target_compile_options(mold PRIVATE -fno-exceptions -fno-unwind-tables
-  -fno-asynchronous-unwind-tables)
+if(NOT MSVC)
+    target_compile_options(mold PRIVATE
+        -fno-exceptions
+        -fno-unwind-tables
+        -fno-asynchronous-unwind-tables)
+endif()
 
 # Build mold with -flto if MOLD_LTO=On
 option(MOLD_LTO "Build mold with link-time optimization enabled")
@@ -59,6 +63,7 @@ if(ZLIB_FOUND)
   target_link_libraries(mold PRIVATE ZLIB::ZLIB)
 else()
   add_subdirectory(third-party/zlib EXCLUDE_FROM_ALL)
+  target_include_directories(zlibstatic INTERFACE third-party/zlib $<TARGET_PROPERTY:zlibstatic,BINARY_DIR>)
   target_link_libraries(mold PRIVATE zlibstatic)
 endif()
 
@@ -131,12 +136,13 @@ if(NOT MSVC)
   endif()
 endif()
 
-find_package(OpenSSL QUIET COMPONENTS Crypto)
-if(OpenSSL_FOUND AND (NOT APPLE AND NOT MOLD_MOSTLY_STATIC))
+if(NOT APPLE AND NOT MOLD_MOSTLY_STATIC AND NOT WIN32)
+  find_package(OpenSSL REQUIRED COMPONENTS Crypto)
   target_link_libraries(mold PRIVATE OpenSSL::Crypto)
-else()
-  target_compile_definitions(mold PRIVATE USE_VENDORERD_SHA256)
-  target_sources(mold PRIVATE third-party/sha256/sha256.cc)
+endif()
+
+if(WIN32)
+    target_compile_definitions(mold PRIVATE NOGDI NOMINMAX)
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES riscv64
@@ -147,11 +153,12 @@ endif()
 set_property(SOURCE main.cc elf/lto.cc macho/output-chunks.cc APPEND PROPERTY
   COMPILE_DEFINITIONS "MOLD_VERSION=\"${CMAKE_PROJECT_VERSION}\"")
 
+find_package(Python3 REQUIRED)
+
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/git-hash.cc
-  COMMAND ${CMAKE_SOURCE_DIR}/update-git-hash.py ${CMAKE_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}/git-hash.cc
-  DEPENDS ${CMAKE_SOURCE_DIR}/update-git-hash.py)
+  OUTPUT git-hash.cc
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/update-git-hash.py ${CMAKE_SOURCE_DIR} git-hash.cc
+  DEPENDS update-git-hash.py)
 
 target_sources(mold PRIVATE
   compress.cc
@@ -197,7 +204,11 @@ target_sources(mold PRIVATE
   macho/tapi.cc
   macho/yaml.cc
   third-party/rust-demangle/rust-demangle.c
-  ${CMAKE_CURRENT_BINARY_DIR}/git-hash.cc)
+  git-hash.cc)
+
+if(MSVC)
+    target_compile_options(mold PRIVATE /bigobj)
+endif()
 
 include(CTest)
 

--- a/demangle.cc
+++ b/demangle.cc
@@ -32,6 +32,9 @@ std::optional<std::string_view> cpp_demangle(std::string_view name) {
   static thread_local char *buf;
   static thread_local size_t buflen;
 
+  // TODO(cwasser): Actually demangle Symbols on Windows using e.g.
+  // `UnDecorateSymbolName` from Dbghelp, maybe even Itanium symbols?
+  #ifndef _WIN32
   if (name.starts_with("_Z")) {
     int status;
     char *p = abi::__cxa_demangle(std::string(name).c_str(), buf, &buflen, &status);
@@ -40,6 +43,8 @@ std::optional<std::string_view> cpp_demangle(std::string_view name) {
       return p;
     }
   }
+  #endif
+
   return {};
 }
 

--- a/demangle.cc
+++ b/demangle.cc
@@ -1,7 +1,10 @@
 #include "mold.h"
 
 #include <cstdlib>
+
+#ifndef _WIN32
 #include <cxxabi.h>
+#endif
 
 #include "third-party/rust-demangle/rust-demangle.h"
 

--- a/elf/arch-arm64.cc
+++ b/elf/arch-arm64.cc
@@ -157,7 +157,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       if (sym.is_absolute() || !ctx.arg.pic) {
         *(ul64 *)loc = S + A;
       } else if (sym.is_imported) {
-        *dynrel++ = {P, R_AARCH64_ABS64, (u32)sym.get_dynsym_idx(ctx), A};
+        *dynrel++ = {P, R_AARCH64_ABS64, (u32)sym.get_dynsym_idx(ctx), (il64)A};
         *(ul64 *)loc = A;
       } else {
         if (!is_relr_reloc(ctx, rel))

--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -251,11 +251,16 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       if (sym.is_absolute() || !ctx.arg.pic) {
         *(ul64 *)loc = S + A;
       } else if (sym.is_imported) {
-        *dynrel++ = {P, R_RISCV_64, (u32)sym.get_dynsym_idx(ctx), A};
+        auto cast_offset = (decltype(ElfRel<E>::r_offset))P;
+        auto cast_addend = (decltype(ElfRel<E>::r_addend))A;
+        *dynrel++ = {cast_offset, R_RISCV_64, (u32)sym.get_dynsym_idx(ctx), cast_addend};
         *(ul64 *)loc = A;
       } else {
-        if (!is_relr_reloc(ctx, rel))
-          *dynrel++ = {P, R_RISCV_RELATIVE, 0, (i64)(S + A)};
+        if (!is_relr_reloc(ctx, rel)) {
+          auto cast_offset = (decltype(ElfRel<E>::r_offset))P;
+          auto cast_addend = (decltype(ElfRel<E>::r_addend))(S + A);
+          *dynrel++ = {cast_offset, R_RISCV_RELATIVE, 0, cast_addend};
+        }
         *(ul64 *)loc = S + A;
       }
       break;

--- a/elf/arch-x86-64.cc
+++ b/elf/arch-x86-64.cc
@@ -253,7 +253,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       if (sym.is_absolute() || !ctx.arg.pic) {
         write64(S + A);
       } else if (sym.is_imported) {
-        *dynrel++ = {P, R_X86_64_64, (u32)sym.get_dynsym_idx(ctx), A};
+        *dynrel++ = {P, R_X86_64_64, (u32)sym.get_dynsym_idx(ctx), (il64)A};
         write64(A);
       } else {
         if (!is_relr_reloc(ctx, rel))
@@ -274,7 +274,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       if (sym.is_absolute() || !sym.is_imported || !ctx.arg.shared) {
         write64(S + A - P);
       } else {
-        *dynrel++ = {P, R_X86_64_64, (u32)sym.get_dynsym_idx(ctx), A};
+        *dynrel++ = {P, R_X86_64_64, (u32)sym.get_dynsym_idx(ctx), (il64)A};
         write64(A);
       }
       continue;

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -332,7 +332,14 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
   std::vector<std::string> remaining;
   std::string_view arg;
 
-  ctx.arg.color_diagnostics = isatty(STDERR_FILENO);
+  ctx.arg.color_diagnostics =
+#ifdef _WIN32
+      _isatty(
+          _fileno(stderr));
+#else
+      isatty(
+          STDERR_FILENO);
+#endif
   ctx.page_size = E::page_size;
 
   bool version_shown = false;
@@ -609,7 +616,14 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.chroot = arg;
     } else if (read_flag("color-diagnostics") ||
                read_flag("color-diagnostics=auto")) {
-      ctx.arg.color_diagnostics = isatty(STDERR_FILENO);
+      ctx.arg.color_diagnostics =
+#ifdef _WIN32
+          _isatty(
+              _fileno(stderr));
+#else
+          isatty(
+              STDERR_FILENO);
+#endif
     } else if (read_flag("color-diagnostics=always")) {
       ctx.arg.color_diagnostics = true;
     } else if (read_flag("color-diagnostics=never")) {

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -212,7 +212,7 @@ static i64 parse_hex(Context<E> &ctx, std::string opt, std::string_view value) {
   static std::regex re(R"((?:0x|0X)?([0-9a-fA-F]+))", flags);
 
   std::cmatch m;
-  if (!std::regex_match(value.begin(), value.end(), m, re))
+  if (!std::regex_match(value.data(), value.data() + value.size(), m, re))
     Fatal(ctx) << "option -" << opt << ": not a hexadecimal number";
   return std::stoul(m[1], nullptr, 16);
 }

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -5,8 +5,11 @@
 #include <sstream>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <unordered_set>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 namespace mold::elf {
 

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1330,7 +1330,7 @@ std::string SharedFile<E>::get_soname(Context<E> &ctx) {
   if (this->mf->given_fullpath)
     return this->filename;
 
-  return filepath(this->filename).filename();
+  return filepath(this->filename).filename().string();
 }
 
 template <typename E>

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -2,7 +2,10 @@
 
 #include <cstring>
 #include <regex>
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 namespace mold::elf {
 

--- a/elf/linker-script.cc
+++ b/elf/linker-script.cc
@@ -146,8 +146,9 @@ read_output_format(Context<E> &ctx, std::span<std::string_view> tok) {
 
 template <typename E>
 static bool is_in_sysroot(Context<E> &ctx, std::string path) {
-  std::string rel =
-    to_abs_path(path).lexically_relative(to_abs_path(ctx.arg.sysroot));
+  std::string rel = to_abs_path(path)
+                        .lexically_relative(to_abs_path(ctx.arg.sysroot))
+                        .string();
   return rel != "." && !rel.starts_with("../");
 }
 

--- a/elf/lto.cc
+++ b/elf/lto.cc
@@ -83,11 +83,14 @@
 
 #include <cstdarg>
 #include <cstring>
-#include <dlfcn.h>
 #include <fcntl.h>
 #include <sstream>
 #include <tbb/parallel_for_each.h>
+
+#ifndef _WIN32
+#include <dlfcn.h>
 #include <unistd.h>
+#endif
 
 #if 0
 # define LOG std::cerr

--- a/elf/lto.cc
+++ b/elf/lto.cc
@@ -445,7 +445,13 @@ static void load_plugin(Context<E> &ctx) {
   phase = 1;
   gctx<E> = &ctx;
 
-  void *handle = dlopen(ctx.arg.plugin.c_str(), RTLD_NOW | RTLD_GLOBAL);
+  void *handle =
+      dlopen(ctx.arg.plugin.c_str()
+#ifndef _WIN32
+        , RTLD_NOW | RTLD_GLOBAL
+#endif
+      );
+
   if (!handle)
     Fatal(ctx) << "could not open plugin file: " << dlerror();
 

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -12,8 +12,11 @@
 #include <sys/types.h>
 #include <tbb/global_control.h>
 #include <tbb/parallel_for_each.h>
-#include <unistd.h>
 #include <unordered_set>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 namespace mold::elf {
 

--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -1,14 +1,17 @@
 #define _GNU_SOURCE 1
 
-#include <alloca.h>
-#include <dlfcn.h>
-#include <spawn.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifndef _WIN32
+#include <alloca.h>
+#include <dlfcn.h>
+#include <spawn.h>
 #include <unistd.h>
+#endif
 
 extern char **environ;
 

--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -65,6 +65,7 @@ static bool is_ld(const char *path) {
          !strcmp(ptr, "ld.gold") || !strcmp(ptr, "ld.bfd");
 }
 
+#ifndef WIN32
 int execvpe(const char *file, char *const *argv, char *const *envp) {
   debug_print("execvpe %s\n", file);
 
@@ -132,3 +133,4 @@ int posix_spawn(pid_t *pid, const char *path,
   typeof(posix_spawn) *real = dlsym(RTLD_NEXT, "posix_spawn");
   return real(pid, path, file_actions, attrp, argv, envp);
 }
+#endif

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -25,11 +25,14 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/task_group.h>
 #include <type_traits>
-#include <unistd.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
 #include <vector>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 // MOLD_DEBUG_{X86_64,ARM64}_ONLY are macros to speed up builds.
 // This should be used only for debugging. When you use this flag,

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -362,7 +362,7 @@ static ElfRel<E> reloc(u64 offset, u32 type, u32 sym, i64 addend = 0) {
   if constexpr (E::is_rel)
     return {(u32)offset, (u8)type, sym};
   else if constexpr (E::word_size == 4)
-    return {offset, (u8)type, sym, addend};
+    return { (ul32)offset, (u8)type, sym, (il32)addend};
   else
     return {offset, type, sym, addend};
 }

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -3,10 +3,13 @@
 
 #include <cctype>
 #include <shared_mutex>
-#include <sys/mman.h>
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_scan.h>
 #include <tbb/parallel_sort.h>
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#endif
 
 namespace mold::elf {
 

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1989,7 +1989,7 @@ static void compute_sha256(Context<E> &ctx, i64 offset) {
   tbb::parallel_for((i64)0, num_shards, [&](i64 i) {
     u8 *begin = buf + shard_size * i;
     u8 *end = (i == num_shards - 1) ? buf + filesize : begin + shard_size;
-    SHA256(begin, end - begin, shards.data() + i * SHA256_SIZE);
+    sha256_hash(begin, end - begin, shards.data() + i * SHA256_SIZE);
 
     // We call munmap early for each chunk so that the last munmap
     // gets cheaper. We assume that the .note.build-id section is
@@ -2002,7 +2002,7 @@ static void compute_sha256(Context<E> &ctx, i64 offset) {
   assert(ctx.arg.build_id.size() <= SHA256_SIZE);
 
   u8 digest[SHA256_SIZE];
-  SHA256(shards.data(), shards.size(), digest);
+  sha256_hash(shards.data(), shards.size(), digest);
   memcpy(buf + offset, digest, ctx.arg.build_id.size());
 
   if (ctx.output_file->is_mmapped) {

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -582,7 +582,7 @@ static std::string create_response_file(Context<E> &ctx) {
   std::string buf;
   std::stringstream out;
 
-  std::string cwd = std::filesystem::current_path();
+  std::string cwd = std::filesystem::current_path().string();
   out << "-C " << cwd.substr(1) << "\n";
 
   if (cwd != "/") {
@@ -616,7 +616,7 @@ void write_repro_file(Context<E> &ctx) {
   std::unordered_set<std::string> seen;
   for (std::unique_ptr<MappedFile<Context<E>>> &mf : ctx.mf_pool) {
     if (!mf->parent) {
-      std::string path = to_abs_path(mf->name);
+      std::string path = to_abs_path(mf->name).string();
       if (seen.insert(path).second)
         tar->append(path, mf->get_contents());
     }
@@ -656,9 +656,9 @@ void sort_init_fini(Context<E> &ctx) {
 
   auto get_priority = [](InputSection<E> *isec) {
     static std::regex re(R"(\.(\d+)$)", std::regex_constants::optimize);
-    std::string name = isec->name().begin();
-    std::smatch m;
-    if (std::regex_search(name, m, re))
+    std::string_view name = isec->name();
+    std::cmatch m;
+    if (std::regex_search(name.data(), name.data() + name.size(), m, re))
       return std::stoi(m[1]);
     return 65536;
   };

--- a/elf/subprocess.cc
+++ b/elf/subprocess.cc
@@ -4,10 +4,13 @@
 #include <filesystem>
 #include <signal.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <sys/types.h>
+
+#ifndef _WIN32
+#include <sys/time.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#endif
 
 namespace mold::elf {
 

--- a/filepath.cc
+++ b/filepath.cc
@@ -7,7 +7,7 @@ namespace mold {
 
 std::string get_realpath(std::string_view path) {
   std::error_code ec;
-  std::string ret = std::filesystem::canonical(path, ec);
+  std::string ret = std::filesystem::canonical(path, ec).string();
   return ec ? std::string(path) : ret;
 }
 
@@ -15,7 +15,7 @@ std::string get_realpath(std::string_view path) {
 // The transformation is done purely by lexical processing.
 // This function does not access file system.
 std::string path_clean(std::string_view path) {
-  return filepath(path).lexically_normal();
+  return filepath(path).lexically_normal().string();
 }
 
 std::filesystem::path to_abs_path(std::filesystem::path path) {

--- a/inttypes.h
+++ b/inttypes.h
@@ -24,6 +24,10 @@
 #include <cstdint>
 #include <cstring>
 
+#ifdef _WIN32
+#include <cstdlib>
+#endif
+
 #ifdef __BIG_ENDIAN__
 #error "mold does not support big-endian hosts"
 #endif
@@ -148,12 +152,25 @@ private:
   uint8_t val[sizeof(T)];
 
   static T bswap(T x) {
-    if constexpr (sizeof(T) == 2)
+    if constexpr (sizeof(T) == 2) {
+#ifdef _WIN32
+      return _byteswap_ushort(x);
+#else
       return __builtin_bswap16(x);
-    else if constexpr (sizeof(T) == 4)
+#endif
+    } else if constexpr (sizeof(T) == 4) {
+#ifdef _WIN32
+      return _byteswap_ulong(x);
+#else
       return __builtin_bswap32(x);
-    else
+#endif
+    } else {
+#ifdef _WIN32
+      return _byteswap_uint64(x);
+#else
       return __builtin_bswap64(x);
+#endif
+    }
   }
 };
 

--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -142,7 +142,7 @@ i64 parse_version(Context<E> &ctx, std::string_view arg) {
   static std::regex re(R"((\d+)(?:\.(\d+))?(?:\.(\d+))?)",
                        std::regex_constants::ECMAScript);
   std::cmatch m;
-  if (!std::regex_match(arg.begin(), arg.end(), m, re))
+  if (!std::regex_match(arg.data(), arg.data() + arg.size(), m, re))
     Fatal(ctx) << "malformed version number: " << arg;
 
   i64 major = (m[1].length() == 0) ? 0 : stoi(m[1]);

--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -6,8 +6,11 @@
 #include <sstream>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <unordered_set>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 namespace mold::macho {
 

--- a/macho/lto.cc
+++ b/macho/lto.cc
@@ -3,7 +3,10 @@
 
 #include <algorithm>
 #include <cstdio>
+
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 
 namespace mold::macho {
 

--- a/macho/lto.cc
+++ b/macho/lto.cc
@@ -25,7 +25,11 @@ static void do_load_plugin(Context<E> &ctx) {
 
   // I don't want to use a macro, but I couldn't find an easy way to
   // write the same thing without a macro.
+#ifdef _WIN32
+#define DLSYM(x) ctx.lto.x = (decltype(ctx.lto.x))GetProcAddress(handle, "lto_" #x)
+#else
 #define DLSYM(x) ctx.lto.x = (decltype(ctx.lto.x))dlsym(handle, "lto_" #x)
+#endif
   DLSYM(get_version);
   DLSYM(get_error_message);
   DLSYM(module_is_object_file);

--- a/macho/lto.h
+++ b/macho/lto.h
@@ -4,6 +4,10 @@
 #include <cstdint>
 #include <sys/types.h>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 namespace mold::macho {
 
 enum LTOSymbolAttributes {
@@ -59,7 +63,12 @@ typedef void LTODiagnosticHandler(LTOCodegenDiagnosticSeverity severity,
                                   const char *diag, void *ctxt);
 
 struct LTOPlugin {
-  void *dlopen_handle = nullptr;
+#ifdef _WIN32
+  HMODULE
+#else
+  void *
+#endif
+  dlopen_handle = nullptr;
   ~LTOPlugin();
 
   char (*get_version)();

--- a/macho/main.cc
+++ b/macho/main.cc
@@ -8,13 +8,16 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/global_control.h>
 #include <tbb/parallel_for_each.h>
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <sys/time.h>
+#endif
 
 namespace mold::macho {
 

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -235,7 +235,7 @@ public:
   u32 input_offset = 0;
   u32 input_size = 0;
   u32 input_addr = 0;
-  u32 output_offset = -1;
+  u32 output_offset = (u32)-1;
   u32 rel_offset = 0;
   u32 nrels = 0;
   u32 unwind_offset = 0;

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -27,7 +27,6 @@
 namespace mold::macho {
 
 static constexpr i64 COMMON_PAGE_SIZE = 0x4000;
-static constexpr i64 SHA256_SIZE = 32;
 
 template <typename E> class Chunk;
 template <typename E> class InputSection;

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -1304,7 +1304,7 @@ void CodeSignatureSection<E>::write_signature(Context<E> &ctx) {
   auto compute_hash = [&](i64 i) {
     u8 *start = ctx.buf + i * E::page_size;
     u8 *end = ctx.buf + std::min<i64>((i + 1) * E::page_size, this->hdr.offset);
-    SHA256(start, end - start, buf + i * SHA256_SIZE);
+    sha256_hash(start, end - start, buf + i * SHA256_SIZE);
   };
 
   for (i64 i = 0; i < num_blocks; i += 1024) {
@@ -1322,7 +1322,7 @@ void CodeSignatureSection<E>::write_signature(Context<E> &ctx) {
   // entire file. We compute its value as a tree hash.
   if (ctx.arg.uuid == UUID_HASH) {
     u8 uuid[SHA256_SIZE];
-    SHA256(ctx.buf + this->hdr.offset, this->hdr.size, uuid);
+    sha256_hash(ctx.buf + this->hdr.offset, this->hdr.size, uuid);
 
     // Indicate that this is UUIDv4 as defined by RFC4122.
     uuid[6] = (uuid[6] & 0b00001111) | 0b01010000;

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -1240,7 +1240,7 @@ void ObjcImageInfoSection<E>::copy_buf(Context<E> &ctx) {
 
 template <typename E>
 void CodeSignatureSection<E>::compute_size(Context<E> &ctx) {
-  std::string filename = filepath(ctx.arg.final_output).filename();
+  std::string filename = filepath(ctx.arg.final_output).filename().string();
   i64 filename_size = align_to(filename.size() + 1, 16);
   i64 num_blocks = align_to(this->hdr.offset, E::page_size) / E::page_size;
   this->hdr.size = sizeof(CodeSignatureHeader) + sizeof(CodeSignatureBlobIndex) +
@@ -1260,7 +1260,7 @@ void CodeSignatureSection<E>::write_signature(Context<E> &ctx) {
   u8 *buf = ctx.buf + this->hdr.offset;
   memset(buf, 0, this->hdr.size);
 
-  std::string filename = filepath(ctx.arg.final_output).filename();
+  std::string filename = filepath(ctx.arg.final_output).filename().string();
   i64 filename_size = align_to(filename.size() + 1, 16);
   i64 num_blocks = align_to(this->hdr.offset, E::page_size) / E::page_size;
 

--- a/macho/output-chunks.cc
+++ b/macho/output-chunks.cc
@@ -2,11 +2,14 @@
 #include "../sha.h"
 
 #include <shared_mutex>
-#include <sys/mman.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_sort.h>
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#endif
 
 namespace mold::macho {
 

--- a/macho/tapi.cc
+++ b/macho/tapi.cc
@@ -152,7 +152,7 @@ static void interpret_ld_symbols(Context<E> &ctx, TextDylib &tbd) {
       R"(\$ld\$previous\$([^$]+)\$([\d.]*)\$(\d+)\$([\d.]+)\$([\d.]+)\$(.*)\$)",
       flags);
 
-    if (std::regex_match(s.begin(), s.end(), m, previous_re)) {
+    if (std::regex_match(s.data(), s.data() + s.size(), m, previous_re)) {
       std::string_view install_name = string_view(m[1]);
       i64 platform = std::stoi(m[3].str());
       i64 min_version = parse_version(m[4]);
@@ -179,7 +179,7 @@ static void interpret_ld_symbols(Context<E> &ctx, TextDylib &tbd) {
     // matches.
     static std::regex add_re(R"(\$ld\$add\$os([\d.]+)\$(.+))", flags);
 
-    if (std::regex_match(s.begin(), s.end(), m, add_re)) {
+    if (std::regex_match(s.data(), s.data() + s.size(), m, add_re)) {
       if (ctx.arg.platform_min_version == parse_version(m[1]))
         syms.insert(string_view(m[2]));
       continue;
@@ -189,7 +189,7 @@ static void interpret_ld_symbols(Context<E> &ctx, TextDylib &tbd) {
     // matches.
     static std::regex hidden_re(R"(\$ld\$hide\$os([\d.]+)\$(.+))", flags);
 
-    if (std::regex_match(s.begin(), s.end(), m, hidden_re)) {
+    if (std::regex_match(s.data(), s.data() + s.size(), m, hidden_re)) {
       if (ctx.arg.platform_min_version == parse_version(m[1]))
         hidden_syms.insert(string_view(m[2]));
       continue;
@@ -200,7 +200,7 @@ static void interpret_ld_symbols(Context<E> &ctx, TextDylib &tbd) {
     static std::regex
       install_name_re(R"(\$ld\$install_name\$os([\d.]+)\$(.+))", flags);
 
-    if (std::regex_match(s.begin(), s.end(), m, install_name_re)) {
+    if (std::regex_match(s.data(), s.data() + s.size(), m, install_name_re)) {
       if (ctx.arg.platform_min_version == parse_version(m[1]))
         tbd.install_name = string_view(m[2]);
       continue;

--- a/main.cc
+++ b/main.cc
@@ -37,19 +37,37 @@ void cleanup() {
 // for the first time.
 //
 // If a disk becomes full as a result of a write to an mmap'ed memory
-// region, the failure of the write is reported as a SIGBUS. This
-// signal handler catches that signal and print out a user-friendly
+// region, the failure of the write is reported as a SIGBUS or structured
+// exeption with code EXCEPTION_IN_PAGE_ERROR on Windows. This
+// signal handler catches that signal and prints out a user-friendly
 // error message. Without this, it is very hard to realize that the
 // disk might be full.
+#ifdef _WIN32
+static LONG WINAPI vectored_handler(_EXCEPTION_POINTERS *exception_info) {
+#else
 static void sighandler(int signo, siginfo_t *info, void *ucontext) {
+#endif
   static std::mutex mu;
   std::scoped_lock lock{mu};
 
+#ifdef _WIN32
+  PEXCEPTION_RECORD exception_record = exception_info->ExceptionRecord;
+  ULONG_PTR *exception_information = exception_record->ExceptionInformation;
+  if (exception_record->ExceptionCode == EXCEPTION_IN_PAGE_ERROR &&
+      (ULONG_PTR)output_buffer_start <= exception_information[1] &&
+      exception_information[1] < (ULONG_PTR)output_buffer_end) {
+#else
   if ((signo == SIGSEGV || signo == SIGBUS) &&
       output_buffer_start <= info->si_addr &&
       info->si_addr < output_buffer_end) {
+#endif
+
     const char msg[] = "mold: failed to write to an output file. Disk full?\n";
+#ifdef _WIN32
+    (void)!write(_fileno(stderr), msg, sizeof(msg) - 1);
+#else
     (void)!write(STDERR_FILENO, msg, sizeof(msg) - 1);
+#endif
   }
 
   cleanup();
@@ -57,6 +75,9 @@ static void sighandler(int signo, siginfo_t *info, void *ucontext) {
 }
 
 void install_signal_handler() {
+#ifdef _WIN32
+  AddVectoredExceptionHandler(0, vectored_handler);
+#else
   struct sigaction action;
   action.sa_sigaction = sighandler;
   sigemptyset(&action.sa_mask);
@@ -65,7 +86,9 @@ void install_signal_handler() {
   sigaction(SIGINT, &action, NULL);
   sigaction(SIGTERM, &action, NULL);
   sigaction(SIGBUS, &action, NULL);
+#endif
 }
+
 
 i64 get_default_thread_count() {
   // mold doesn't scale well above 32 threads.

--- a/main.cc
+++ b/main.cc
@@ -79,7 +79,7 @@ i64 get_default_thread_count() {
 int main(int argc, char **argv) {
   mold::mold_version = mold::get_mold_version();
 
-  std::string cmd = mold::filepath(argv[0]).filename();
+  std::string cmd = mold::filepath(argv[0]).filename().string();
   if (cmd == "ld64" || cmd == "ld64.mold")
     return mold::macho::main(argc, argv);
   return mold::elf::main(argc, argv);

--- a/mold.h
+++ b/mold.h
@@ -18,13 +18,17 @@
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/enumerable_thread_specific.h>
-#include <unistd.h>
 #include <vector>
+
+#ifdef _WIN32
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 #define XXH_INLINE_ALL 1
 #include "third-party/xxhash/xxhash.h"

--- a/mold.h
+++ b/mold.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #ifdef _WIN32
+#include <io.h>
 #else
 #include <sys/mman.h>
 #include <unistd.h>
@@ -758,14 +759,23 @@ public:
   MappedFile *parent = nullptr;
   MappedFile *thin_parent = nullptr;
   int fd = -1;
+#ifdef _WIN32
+  HANDLE file_mapping = INVALID_HANDLE_VALUE;
+#endif
 };
 
 template <typename C>
 MappedFile<C> *MappedFile<C>::open(C &ctx, std::string path) {
   if (path.starts_with('/') && !ctx.arg.chroot.empty())
     path = ctx.arg.chroot + "/" + path_clean(path);
+  
+#ifdef _WIN32
+#define MOLD_OPEN ::_open
+#else
+#define MOLD_OPEN ::open
+#endif
 
-  i64 fd = ::open(path.c_str(), O_RDONLY);
+  i64 fd = MOLD_OPEN(path.c_str(), O_RDONLY);
   if (fd == -1)
     return nullptr;
 
@@ -778,18 +788,33 @@ MappedFile<C> *MappedFile<C>::open(C &ctx, std::string path) {
 
   mf->name = path;
   mf->size = st.st_size;
-
-#ifdef __APPLE__
-  mf->mtime = (u64)st.st_mtimespec.tv_sec * 1000000000 + st.st_mtimespec.tv_nsec;
+#ifdef _WIN32
+  mf->mtime = st.st_mtime;
+#elif defined(__APPLE__)
+  mf->mtime =
+      (u64)st.st_mtimespec.tv_sec * 1000000000 + st.st_mtimespec.tv_nsec;
 #else
   mf->mtime = (u64)st.st_mtim.tv_sec * 1000000000 + st.st_mtim.tv_nsec;
 #endif
 
   if (st.st_size > 0) {
+#ifdef _WIN32
+    HANDLE file_mapping =
+        CreateFileMapping((HANDLE)_get_osfhandle(fd), nullptr, PAGE_READWRITE,
+                          0, st.st_size, nullptr);
+    if (!file_mapping)
+      Fatal(ctx) << path << ": CreateFileMapping failed: " << GetLastError();
+    mf->file_mapping = file_mapping;
+    mf->data = (u8 *)MapViewOfFile(file_mapping, FILE_MAP_ALL_ACCESS, 0, 0,
+                                   st.st_size);
+    if (!mf->data)
+      Fatal(ctx) << path << ": MapViewOfFile failed: " << GetLastError();
+#else
     mf->data = (u8 *)mmap(nullptr, st.st_size, PROT_READ | PROT_WRITE,
                           MAP_PRIVATE, fd, 0);
     if (mf->data == MAP_FAILED)
       Fatal(ctx) << path << ": mmap failed: " << errno_string();
+#endif
   }
 
   close(fd);
@@ -818,8 +843,14 @@ MappedFile<C>::slice(C &ctx, std::string name, u64 start, u64 size) {
 
 template <typename C>
 MappedFile<C>::~MappedFile() {
-  if (size && !parent)
+  if (size && !parent) {
+#ifdef _WIN32
+    UnmapViewOfFile(data);
+    if (file_mapping != INVALID_HANDLE_VALUE) CloseHandle(file_mapping);
+#else
     munmap(data, size);
+#endif
+  }
 }
 
 } // namespace mold

--- a/output-file.h
+++ b/output-file.h
@@ -2,9 +2,12 @@
 
 #include <fcntl.h>
 #include <filesystem>
+
+#ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#endif
 
 namespace mold {
 

--- a/perf.cc
+++ b/perf.cc
@@ -3,8 +3,11 @@
 #include <functional>
 #include <iomanip>
 #include <ios>
+
+#ifndef _WIN32
 #include <sys/resource.h>
 #include <sys/time.h>
+#endif
 
 namespace mold {
 

--- a/perf.cc
+++ b/perf.cc
@@ -26,23 +26,44 @@ void Counter::print() {
 }
 
 static i64 now_nsec() {
+#ifdef _WIN32
+  return (i64)std::chrono::steady_clock::now().time_since_epoch().count();
+#else
   struct timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
   return (i64)t.tv_sec * 1000000000 + t.tv_nsec;
+  #endif
 }
 
+#ifdef _WIN32
+static i64 to_nsec(FILETIME t) {
+  return ((u64)t.dwHighDateTime << 32 + (u64)t.dwLowDateTime) * 100;
+}
+#else
 static i64 to_nsec(struct timeval t) {
   return (i64)t.tv_sec * 1000000000 + t.tv_usec * 1000;
 }
+#endif
 
 TimerRecord::TimerRecord(std::string name, TimerRecord *parent)
   : name(name), parent(parent) {
+#ifdef _WIN32
+  FILETIME creation_time, exit_time, kernel_time, user_time;
+  GetProcessTimes(GetCurrentProcess(), &creation_time, &exit_time, &kernel_time,
+                  &user_time);
+#else
   struct rusage usage;
   getrusage(RUSAGE_SELF, &usage);
+#endif
 
   start = now_nsec();
+#ifdef _WIN32
+  user = to_nsec(user_time);
+  sys = to_nsec(kernel_time);
+#else
   user = to_nsec(usage.ru_utime);
   sys = to_nsec(usage.ru_stime);
+#endif
 
   if (parent)
     parent->children.push_back(this);
@@ -53,12 +74,23 @@ void TimerRecord::stop() {
     return;
   stopped = true;
 
+#ifdef _WIN32
+  FILETIME creation_time, exit_time, kernel_time, user_time;
+  GetProcessTimes(GetCurrentProcess(), &creation_time, &exit_time, &kernel_time,
+                  &user_time);
+#else
   struct rusage usage;
   getrusage(RUSAGE_SELF, &usage);
+#endif
 
   end = now_nsec();
+#ifdef _WIN32
+  user = to_nsec(user_time) - user;
+  sys = to_nsec(kernel_time) - sys;
+#else
   user = to_nsec(usage.ru_utime) - user;
   sys = to_nsec(usage.ru_stime) - sys;
+#endif
 }
 
 static void print_rec(TimerRecord &rec, i64 indent) {

--- a/sha.h
+++ b/sha.h
@@ -1,6 +1,25 @@
+static constexpr int64_t SHA256_SIZE = 32;
+
 #if defined(USE_VENDORERD_SHA256)
 #  include "third-party/sha256/sha256.h"
 #elif defined(_WIN32)
+#include <Windows.h>
+#include <bcrypt.h>
+#include <ntstatus.h>
+
+inline static std::once_flag sha256_alg_handle_flag;
+inline static BCRYPT_ALG_HANDLE sha256_alg_handle() {
+  static BCRYPT_ALG_HANDLE alg_handle;
+  std::call_once(
+      sha256_alg_handle_flag,
+      [](BCRYPT_ALG_HANDLE* alg_handle_ptr) {
+        BCryptOpenAlgorithmProvider(alg_handle_ptr, BCRYPT_SHA256_ALGORITHM,
+                                    nullptr, 0);
+      },
+      &alg_handle);
+
+  return alg_handle;
+}
 #elif defined(__APPLE__)
 #  define COMMON_DIGEST_FOR_OPENSSL
 #  include <CommonCrypto/CommonDigest.h>
@@ -9,3 +28,57 @@
 #define OPENSSL_SUPPRESS_DEPRECATED 1
 #include <openssl/sha.h>
 #endif
+
+inline void sha256_hash(unsigned char* input_begin, size_t input_size,
+                 unsigned char* output_begin) {
+#ifdef _WIN32
+  BCryptHash(sha256_alg_handle(), nullptr, 0, input_begin, input_size,
+             output_begin, SHA256_SIZE);
+#else
+  SHA256(input_begin, input_size, output_begin);
+#endif
+}
+
+struct SHA256Hash {
+#ifdef _WIN32
+  BCRYPT_HASH_HANDLE hash_handle;
+  DWORD hash_buffer_length, hash_object_length, data_length;
+  std::unique_ptr<BYTE[]> hash_buffer, hash_object;
+#else
+  SHA256_CTX ctx;
+#endif
+
+  SHA256Hash() {
+#ifdef _WIN32
+    auto alg_handle = sha256_alg_handle();
+    BCryptGetProperty(alg_handle, BCRYPT_OBJECT_LENGTH,
+                      (PUCHAR)&hash_object_length, sizeof(DWORD), &data_length,
+                      0);
+    hash_object = std::make_unique<BYTE[]>(hash_object_length);
+    BCryptGetProperty(alg_handle, BCRYPT_HASH_LENGTH,
+                      (PUCHAR)&hash_buffer_length, sizeof(DWORD), &data_length,
+                      0);
+    hash_buffer = std::make_unique<BYTE[]>(hash_buffer_length);
+    BCryptCreateHash(alg_handle, &hash_handle, hash_object.get(),
+                     hash_object_length, nullptr, 0, 0);
+#else
+    SHA256_Init(&ctx);
+#endif
+  }
+
+  void update(unsigned char* data, size_t size) {
+#ifdef _WIN32
+    BCryptHashData(sha256_alg_handle(), data, size, 0);
+#else
+    SHA256_Update(&ctx, data, size);
+#endif
+  }
+
+  int finish(unsigned char* out) {
+#ifdef _WIN32
+    return BCryptFinishHash(sha256_alg_handle(), out, SHA256_SIZE, 0) == STATUS_SUCCESS;
+#else
+    return SHA256_Final(out, &ctx);
+#endif
+  }
+};

--- a/sha.h
+++ b/sha.h
@@ -1,10 +1,11 @@
 #if defined(USE_VENDORERD_SHA256)
 #  include "third-party/sha256/sha256.h"
+#elif defined(_WIN32)
 #elif defined(__APPLE__)
 #  define COMMON_DIGEST_FOR_OPENSSL
 #  include <CommonCrypto/CommonDigest.h>
 #  define SHA256(data, len, md) CC_SHA256(data, len, md)
 #else
-#  define OPENSSL_SUPPRESS_DEPRECATED 1
-#  include <openssl/sha.h>
+#define OPENSSL_SUPPRESS_DEPRECATED 1
+#include <openssl/sha.h>
 #endif

--- a/strerror.cc
+++ b/strerror.cc
@@ -13,7 +13,11 @@ namespace mold {
 
 std::string_view errno_string() {
   static thread_local char buf[200];
+  #ifdef _WIN32
+  strerror_s(buf, errno);
+  #else
   strerror_r(errno, buf, sizeof(buf));
+  #endif
   return buf;
 }
 


### PR DESCRIPTION
This fixes some of the errors when compiling for Windows but **not** all of them.
The remaining ones are mostly related to `mmap` calls and one in `elf\cmdline.cc`:
`fatal error C1061: compiler limit: blocks nested too deeply`
MSVC does only support up to 128 `else if` branches.
@rui314 I have reverted your changes related to the usage of the vendored sha256 implementation as I have already a implementation using CNG.