### PR TITLE
Enable compress-debug-sections-zstd for GCC

### DIFF
--- a/test/elf/compress-debug-sections-zstd.sh
+++ b/test/elf/compress-debug-sections-zstd.sh
@@ -13,7 +13,6 @@ t=out/test/elf/$MACHINE/$testname
 mkdir -p $t
 
 [ $MACHINE == x86_64 ] || { echo skipped; exit; }
-[ $CC == cc ] || { echo skipped; exit; }
 command -v zstdcat >& /dev/null || { echo skipped; exit; }
 
 cat <<EOF | $CC -c -g -o $t/a.o -xc -


### PR DESCRIPTION
The compression option is directly passed to linker, so GCC can handle it as well.

Signed-off-by: Martin Liska <mliska@suse.cz>