### PR TITLE
[RV32] Skip all test cases not applicable to RV32

### DIFF
--- a/test/elf/discard.sh
+++ b/test/elf/discard.sh
@@ -12,6 +12,7 @@ echo -n "Testing $testname ... "
 t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 cat <<EOF | $CC -o $t/a.o -c -x assembler -Wa,-L -

--- a/test/elf/dt-init.sh
+++ b/test/elf/dt-init.sh
@@ -12,6 +12,7 @@ echo -n "Testing $testname ... "
 t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 cat <<EOF | $CC -c -fPIC -o $t/a.o -xc -

--- a/test/elf/gdb-index-compress-output.sh
+++ b/test/elf/gdb-index-compress-output.sh
@@ -14,6 +14,7 @@ mkdir -p $t
 
 [ $MACHINE = $(uname -m) ] || { echo skipped; exit; }
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 which gdb >& /dev/null || { echo skipped; exit; }

--- a/test/elf/gdb-index-dwarf2.sh
+++ b/test/elf/gdb-index-dwarf2.sh
@@ -14,6 +14,7 @@ mkdir -p $t
 
 [ $MACHINE = $(uname -m) ] || { echo skipped; exit; }
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 which gdb >& /dev/null || { echo skipped; exit; }

--- a/test/elf/gdb-index-dwarf3.sh
+++ b/test/elf/gdb-index-dwarf3.sh
@@ -14,6 +14,7 @@ mkdir -p $t
 
 [ $MACHINE = $(uname -m) ] || { echo skipped; exit; }
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 which gdb >& /dev/null || { echo skipped; exit; }

--- a/test/elf/gdb-index-dwarf4.sh
+++ b/test/elf/gdb-index-dwarf4.sh
@@ -14,6 +14,7 @@ mkdir -p $t
 
 [ $MACHINE = $(uname -m) ] || { echo skipped; exit; }
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 which gdb >& /dev/null || { echo skipped; exit; }

--- a/test/elf/gdb-index-dwarf5.sh
+++ b/test/elf/gdb-index-dwarf5.sh
@@ -14,6 +14,7 @@ mkdir -p $t
 
 [ $MACHINE = $(uname -m) ] || { echo skipped; exit; }
 
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 which gdb >& /dev/null || { echo skipped; exit; }

--- a/test/elf/ifunc-dso.sh
+++ b/test/elf/ifunc-dso.sh
@@ -13,6 +13,7 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 # IFUNC is not supported on RISC-V yet
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 # Skip if libc is musl because musl does not support GNU FUNC

--- a/test/elf/ifunc-dynamic.sh
+++ b/test/elf/ifunc-dynamic.sh
@@ -13,6 +13,7 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 # IFUNC is not supported on RISC-V yet
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 # Skip if libc is musl because musl does not support GNU FUNC

--- a/test/elf/ifunc-export.sh
+++ b/test/elf/ifunc-export.sh
@@ -13,6 +13,7 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 # IFUNC is not supported on RISC-V yet
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 # Skip if libc is musl because musl does not support GNU FUNC

--- a/test/elf/ifunc-static-pie.sh
+++ b/test/elf/ifunc-static-pie.sh
@@ -18,7 +18,8 @@ ldd --help 2>&1 | grep -q musl && { echo skipped; exit; }
 # We need to implement R_386_GOT32X relaxation to support PIE on i386
 [ $MACHINE = i386 -o $MACHINE = i686 ] && { echo skipped; exit; }
 
-# RISCV64 does not support IFUNC yet
+# IFUNC is not supported on RISC-V yet
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 [ $MACHINE = aarch64 ] && { echo skipped; exit; }

--- a/test/elf/ifunc-static.sh
+++ b/test/elf/ifunc-static.sh
@@ -13,6 +13,7 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 # IFUNC is not supported on RISC-V yet
+[ $MACHINE = riscv32 ] && { echo skipped; exit; }
 [ $MACHINE = riscv64 ] && { echo skipped; exit; }
 
 # Skip if libc is musl because musl does not support GNU FUNC

--- a/test/elf/strip.sh
+++ b/test/elf/strip.sh
@@ -26,7 +26,7 @@ fgrep -q _start $t/log
 fgrep -q foo $t/log
 fgrep -q bar $t/log
 
-if [ $MACHINE '!=' riscv64 ]; then
+if [ $MACHINE '!=' riscv32 ] && [ $MACHINE '!=' riscv64 ]; then
   fgrep -q .L.baz $t/log
 fi
 
@@ -36,7 +36,7 @@ readelf --symbols $t/exe > $t/log
 ! fgrep -q foo $t/log || false
 ! fgrep -q bar $t/log || false
 
-if [ $MACHINE '!=' riscv64 ]; then
+if [ $MACHINE '!=' riscv32 ] && [ $MACHINE '!=' riscv64 ]; then
   ! fgrep -q .L.baz $t/log || false
 fi
 


### PR DESCRIPTION
Along with https://github.com/rui314/mold/pull/669, all test cases for RV32 are passed.