### PR TITLE
armv6l: properly skip arm32-thumb-interwork.sh

### DIFF
--- a/test/elf/arm32-thumb-interwork.sh
+++ b/test/elf/arm32-thumb-interwork.sh
@@ -14,7 +14,7 @@ mkdir -p $t
 
 [[ $MACHINE == arm* ]] || { echo skipped; exit; }
 
-$CC -o /dev/null -c -xc /dev/null -mthumb 2> /dev/null || { echo skipped; exit; }
+echo 'int foo() { return 0; }' | $CC -o /dev/null -c -xc - -mthumb 2> /dev/null || { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -xc - -mthumb
 #include <stdio.h>


### PR DESCRIPTION
I was not correct as the 'sorry, unimplemented: Thumb-1 'hard-float' VFP ABI
really comes late in target register allocator. Thus one needs to
assembly a function.

Fixes: #655
Signed-off-by: Martin Liska <mliska@suse.cz>