### PR TITLE
fix a test warning

### DIFF
--- a/test/elf/tls-gd2.sh
+++ b/test/elf/tls-gd2.sh
@@ -12,7 +12,7 @@ echo -n "Testing $testname ... "
 t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
-if [ $MACHINE = x86_64]; then
+if [ $MACHINE = x86_64 ]; then
   mtls=-mtls-dialect=gnu
 elif [ $MACHINE = aarch64 ]; then
   mtls=-mtls-dialect=trad


### PR DESCRIPTION
Fixes:
```
./test/elf/tls-gd2.sh: line 15: [: missing `]'
```

Signed-off-by: Martin Liska <mliska@suse.cz>