### PR TITLE
Make sure symbol points to correct section.

### DIFF
--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1220,10 +1220,10 @@ void get_output_esym(Context<E> &ctx, const Symbol<E> &sym, i64 strtab_offset,
       out_esym.st_shndx = SHN_ABS;
       out_esym.st_value = sym.get_addr(ctx);
     } else if (sym.get_type() == STT_TLS) {
-      out_esym.st_shndx = isec->output_section->shndx;
+      out_esym.st_shndx = sym.get_st_shndx();
       out_esym.st_value = sym.get_addr(ctx) - ctx.tls_begin;
     } else {
-      out_esym.st_shndx = isec->output_section->shndx;
+      out_esym.st_shndx = sym.get_st_shndx();
       out_esym.st_value = sym.get_addr(ctx, false);
       out_esym.st_visibility = sym.visibility;
     }


### PR DESCRIPTION
I was debugging #550, and I noticed a symbol was pointing to the
start of a section, but its shndx was set to SHN_UNDEF. Looking over
the code, I realized that for each section you create a corresponding
output section, but if the input section is mergeable, you also create
a fragment for it whose parent is MergeableSection, which in the end
will be copied into the output binary instead of the output section.

Since the symbol was pointing to the start of a mergeable section, I
realized that it is probably wrong to use the shndx of
`isec->output_section`, because that particular Chunk never actually
makes it to the list of final Chunks for mergeable sections.

Before:
```
$ eu-readelf -s ./target/debug/mold_test | grep _rustc
  Num:    Value   Size Type    Bind   Vis          Ndx Name
   77: 000d563c     34 OBJECT  LOCAL  DEFAULT    UNDEF __rustc_debug_gdb_scripts_section__

$ eu-readelf -S ./target/debug/mold_test
[Nr] Name                 Type         Addr     Off    Size   ES Flags Lk Inf Al
...
[22] .debug_gdb_scripts   PROGBITS     000d563c 0d563c 000022  0 A      0   0  1
...
```

After:
```
$ eu-readelf -s ./target/debug/mold_test | grep _rustc
  Num:    Value   Size Type    Bind   Vis          Ndx Name
   77: 000d563c     34 OBJECT  LOCAL  DEFAULT       22 __rustc_debug_gdb_scripts_section__

$ eu-readelf -S ./target/debug/mold_test
[Nr] Name                 Type         Addr     Off    Size   ES Flags Lk Inf Al
...
[22] .debug_gdb_scripts   PROGBITS     000d563c 0d563c 000022  0 A      0   0  1
...
```

Signed-off-by: Robert Bartlensky <bartlensky.robert@gmail.com>