### PR TITLE
Convert hidden global symbols into local ones.

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1081,6 +1081,26 @@ void ObjectFile<E>::claim_unresolved_symbols(Context<E> &ctx) {
 }
 
 template <typename E>
+void ObjectFile<E>::convert_hidden_symbols(Context<E> &ctx) {
+  if (!this->is_alive)
+    return;
+
+  for (i64 i = this->first_global; i < this->symbols.size(); i++) {
+    Symbol<E> &sym = *this->symbols[i];
+
+    if (sym.visibility != STV_HIDDEN)
+      continue;
+
+    std::scoped_lock lock(sym.mu);
+
+    // make the symbol local
+    sym.is_imported = false;
+    sym.is_exported = false;
+    sym.is_weak = false;
+  }
+}
+
+template <typename E>
 void ObjectFile<E>::scan_relocations(Context<E> &ctx) {
   // Scan relocations against seciton contents
   for (std::unique_ptr<InputSection<E>> &isec : sections)

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -526,6 +526,10 @@ static int elf_main(int argc, char **argv) {
   // resolved.
   claim_unresolved_symbols(ctx);
 
+  // Hidden global/weak symbols are converted into local symbols (this is not
+  // done for symbols coming from shared objects)
+  convert_hidden_symbols(ctx);
+
   // Beyond this point, no new symbols will be added to the result.
 
   // Handle --print-dependencies

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1120,6 +1120,7 @@ public:
   void mark_addrsig(Context<E> &ctx);
   void eliminate_duplicate_comdat_groups();
   void claim_unresolved_symbols(Context<E> &ctx);
+  void convert_hidden_symbols(Context<E> &ctx);
   void scan_relocations(Context<E> &ctx);
   void convert_common_symbols(Context<E> &ctx);
   void compute_symtab(Context<E> &ctx);
@@ -1326,6 +1327,7 @@ collect_output_sections(Context<E> &);
 template <typename E> void compute_section_sizes(Context<E> &);
 template <typename E> void sort_output_sections(Context<E> &);
 template <typename E> void claim_unresolved_symbols(Context<E> &);
+template <typename E> void convert_hidden_symbols(Context<E> &);
 template <typename E> void scan_rels(Context<E> &);
 template <typename E> void construct_relr(Context<E> &);
 template <typename E> void create_output_symtab(Context<E> &);

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -899,6 +899,14 @@ void claim_unresolved_symbols(Context<E> &ctx) {
 }
 
 template <typename E>
+void convert_hidden_symbols(Context<E> &ctx) {
+  Timer t(ctx, "convert_hidden_symbols");
+  tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
+    file->convert_hidden_symbols(ctx);
+  });
+}
+
+template <typename E>
 void scan_rels(Context<E> &ctx) {
   Timer t(ctx, "scan_rels");
 
@@ -1783,6 +1791,7 @@ void write_dependency_file(Context<E> &ctx) {
   template void compute_section_sizes(Context<E> &);                    \
   template void sort_output_sections(Context<E> &);                     \
   template void claim_unresolved_symbols(Context<E> &);                 \
+  template void convert_hidden_symbols(Context<E> &);                   \
   template void scan_rels(Context<E> &);                                \
   template void create_reloc_sections(Context<E> &);                    \
   template void construct_relr(Context<E> &);                           \

--- a/test/elf/hidden-conversion.sh
+++ b/test/elf/hidden-conversion.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+export LC_ALL=C
+set -e
+CC="${TEST_CC:-cc}"
+CXX="${TEST_CXX:-c++}"
+GCC="${TEST_GCC:-gcc}"
+GXX="${TEST_GXX:-g++}"
+OBJDUMP="${OBJDUMP:-objdump}"
+MACHINE="${MACHINE:-$(uname -m)}"
+testname=$(basename "$0" .sh)
+echo -n "Testing $testname ... "
+t=out/test/elf/$MACHINE/$testname
+mkdir -p $t
+
+cat <<EOF | $CC -o $t/foo.o -fPIC -c -xc -
+__attribute__((visibility("hidden"))) void foo();
+int main() { foo(); }
+EOF
+
+./mold -shared -o $t/foo.so $t/foo.o
+readelf --symbols $t/foo.so > $t/log
+grep -q '.*LOCAL  DEFAULT  UND foo' $t/log
+
+echo OK


### PR DESCRIPTION
I decided to add an extra pass for this since it makes sense to do it after all symbols have been processed, but before scanning relocations.

Fixes #528.

```
$ clang++ test.cc -mno-relax --target=riscv64-unknown-linux-none -Wall -c -o foo.o
$ ../mold foo.o -shared -o foo.so
$ readelf -r foo.so

There are no relocations in this file.
```

Signed-off-by: Robert Bartlensky <bartlensky.robert@gmail.com>