### PR TITLE
Disable PIE in `run-clang.sh` unit test

### DIFF
--- a/test/elf/run-clang.sh
+++ b/test/elf/run-clang.sh
@@ -29,7 +29,7 @@ int main() {
 EOF
 
 LD_PRELOAD=`pwd`/mold-wrapper.so MOLD_PATH=`pwd`/mold \
-  clang -o $t/exe $t/a.o -fuse-ld=/usr/bin/ld
+  clang -no-pie -o $t/exe $t/a.o -fuse-ld=/usr/bin/ld
 readelf -p .comment $t/exe > $t/log
 grep -q mold $t/log
 


### PR DESCRIPTION
This fixes the following error when Clang 15 is installed on the system:
> mold: error: out/test/elf/x86_64/run-clang/a.o:(.text):
> R_X86_64_32 relocation at offset 0x5 against symbol `.rodata' can not
> be used; recompile with -fPIC

The error occurs because Clang 15 assumes PIE to be enabled by default: https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#build-system-changes

Attempting to produce a position-independent executable from an object file that was created by `cc` without `-fPIE` caused the linker to bail out.