### PR TITLE
Fix warnings seen with binutils 2.39

### DIFF
--- a/test/elf/pltgot.sh
+++ b/test/elf/pltgot.sh
@@ -14,7 +14,7 @@ mkdir -p $t
 
 [ $MACHINE = x86_64 ] || { echo skipped; exit; }
 
-cat <<EOF | $CC -fPIC -shared -o $t/a.so -x assembler -
+cat <<EOF | $CC -fPIC -shared -Wl,-z,noexecstack -o $t/a.so -x assembler -
 .globl ext1, ext2
 ext1:
   nop

--- a/test/elf/reloc.sh
+++ b/test/elf/reloc.sh
@@ -37,7 +37,7 @@ int print64(long x) {
 }
 EOF
 
-$CC -shared -o $t/c.so $t/a.o $t/b.o
+$CC -shared -o $t/c.so $t/a.o $t/b.o -Wl,-z,noexecstack
 
 # Absolute symbol
 cat <<'EOF' > $t/d.s


### PR DESCRIPTION
The following warnings are seen:

```
Testing pltgot ... /usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: warning: /tmp/ccpkwmmy.o: missing .note.GNU-stack section implies executable stack
/usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

Testing reloc ... /usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: warning: out/test/elf/x86_64/reloc/a.o: missing .note.GNU-stack section implies executable stack
/usr/lib64/gcc/x86_64-suse-linux/12/../../../../x86_64-suse-linux/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```