### PR TITLE
Enable mold to build under OpenBSD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ MOLD_CXXFLAGS := -std=c++20 -fno-exceptions -fno-unwind-tables \
                  -fno-asynchronous-unwind-tables \
                  -DMOLD_VERSION=\"$(VERSION)\" -DLIBDIR="\"$(LIBDIR)\""
 
-MOLD_LDFLAGS := -pthread -lz -lm -ldl
+ifeq ($(OS), OpenBSD)
+  MOLD_LDFLAGS := -pthread -lz -lm
+else
+  MOLD_LDFLAGS := -pthread -lz -lm -ldl
+endif
 
 LTO = 0
 ifeq ($(LTO), 1)

--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -1,6 +1,8 @@
 #define _GNU_SOURCE 1
 
-#include <alloca.h>
+#ifndef __OpenBSD__
+#  include <alloca.h>
+#endif
 #include <dlfcn.h>
 #include <spawn.h>
 #include <stdarg.h>


### PR DESCRIPTION
In conjunction with https://github.com/rui314/mold/pull/637 and https://github.com/rui314/mold/issues/549 (and some changes that will hopefully be soon merged into OpenBSD for `RTLD_NOLOAD`), this is enough to minimally build mold on OpenBSD. 