### PR TITLE
tests: fix test/elf/exception-mcmodel-large.sh

### DIFF
--- a/test/elf/exception-mcmodel-large.sh
+++ b/test/elf/exception-mcmodel-large.sh
@@ -28,7 +28,7 @@ EOF
 $CXX -B. -o $t/exe $t/a.o -mcmodel=large
 $QEMU $t/exe
 
-if 'int main() {}' | cc -o /dev/null -xc - -static >& /dev/null; then
+if echo 'int main() {}' | cc -o /dev/null -xc - -static >& /dev/null; then
   $CXX -B. -o $t/exe $t/a.o -static -mcmodel=large
   $QEMU $t/exe
 fi


### PR DESCRIPTION
Fix syntax error:
line 31: int main() {}: command not found