### PR TITLE
[RISCV] Add zero-page relaxation 

### DIFF
--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -859,7 +859,7 @@ static void update_symbol_values(Context<E> &ctx, InputSection<E> &isec) {
 // symbol values. For example, if we replace AUIPC+JALR with JAL
 // (which saves 4 bytes), all relocations pointing to anywhere after
 // that location need to be shifted by 4. In addition to that, any
-// symbol that refers anywhere after that locatioin need to be shifted
+// symbol that refers anywhere after that location need to be shifted
 // by 4 bytes as well.
 //
 // For relocations, we use `r_deltas` array to memorize how many bytes
@@ -880,7 +880,7 @@ i64 riscv_resize_sections(Context<E> &ctx) {
   // True if we can use the 2-byte instructions.
   bool use_rvc = get_eflags(ctx) & EF_RISCV_RVC;
 
-  // Find R_RISCV_CALL AND R_RISCV_CALL_PLT that can be relaxed.
+  // Find all the relocations that can be relaxed.
   // This step should only shrink sections.
   tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
     for (std::unique_ptr<InputSection<E>> &isec : file->sections)

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -721,7 +721,7 @@ void ObjectFile<E>::register_section_pieces(Context<E> &ctx) {
                                          (i32)(offset - offsets[idx])};
     }
 
-    isec->rel_fragments[frag_idx++] = {nullptr, -1, -1};
+    isec->rel_fragments[frag_idx] = {nullptr, -1, -1};
   }
 
   // Initialize sym_fragments

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -612,7 +612,7 @@ split_section(Context<E> &ctx, InputSection<E> &sec) {
 // are usually put into a mergeable section by a compiler. If the same
 // string literal happen to occur in two different translation units,
 // a linker merges them into a single instance of a string, so that
-// a linker's output doens't contain duplicate string literals.
+// a linker's output doesn't contain duplicate string literals.
 //
 // Handling relocations referring mergeable sections is a bit tricky.
 // Assume that we have a mergeable section with the following contents

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -306,6 +306,8 @@ public:
   std::span<ElfRel<E>> get_rels(Context<E> &ctx) const;
   std::span<FdeRecord<E>> get_fdes() const;
   std::string_view get_func_name(Context<E> &ctx, i64 offset);
+  std::pair<SectionFragment<E> *, i64>
+  get_fragment(Context<E> &ctx, const ElfRel<E> &rel);
   bool is_relr_reloc(Context<E> &ctx, const ElfRel<E> &rel);
 
   void record_undef_error(Context<E> &ctx, const ElfRel<E> &rel);
@@ -354,9 +356,6 @@ private:
                          u8 *loc, u64 S, i64 A, u64 P, ElfRel<E> *&dynrel);
 
   void copy_contents_riscv(Context<E> &ctx, u8 *buf);
-
-  std::pair<SectionFragment<E> *, i64>
-  get_fragment(Context<E> &ctx, const ElfRel<E> &rel);
 
   std::optional<u64> get_tombstone(Symbol<E> &sym);
 };


### PR DESCRIPTION
Currently, this patch fails at tests with -static option and needs more work to do before merging.

Also, seems TLS relaxation(https://github.com/rui314/mold/issues/461) is already supported. We only have global-pointer relaxation(https://github.com/rui314/mold/issues/460) left to do for RISC-V.