### PR TITLE
[RISCV32] Fix R_RISCV_HI20 relocations

### DIFF
--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -565,13 +565,11 @@ void InputSection<E>::scan_relocations(Context<E> &ctx) {
 
     switch (rel.r_type) {
     case R_RISCV_32:
+    case R_RISCV_HI20:
       if constexpr (sizeof(Word<E>) == 8)
         handle_abs_rel(ctx, sym, rel);
       else
         handle_abs_dyn_rel(ctx, sym, rel);
-      break;
-    case R_RISCV_HI20:
-      handle_abs_rel(ctx, sym, rel);
       break;
     case R_RISCV_64:
       if constexpr (sizeof(Word<E>) == 4)


### PR DESCRIPTION
Fixed the `exclude-libs3` test case with the following command line:
```
make test-arch TRIPLE=riscv32-unknown-elf MACHINE=riscv32
```

> I'm still learning how linkers work in general as well as the codebase itself, please forgive me if this is the wrong way to fix it.