### PR TITLE
Fix or remove ARM precondition checks in test cases

### DIFF
--- a/test/elf/arm32-thumb-interwork.sh
+++ b/test/elf/arm32-thumb-interwork.sh
@@ -12,7 +12,7 @@ echo -n "Testing $testname ... "
 t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
-[ $MACHINE = arm ] || { echo skipped; exit; }
+[[ $MACHINE == arm* ]] || { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -mthumb
 #include <stdio.h>

--- a/test/elf/large-alignment-dso.sh
+++ b/test/elf/large-alignment-dso.sh
@@ -13,7 +13,6 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 [ $MACHINE = i386 -o $MACHINE = i686 ] && { echo skipped; exit; }
-[ $MACHINE = arm ] && { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -ffunction-sections -fPIC
 #include <stdio.h>

--- a/test/elf/large-alignment.sh
+++ b/test/elf/large-alignment.sh
@@ -13,7 +13,6 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 [ $MACHINE = i386 -o $MACHINE = i686 ] && { echo skipped; exit; }
-[ $MACHINE = arm ] && { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -ffunction-sections
 #include <stdio.h>


### PR DESCRIPTION
Two checks are unnecessary; one is too restrictive.