### PR TITLE
Fix test case being skipped unconditionally

### DIFF
--- a/test/elf/note-property.sh
+++ b/test/elf/note-property.sh
@@ -15,7 +15,7 @@ mkdir -p $t
 # Skip if target is not x86-64
 [ $MACHINE = x86_64 ] || { echo skipped; exit; }
 
-$CC -fcf-protection=branch /dev/null -o /dev/null -xc 2> /dev/null || \
+$CC -fcf-protection=branch -c /dev/null -o /dev/null -xc 2> /dev/null || \
   { echo skipped; exit; }
 
 cat <<EOF | $CC -fcf-protection=branch -c -o $t/a.o -xc -


### PR DESCRIPTION
The precondition check was supposed to find out whether the compiler
supports `-fcfprotection`, but it always failed complaining about an
undefined reference to `main()`. As a consequence, the test case was
never executed.

Add `-c` to omit the link step in the compiler call.