### PR TITLE
fix i686 ld warning

### DIFF
--- a/test/elf/tls-module-base-i386.sh
+++ b/test/elf/tls-module-base-i386.sh
@@ -31,6 +31,7 @@ get_foo:
 .section .tdata, "awT", @progbits
 foo:
 .long 20
+.section .note.GNU-stack, "", @progbits
 EOF
 
 cat <<EOF | $CC -fPIC -o $t/b.o -c -xc -


### PR DESCRIPTION
`ld: warning: out/test/elf/i686/tls-module-base-i386/a.o: missing .note.GNU-stack section implies executable stack`

Signed-off-by: Martin Liska <mliska@suse.cz>