### PR TITLE
Support compilation of mold-wrapper.c on FreeBSD

### DIFF
--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE 1
 
-#ifndef __OpenBSD__
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
 #  include <alloca.h>
 #endif
 #include <dlfcn.h>


### PR DESCRIPTION
In FreeBSD, alloca(3) are located in <stdlib.h> instead of <alloca.h>.  So preclude the #include directive to support building 'mold' on FreeBSD. 

Reference: https://www.freebsd.org/cgi/man.cgi?alloca