### PR TITLE
only ignore .gnu.warning. sections if emit_relocs is true

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -186,7 +186,7 @@ void ObjectFile<E>::initialize_sections(Context<E> &ctx) {
         continue;
       }
 
-      if (name.starts_with(".gnu.warning."))
+      if (name.starts_with(".gnu.warning.") && !ctx.arg.emit_relocs)
         continue;
 
       if (name == ".note.gnu.property") {


### PR DESCRIPTION
This attempts to fix Issue #567 where mold would segfault trying to emit relocations for .gnu.warning. sections.