### PR TITLE
remove unused to_string impl for Digest (aka array<uint8_t, ...>)

### DIFF
--- a/elf/icf.cc
+++ b/elf/icf.cc
@@ -86,13 +86,6 @@ template<> struct hash<Digest> {
     return *(int64_t *)&k[0];
   }
 };
-
-std::string to_string(Digest digest) {
-  char buf[HASH_SIZE * 2];
-  for (int i = 0; i < HASH_SIZE; i++)
-    sprintf(buf + i * 2, "%02x", digest[i]);
-  return {buf, sizeof(buf)};
-}
 }
 
 namespace mold::elf {


### PR DESCRIPTION
Fixes this warning when building with make or Cmake.

```
elf/icf.cc:93:5: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    sprintf(buf + i * 2, "%02x", digest[i]);
    ^
/Applications/Xcode-14.0.0-Beta.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode-14.0.0-Beta.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:214:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
```

Seems to be safe to use `snprintf` here with buffer size equal to 2.

**EDIT:** this `to_string` impl appears to be unused, so just remove it.