### PR TITLE
[ELF] implement -Y flag

### DIFF
--- a/docs/mold.1
+++ b/docs/mold.1
@@ -320,6 +320,13 @@ Temporary local symbols are local symbols starting with
 Compilers usually generate such symbols for unnamed program elements such as \
 string literals or floating-point literals.
 .Pp
+.It Fl Y Ns Ar dir
+Add
+.Ar dir
+to the list of default search paths from which
+.Nm
+searches libraries for the \fB-l\fR option.
+.Pp
 .It Fl e Ar symbol , Fl -entry Ns = Ns Ar symbol
 Use
 .Ar symbol

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -39,6 +39,7 @@ Options:
   -S, --strip-debug           Strip .debug_* sections
   -T FILE, --script FILE      Read linker script
   -X, --discard-locals        Discard temporary local symbols
+  -Y DIR                      Add DIR to default library search path
   -e SYMBOL, --entry SYMBOL   Set program entry point
   -f SHLIB, --auxiliary SHLIB Set DT_AUXILIARY to the specified value
   -h LIBNAME, --soname LIBNAME
@@ -338,6 +339,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
   ctx.page_size = E::page_size;
   ctx.arg.color_diagnostics = isatty(STDERR_FILENO);
 
+  std::vector<std::string> default_library_paths;
   bool version_shown = false;
   bool warn_shared_textrel = false;
 
@@ -533,6 +535,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.filler = parse_hex(ctx, "filler", arg);
     } else if (read_arg("L") || read_arg("library-path")) {
       ctx.arg.library_paths.push_back(std::string(arg));
+    } else if (read_arg("Y")) {
+      default_library_paths.push_back(std::string(arg));
     } else if (read_arg("sysroot")) {
       ctx.arg.sysroot = arg;
     } else if (read_arg("unique")) {
@@ -997,6 +1001,10 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       args = args.subspan(1);
     }
   }
+
+  ctx.arg.library_paths.insert(ctx.arg.library_paths.end(),
+          default_library_paths.begin(),
+          default_library_paths.end());
 
   if (!ctx.arg.sysroot.empty()) {
     for (std::string &path : ctx.arg.library_paths) {


### PR DESCRIPTION
Please consider supporting the -Y flag, which is supported by the bfd linker (but not gold):

```
       -Y path
           Add path to the default library search path.  This option exists for Solaris compatibility.
```

While this is a compatibility option in bfd, it is still very useful when you want to share a cross-toolchain to build binaries and libraries for different targets, without having to copy the full toolchain to their staging dir and using the --sysroot option.