### PR TITLE
cmake: use unambiguously absolute paths for install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 add_executable(mold)
 target_compile_features(mold PRIVATE cxx_std_20)
 target_compile_definitions(mold PRIVATE
-  "LIBDIR=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\"")
+  "LIBDIR=\"${CMAKE_INSTALL_FULL_LIBDIR}\"")
 target_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS})
 
 if(NOT "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
@@ -291,17 +291,17 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
   install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
   install(FILES docs/mold.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
   install(CODE "
-    set(DEST \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
+    set(DEST \"\$ENV{DESTDIR}\")
     file(RELATIVE_PATH RELPATH
-       /${CMAKE_INSTALL_LIBEXECDIR}/mold /${CMAKE_INSTALL_BINDIR}/mold)
+       /${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold /${CMAKE_INSTALL_FULL_BINDIR}/mold)
     execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
-      \${DEST}/${CMAKE_INSTALL_LIBEXECDIR}/mold)
+      \${DEST}/${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold)
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \${RELPATH}
-      \${DEST}/${CMAKE_INSTALL_LIBEXECDIR}/mold/ld)
+      \${DEST}/${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold/ld)
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink mold
-      \${DEST}/${CMAKE_INSTALL_BINDIR}/ld.mold)
+      \${DEST}/${CMAKE_INSTALL_FULL_BINDIR}/ld.mold)
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink mold
-      \${DEST}/${CMAKE_INSTALL_BINDIR}/ld64.mold)
+      \${DEST}/${CMAKE_INSTALL_FULL_BINDIR}/ld64.mold)
     execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink mold.1
-      \${DEST}/${CMAKE_INSTALL_MANDIR}/man1/ld.mold.1)")
+      \${DEST}/${CMAKE_INSTALL_FULL_MANDIR}/man1/ld.mold.1)")
 endif()


### PR DESCRIPTION
as per https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html CMAKE_INSTALL_<dir> can be both relative and absolute. so far mold made assumption these are relative only, but handle both cases by using CMAKE_INSTALL_FULL_<dir> instead.

Signed-off-by: Jan Palus <jpalus@fastmail.com>