### PR TITLE
tests: grep for output of nm in defsym2.sh test

### DIFF
--- a/test/elf/defsym2.sh
+++ b/test/elf/defsym2.sh
@@ -17,6 +17,6 @@ void foo() {}
 EOF
 
 $CC -B. -o $t/b.so -shared -Wl,-defsym=bar=foo $t/a.o
-nm -D $t/b.so
+nm -D $t/b.so | grep -q 'bar' || false
 
 echo OK


### PR DESCRIPTION
Right now, the test prints to the output:

```
Testing defsym2 ...                  w _ITM_deregisterTMCloneTable
                 w _ITM_registerTMCloneTable
                 U __cxa_finalize
                 w __gmon_start__
00000000000010f9 T bar
00000000000010f9 T foo
OK
```

which is changed to:

```
Testing defsym2 ... OK
```

Signed-off-by: Martin Liska <mliska@suse.cz>