### PR TITLE
Add Rust macOS instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ take an absolute path as an argument for `-fuse-ld` though.
 
 Create `.cargo/config.toml` in your project directory with the following:
 
-```
+```toml
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=/path/to/mold"]
@@ -128,6 +128,16 @@ Please make sure you have installed `clang`.
 
 If you want to use mold for all projects, put the above snippet to
 `~/.cargo/config.toml`.
+
+> If you are using macOS, you can modify `config.toml` in a similar
+> manner. Here is an example on `aarch64` with `mold` installed via
+> [Homebrew](https://brew.sh/).
+>
+> ```toml
+> [target.aarch64-apple-darwin]
+> linker = "clang"
+> rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/ld64.mold"]
+> ```
 
 </details>
 


### PR DESCRIPTION
Since version 1.4.1 contains alpha support for macOS, it may be a good idea to show Rust users how to try it.