### PR TITLE
Fix missing parameter in linker script tests

### DIFF
--- a/test/elf/linker-script2.sh
+++ b/test/elf/linker-script2.sh
@@ -24,6 +24,6 @@ cat <<EOF > $t/b.script
 INPUT(-lfoo)
 EOF
 
-$CC -o $t/exe -L$t/foo/bar $t/b.script
+$CC -B. -o $t/exe -L$t/foo/bar $t/b.script
 
 echo OK

--- a/test/elf/linker-script3.sh
+++ b/test/elf/linker-script3.sh
@@ -22,6 +22,6 @@ cat <<EOF > $t/b.script
 INPUT(a.o)
 EOF
 
-$CC -o $t/exe -L$t/foo $t/b.script
+$CC -B. -o $t/exe -L$t/foo $t/b.script
 
 echo OK


### PR DESCRIPTION
We should add `-B.` to test mold instead of GNU ld, right?