### PR TITLE
Fix `ld64.mold` version flag

### DIFF
--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -104,7 +104,7 @@ Options:
   -unexported_symbol <SYMBOL> Export all but a given symbol
   -unexported_symbols_list <FILE>
                               Read a list of unexported symbols from a given file
-  -v, --version               Report version information
+  -v                          Report version information
   -weak_framework <NAME>[,<SUFFIX>]
                               Search for a given framework
   -weak-l<LIB>                Search for a given library)";
@@ -483,9 +483,6 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_flag("-v")) {
       SyncOut(ctx) << mold_version;
       version_shown = true;
-    } else if (read_flag("--version")) {
-      SyncOut(ctx) << mold_version;
-      exit(0);
     } else if (read_arg("-weak_framework")) {
       remaining.push_back("-weak_framework");
       remaining.push_back(std::string(arg));

--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -104,7 +104,7 @@ Options:
   -unexported_symbol <SYMBOL> Export all but a given symbol
   -unexported_symbols_list <FILE>
                               Read a list of unexported symbols from a given file
-  -v                          Report version information
+  -v, --version               Report version information
   -weak_framework <NAME>[,<SUFFIX>]
                               Search for a given framework
   -weak-l<LIB>                Search for a given library)";
@@ -483,6 +483,9 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_flag("-v")) {
       SyncOut(ctx) << mold_version;
       version_shown = true;
+    } else if (read_flag("--version")) {
+      SyncOut(ctx) << mold_version;
+      exit(0);
     } else if (read_arg("-weak_framework")) {
       remaining.push_back("-weak_framework");
       remaining.push_back(std::string(arg));

--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -210,6 +210,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
   bool nostdlib = false;
   std::optional<i64> pagezero_size;
 
+  bool version_shown = false;
+
   while (i < args.size()) {
     std::string_view arg;
     std::string_view arg2;
@@ -480,6 +482,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
                      << ": invalid glob pattern: " << pat;
     } else if (read_flag("-v")) {
       SyncOut(ctx) << mold_version;
+      version_shown = true;
     } else if (read_arg("-weak_framework")) {
       remaining.push_back("-weak_framework");
       remaining.push_back(std::string(arg));
@@ -557,6 +560,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
   if (ctx.arg.uuid == UUID_RANDOM)
     memcpy(ctx.uuid, get_uuid_v4().data(), 16);
 
+  if (version_shown && remaining.empty())
+    exit(0);
   return remaining;
 }
 

--- a/test/macho/CMakeLists.txt
+++ b/test/macho/CMakeLists.txt
@@ -88,6 +88,7 @@ set(MOLD_MACHO_TESTS
   unkown-tbd-target
   uuid
   uuid2
+  version
   weak-def
   weak-def-dylib
   weak-def-ref

--- a/test/macho/version.sh
+++ b/test/macho/version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+export LC_ALL=C
+set -e
+CC="${TEST_CC:-cc}"
+CXX="${TEST_CXX:-c++}"
+GCC="${TEST_GCC:-gcc}"
+GXX="${TEST_GXX:-g++}"
+OBJDUMP="${OBJDUMP:-objdump}"
+MACHINE="${MACHINE:-$(uname -m)}"
+testname=$(basename "$0" .sh)
+echo -n "Testing $testname ... "
+t=out/test/macho/$MACHINE/$testname
+mkdir -p $t
+
+./ld64 -v | grep -q 'mold .*compatible with GNU ld'
+./ld64 --version | grep -q 'mold .*compatible with GNU ld'
+
+cat <<EOF | $CC -o $t/a.o -c -xc -
+#include <stdio.h>
+
+int main() {
+  printf("Hello world\n");
+}
+EOF
+
+rm -f $t/exe
+clang --ld-path=./ld64 -Wl,--version -o $t/exe $t/a.o 2>&1 | grep -q mold
+! [ -f $t/exe ] || false
+
+clang --ld-path=./ld64 -Wl,-v -o $t/exe $t/a.o 2>&1 | grep -q mold
+$QEMU $t/exe | grep -q 'Hello world'
+
+! ./ld64 --v >& $t/log
+grep -q 'unknown command line option:' $t/log
+
+echo OK

--- a/test/macho/version.sh
+++ b/test/macho/version.sh
@@ -13,7 +13,6 @@ t=out/test/macho/$MACHINE/$testname
 mkdir -p $t
 
 ./ld64 -v | grep -q 'mold .*compatible with GNU ld'
-./ld64 --version | grep -q 'mold .*compatible with GNU ld'
 
 cat <<EOF | $CC -o $t/a.o -c -xc -
 #include <stdio.h>
@@ -22,10 +21,6 @@ int main() {
   printf("Hello world\n");
 }
 EOF
-
-rm -f $t/exe
-clang --ld-path=./ld64 -Wl,--version -o $t/exe $t/a.o 2>&1 | grep -q mold
-! [ -f $t/exe ] || false
 
 clang --ld-path=./ld64 -Wl,-v -o $t/exe $t/a.o 2>&1 | grep -q mold
 $QEMU $t/exe | grep -q 'Hello world'


### PR DESCRIPTION
Currently, `ld64.mold -v` returns a nonzero exit code, with the following output:

```plaintext
mold 1.4.1 (compatible with GNU ld)
mold: fatal: no input files
```

- 6d8dcc9cea037af7b6d938df4fb21945f4299699 corrects this in a similar manner as in `elf/cmdline.cc`.
- ~~In addition, I would like to propose adding a `--version` flag, as present in `ld64.lld` (156aad6354bd90d97e7170015600ddb59a861338).~~
- A test `test/macho/version.sh` is added to cover the above (6d8dcc9cea037af7b6d938df4fb21945f4299699).
