### PR TITLE
test: Add missing tests to CMakeLists

### DIFF
--- a/test/elf/CMakeLists.txt
+++ b/test/elf/CMakeLists.txt
@@ -43,6 +43,7 @@ set(MOLD_ELF_TESTS
   duplicate-error
   dynamic-dt-debug
   dynamic-linker
+  dynamic-list3
   dynamic-list2
   dynamic-list
   dynamic
@@ -107,6 +108,7 @@ set(MOLD_ELF_TESTS
   linker-script3
   linker-script4
   linker-script
+  linker-script-defsym
   link-order
   lto-archive
   lto-dso
@@ -217,6 +219,8 @@ set(MOLD_ELF_TESTS
   version-script13
   version-script14
   version-script15
+  version-script16
+  version-script17
   version-script2
   version-script3
   version-script4

--- a/test/elf/dynamic-list3.sh
+++ b/test/elf/dynamic-list3.sh
@@ -9,7 +9,7 @@ OBJDUMP="${OBJDUMP:-objdump}"
 MACHINE="${MACHINE:-$(uname -m)}"
 testname=$(basename "$0" .sh)
 echo -n "Testing $testname ... "
-t=out/test/elf/$testname
+t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 cat <<'EOF' > $t/dyn

--- a/test/macho/CMakeLists.txt
+++ b/test/macho/CMakeLists.txt
@@ -42,6 +42,7 @@ set(MOLD_MACHO_TESTS
   lc-linker-option
   lib1
   libunwind
+  linker-optimization-hints
   lto
   macos-version-min
   map
@@ -49,7 +50,9 @@ set(MOLD_MACHO_TESTS
   missing-error
   needed-framework
   needed-l
+  no-function-starts
   objc
+  objc-selector
   object-path-lto
   order-file
   pagezero-size2
@@ -65,6 +68,7 @@ set(MOLD_MACHO_TESTS
   search-paths-first
   sectcreate
   stack-size
+  start-stop-symbol
   subsections-via-symbols
   syslibroot
   tbd-add


### PR DESCRIPTION
These tests were added to the repo, but not the list of tests in the
corresponding CMakeLists. As a result, they are not run in CI when using
CTest.

Signed-off-by: Andrew Kaster <akaster@serenityos.org>