### PR TITLE
Detect skipped tests

### DIFF
--- a/test/elf/CMakeLists.txt
+++ b/test/elf/CMakeLists.txt
@@ -13,6 +13,12 @@ function(add_qemu_test TEST TRIPLE MACHINE)
       COMMAND bash -x ${CMAKE_CURRENT_LIST_DIR}/${TEST}
       WORKING_DIRECTORY ${mold_BINARY_DIR})
 
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
+      set_property(TEST "${MACHINE}-${TEST}" PROPERTY
+        SKIP_REGULAR_EXPRESSION "skipped"
+      )
+    endif()
+
     set(ENV
       TEST_CC=${TRIPLE}-gcc
       TEST_CXX=${TRIPLE}-g++
@@ -29,6 +35,12 @@ foreach(TEST IN LISTS TESTS)
   add_test(NAME "${CMAKE_HOST_SYSTEM_PROCESSOR}-${TEST}"
     COMMAND bash -x ${CMAKE_CURRENT_LIST_DIR}/${TEST}
     WORKING_DIRECTORY ${mold_BINARY_DIR})
+
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
+    set_property(TEST "${CMAKE_HOST_SYSTEM_PROCESSOR}-${TEST}" PROPERTY
+      SKIP_REGULAR_EXPRESSION "skipped"
+    )
+  endif()
 
   if(MOLD_ENABLE_QEMU_TESTS)
     add_qemu_test(${TEST} x86_64-linux-gnu x86_64)

--- a/test/macho/CMakeLists.txt
+++ b/test/macho/CMakeLists.txt
@@ -7,4 +7,10 @@ foreach(TEST IN LISTS TESTS)
   add_test(NAME ${TEST}
     COMMAND bash -x ${CMAKE_CURRENT_LIST_DIR}/${TEST}
     WORKING_DIRECTORY ${mold_BINARY_DIR})
+
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16")
+    set_property(TEST ${TEST} PROPERTY
+      SKIP_REGULAR_EXPRESSION "skipped"
+    )
+  endif()
 endforeach()


### PR DESCRIPTION
This allows CTest to differentiate between tests that were executed successfully and tests that were skipped.

The [`SKIP_REGULAR_EXPRESSION`](https://cmake.org/cmake/help/latest/prop_test/SKIP_REGULAR_EXPRESSION.html) property was added in CMake 3.16, so we need conditional `if`-blocks around the places where we set it. Alternatively, we could increase `cmake_minimum_required(VERSION 3.13)` in the main `CMakeLists.txt`.

Side note: Ubuntu 20.04 comes with CMake 3.16.3.

Which would you prefer?