### PR TITLE
include mold.h before standard header files

### DIFF
--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "elf.h"
 #include "../mold.h"
+#include "elf.h"
 
 #include <atomic>
 #include <bitset>

--- a/macho/lto-win32.cc
+++ b/macho/lto-win32.cc
@@ -1,7 +1,7 @@
 #ifdef _WIN32
 
-#include "lto.h"
 #include "mold.h"
+#include "lto.h"
 
 namespace mold::macho {
 

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "../mold.h"
 #include "macho.h"
 #include "lto.h"
-#include "../mold.h"
 
 #include <functional>
 #include <map>


### PR DESCRIPTION
If mold.h is included after standard header files, _WIN32_WINNT is
not defined and, by default, the value 0x0601 (Windows 7) is set in
the C header files.

This commit suppresses  the warnings like this one:

C:/Documents/msys2/home/vincent.torri/gitroot_64/mold_vtorri/mold.h:8: warning: "_WIN32_WINNT" redefined
    8 | # define _WIN32_WINNT 0x0A00
      |
In file included from C:/Documents/msys2/mingw64/include/corecrt.h:10,
                 from C:/Documents/msys2/mingw64/include/stdlib.h:9,
                 from C:/Documents/msys2/mingw64/include/c++/12.1.0/cstdlib:75,
                 from C:/Documents/msys2/mingw64/include/c++/12.1.0/bits/stl_algo.h:69,
                 from C:/Documents/msys2/mingw64/include/c++/12.1.0/functional:64,
                 from C:/Documents/msys2/home/vincent.torri/gitroot_64/mold_vtorri/macho/mold.h:3:
C:/Documents/msys2/mingw64/include/_mingw.h:239: note: this is the location of the previous definition
  239 | #define _WIN32_WINNT 0x601
      |

Signed-off-by: Vincent Torri <vtorri@outlook.fr>
