### PR TITLE
[Mach-O] Add debug sections field

### DIFF
--- a/macho/dwarf.cc
+++ b/macho/dwarf.cc
@@ -1,0 +1,29 @@
+#include "mold.h"
+
+namespace mold::macho {
+
+template <typename E>
+std::unique_ptr<DwarfObject<E>>
+DwarfObject<E>::create(ObjectFile<E> *obj) {
+  std::unique_ptr<DwarfObject<E>> dwarf_obj = std::make_unique<DwarfObject>();
+
+  bool has_dwarf_info = false;
+  for (std::unique_ptr<InputSection<E>> &isec : obj->debug_sections) {
+    if (isec->hdr.match("__DWARF", "__debug_str")) {
+      dwarf_obj->str_section = isec->contents;
+      has_dwarf_info = true;
+    }
+  }
+
+  if (has_dwarf_info)
+    return dwarf_obj;
+  return nullptr;
+}
+
+
+#define INSTANTIATE(E)           \
+  template class DwarfObject<E>;
+
+INSTANTIATE_ALL;
+
+} // namespace mold::macho

--- a/macho/input-files.cc
+++ b/macho/input-files.cc
@@ -118,6 +118,8 @@ void ObjectFile<E>::parse_sections(Context<E> &ctx) {
 
     sections.back().reset(isec);
   }
+
+  dwarf_obj = DwarfObject<E>::create(this);
 }
 
 template <typename E>

--- a/macho/input-files.cc
+++ b/macho/input-files.cc
@@ -110,10 +110,13 @@ void ObjectFile<E>::parse_sections(Context<E> &ctx) {
       continue;
     }
 
-    if (msec.attr & S_ATTR_DEBUG)
+    InputSection<E> *isec = new InputSection<E>(ctx, *this, msec, i);
+    if (msec.attr & S_ATTR_DEBUG) {
+      debug_sections.emplace_back(isec);
       continue;
+    }
 
-    sections.back().reset(new InputSection<E>(ctx, *this, msec, i));
+    sections.back().reset(isec);
   }
 }
 

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -127,6 +127,7 @@ public:
   Relocation<E> read_reloc(Context<E> &ctx, const MachSection &hdr, MachRel r);
 
   std::vector<std::unique_ptr<InputSection<E>>> sections;
+  std::vector<std::unique_ptr<InputSection<E>>> debug_sections;
   std::vector<Subsection<E> *> subsections;
   std::vector<Subsection<E> *> sym_to_subsec;
   std::span<MachSym> mach_syms;

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -35,6 +35,7 @@ template <typename E> class OutputSection;
 template <typename E> class Subsection;
 template <typename E> struct Context;
 template <typename E> struct Symbol;
+template <typename E> struct DwarfObject;
 
 //
 // input-files.cc
@@ -136,6 +137,7 @@ public:
   std::span<DataInCodeEntry> data_in_code_entries;
   ObjcImageInfo *objc_image_info = nullptr;
   LTOModule *lto_module = nullptr;
+  std::unique_ptr<DwarfObject<E>> dwarf_obj = nullptr;
 
   // For the internal file and LTO object files
   std::vector<MachSym> mach_syms2;
@@ -811,6 +813,20 @@ void do_lto(Context<E> &ctx);
 
 void create_range_extension_thunks(Context<ARM64> &ctx, OutputSection<ARM64> &osec);
 void apply_linker_optimization_hints(Context<ARM64> &ctx);
+
+//
+// dwarf.cc
+//
+
+template <typename E>
+struct DwarfObject {
+public:
+  DwarfObject() = default;
+  static std::unique_ptr<DwarfObject<E>>
+  create(ObjectFile<E> *obj);
+
+  std::string_view str_section;
+};
 
 //
 // main.cc


### PR DESCRIPTION
Currently, mold does not emit any STABS symbol. The debugger needs these symbols to locate debug info in the `*.dSYM` directory. This patch added a debug sections field, which will be used when generating STABS symbols.