### PR TITLE
Correctly compute R_ARM_GOT_PREL.

### DIFF
--- a/elf/arch-arm32.cc
+++ b/elf/arch-arm32.cc
@@ -190,7 +190,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       *(ul32 *)loc = GOT + A - P;
       continue;
     case R_ARM_GOT_PREL:
-      *(ul32 *)loc = G + A - P;
+      *(ul32 *)loc = sym.get_got_addr(ctx) + A - P;
       continue;
     case R_ARM_GOT_BREL:
       *(ul32 *)loc = G + A;


### PR DESCRIPTION
Fixes #550.

In the Arm32 [spec][spec], R_ARM_GOT_PREL and R_ARM_GOT_BREL are defined as
follows:

R_ARM_GOT_BREL: GOT(S) + A – GOT_ORG
R_ARM_GOT_PREL: GOT(S) + A – P

Where:
> GOT_ORG is the addressing origin of the Global Offset Table...
> GOT(S) is the address of the GOT entry for the symbol S.

If we look at the code a bit, notice that G is actually the _offset_
of S into the GOT, not symbol's address in GOT. This patch brings the
use of G and GOT more in line with the definitions from the spec,
thereby fixing the mentioned issue.

[spec]: https://github.com/ARM-software/abi-aa/blob/60a8eb8c55e999d74dac5e368fc9d7e36e38dda4/aaelf32/aaelf32.rst#5612relocation-types

Signed-off-by: Robert Bartlensky <bartlensky.robert@gmail.com>