### PR TITLE
Use /usr/bin/env rather than a hard-coded path to python3.

### DIFF
--- a/update-git-hash.py
+++ b/update-git-hash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#! /usr/bin/env python3
 #
 # This script updates git-hash.cc so that the file contains the
 # current git hash.


### PR DESCRIPTION
This works well on platforms that store python3 elsewhere than /usr/bin/ (e.g. on OpenBSD it's stored in /usr/local/bin/).