### PR TITLE
fix -Wreoder warning

### DIFF
--- a/elf/elf.h
+++ b/elf/elf.h
@@ -2098,7 +2098,7 @@ struct PPCEL64Sym {
 struct SparcEB64Rela {
   SparcEB64Rela() = default;
   SparcEB64Rela(u64 r_offset, u32 r_type, u32 r_sym, i64 r_addend)
-    : r_offset(r_offset), r_sym(r_sym), r_type(r_type), r_type_data(0),
+    : r_offset(r_offset), r_sym(r_sym), r_type_data(0), r_type(r_type),
       r_addend(r_addend) {}
 
   ub64 r_offset;


### PR DESCRIPTION
Fixes:

```
elf/elf.h:2107:6: warning: ‘mold::elf::SparcEB64Rela::r_type’ will be initialized after [-Wreorder]
 2107 |   u8 r_type;
      |      ^~~~~~
elf/elf.h:2106:8: warning:   ‘mold::ub24 mold::elf::SparcEB64Rela::r_type_data’ [-Wreorder]
 2106 |   ub24 r_type_data; // SPARC-specific: used for R_SPARC_OLO10
```

Signed-off-by: Martin Liska <mliska@suse.cz>