### PR TITLE
Removed repeated if in cleanup() at main.cc:30

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -27,8 +27,6 @@ static std::string get_mold_version() {
 void cleanup() {
   if (output_tmpfile)
     unlink(output_tmpfile);
-  if (socket_tmpfile)
-    unlink(socket_tmpfile);
 }
 
 // mold mmap's an output file, and the mmap succeeds even if there's


### PR DESCRIPTION
It looks to me as though there is a repeated statement in `main.cc` at line 30. 
```cpp
void cleanup() {
  if (output_tmpfile)
    unlink(output_tmpfile);
  if (output_tmpfile) // repeated (?)
    unlink(output_tmpfile);
}
```

So I tried removing it and it passed all tests (Using `make test`)
```
cmake -DSOURCE_DIR=. -DOUTPUT_FILE=out/git-hash.cc -P update-git-hash.cmake
Testing U ... OK
Testing Z ... OK
Testing add-ast-path ... OK
Testing add-empty-section ... OK
Testing adhoc-codesign ... OK
Testing all-load ... OK
Testing application-extension ... OK
Testing archive ... OK
Testing baserel ... OK
Testing basic ... OK
Testing bss ... OK
Testing bundle ... OK
Testing comdat ... OK
Testing common-alignment ... OK
Testing common ... OK
Testing cstring ... OK
Testing data-reloc ... OK
Testing dead-strip-dylibs ... OK
Testing dead-strip-dylibs2 ... OK
Testing dead-strip ... OK
Testing dependency-info ... OK
Testing dlinfo ... OK
Testing duplicate-error ... OK
Testing dylib ... OK
Testing entry ... OK
Testing exception-in-static-initializer ... OK
Testing exception ... OK
Testing export-dynamic ... OK
Testing exported-symbols-list ... OK
Testing filepath ... OK
Testing filepath2 ... OK
Testing force-load ... OK
Testing framework ... OK
Testing headerpad-max-install-names ... OK
Testing headerpad ... skipped
Testing hello ... OK
Testing hello2 ... OK
Testing hello3 ... OK
Testing hello4 ... OK
Testing hello5 ... OK
Testing hidden-l ... OK
Testing install-name ... OK
Testing lc-build-version ... OK
Testing lc-linker-option ... OK
Testing lib1 ... OK
Testing libunwind ... OK
Testing linker-optimization-hints ... OK
Testing lto-dead-strip-dylibs ... OK
Testing lto ... OK
Testing macos-version-min ... OK
Testing map ... OK
Testing merge-scope ... OK
Testing missing-error ... OK
Testing needed-framework ... OK
Testing needed-l ... OK
Testing no-function-starts ... OK
Testing objc-selector ... OK
Testing objc ... OK
Testing object-path-lto ... OK
Testing order-file ... OK
Testing pagezero-size ... skipped
Testing pagezero-size2 ... OK
Testing pagezero-size3 ... OK
Testing platform-version ... OK
Testing private-extern ... OK
Testing reexport-l ... OK
Testing reproducibility ... OK
Testing response-file ... OK
Testing rpath ... OK
Testing search-dylibs-first ... OK
Testing search-paths-first ... OK
Testing sectcreate ... OK
Testing stack-size ... OK
Testing start-stop-symbol ... OK
Testing subsections-via-symbols ... OK
Testing syslibroot ... OK
Testing tbd-add ... OK
Testing tbd-hide ... OK
Testing tbd-install-name ... OK
Testing tbd-previous ... OK
Testing tbd-reexport ... OK
Testing tbd ... OK
Testing tls ... OK
Testing tls2 ... OK
Testing undef ... OK
Testing unexported-symbols-list ... OK
Testing universal ... OK
Testing unkown-tbd-target ... OK
Testing uuid ... OK
Testing uuid2 ... OK
Testing version ... OK
Testing weak-def-archive ... OK
Testing weak-def-dylib ... OK
Testing weak-def-ref ... OK
Testing weak-def ... OK
Testing weak-l ... OK
Testing weak-undef ... OK
Passed all tests
```

I didn't sign off the commit as the contribution is less than 10 lines long.
Hope this helps out and doesn't break anything.