### PR TITLE
fix -Wreorder warnings

### DIFF
--- a/elf/elf.h
+++ b/elf/elf.h
@@ -1921,7 +1921,7 @@ struct EB32Phdr {
 struct EB64Rel {
   EB64Rel() = default;
   EB64Rel(u64 r_offset, u32 r_type, u32 r_sym, i64 r_addend = 0)
-    : r_offset(r_offset), r_type(r_type), r_sym(r_sym) {}
+    : r_offset(r_offset), r_sym(r_sym), r_type(r_type) {}
 
   ub64 r_offset;
   ub32 r_sym;
@@ -1931,7 +1931,7 @@ struct EB64Rel {
 struct EB32Rel {
   EB32Rel() = default;
   EB32Rel(u64 r_offset, u32 r_type, u32 r_sym, i64 r_addend = 0)
-    : r_offset(r_offset), r_type(r_type), r_sym(r_sym) {}
+    : r_offset(r_offset), r_sym(r_sym), r_type(r_type) {}
 
   ub32 r_offset;
   ub24 r_sym;
@@ -1941,7 +1941,7 @@ struct EB32Rel {
 struct EB64Rela {
   EB64Rela() = default;
   EB64Rela(u64 r_offset, u32 r_type, u32 r_sym, i64 r_addend)
-    : r_offset(r_offset), r_type(r_type), r_sym(r_sym), r_addend(r_addend) {}
+    : r_offset(r_offset), r_sym(r_sym), r_type(r_type), r_addend(r_addend) {}
 
   ub64 r_offset;
   ub32 r_sym;
@@ -1952,7 +1952,7 @@ struct EB64Rela {
 struct EB32Rela {
   EB32Rela() = default;
   EB32Rela(u64 r_offset, u32 r_type, u32 r_sym, i64 r_addend)
-    : r_offset(r_offset), r_type(r_type), r_sym(r_sym), r_addend(r_addend) {}
+    : r_offset(r_offset), r_sym(r_sym), r_type(r_type), r_addend(r_addend) {}
 
   ub32 r_offset;
   ub24 r_sym;


### PR DESCRIPTION
Fixes:

```
elf/elf.h: In constructor 'mold::elf::EB64Rel::EB64Rel(mold::u64, mold::u32, mold::u32, mold::i64)': elf/elf.h:1928:8: warning: 'mold::elf::EB64Rel::r_type' will be initialized after [-Wreorder]
 1928 |   ub32 r_type;
      |        ^~~~~~
elf/elf.h:1927:8: warning:   'mold::ub32 mold::elf::EB64Rel::r_sym' [-Wreorder]
 1927 |   ub32 r_sym;
      |        ^~~~~
elf/elf.h:1923:3: warning:   when initialized here [-Wreorder]
 1923 |   EB64Rel(u64 r_offset, u32 r_type, u32 r_sym, i64 r_addend = 0)
      |   ^~~~~~~
elf/elf.h: In constructor 'mold::elf::EB32Rel::EB32Rel(mold::u64, mold::u32, mold::u32, mold::i64)':
elf/elf.h:1938:6: warning: 'mold::elf::EB32Rel::r_type' will be initialized after [-Wreorder]
 1938 |   u8 r_type;
      |      ^~~~~~
```

Signed-off-by: Martin Liska <mliska@suse.cz>