### PR TITLE
Remove 'Ignored' helptext for lto_library and order_file

### DIFF
--- a/macho/cmdline.cc
+++ b/macho/cmdline.cc
@@ -70,7 +70,7 @@ Options:
     -enable_optimization_hints
   -install_name <NAME>
   -l<LIB>                     Search for a given library
-  -lto_library <FILE>         Ignored
+  -lto_library <FILE>         Path to the LLVM link time optimizer library
   -macos_version_min <VERSION>
   -map <FILE>                 Write map file to a given file
   -mark_dead_strippable_dylib Mark the output as dead-strippable
@@ -83,7 +83,9 @@ Options:
   -o <FILE>                   Set output filename
   -objc_abi_version <VERSION> Ignored
   -object_path_lto <FILE>     Write a LTO temporary file to a given path
-  -order_file <FILE>          Ignored
+  -order_file <FILE>          Path to an order file specifying symbols which
+                              should be laid out first and in the order specified.
+                              Symbols should be delimited by newlines
   -pagezero_size <SIZE>       Specify the size of the __PAGEZERO segment
   -platform_version <PLATFORM> <MIN_VERSION> <SDK_VERSION>
                               Set platform, platform version and SDK version


### PR DESCRIPTION
I see that these 2 flags are implemented and not ignored, albeit potentially incomplete (order file code does not handle colon delimiter yet for example).

If the intent was to leave these as undocumented/Ignored for the time being, you can ignore this pull request :)

