### PR TITLE
Optionally detect skipped tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,13 @@ target_sources(mold PRIVATE
 
 include(CTest)
 
+option(MOLD_SHOW_SKIPPED_TESTS "Print list of skipped tests in the summary" OFF)
+if(MOLD_SHOW_SKIPPED_TESTS AND ${CMAKE_VERSION} VERSION_LESS "3.16")
+  # This feature uses `SKIP_REGULAR_EXPRESSION`, which requires CMake >= 3.16
+  message(WARNING "MOLD_SHOW_SKIPPED_TESTS=ON requires CMake >= 3.16; forcing it to OFF")
+  set(MOLD_SHOW_SKIPPED_TESTS OFF)
+endif()
+
 if(BUILD_TESTING)
   # Create the ld and ld64 symlinks required for testing
   if(NOT WIN32)

--- a/test/elf/CMakeLists.txt
+++ b/test/elf/CMakeLists.txt
@@ -30,6 +30,12 @@ foreach(TEST IN LISTS TESTS)
     COMMAND bash -x ${CMAKE_CURRENT_LIST_DIR}/${TEST}
     WORKING_DIRECTORY ${mold_BINARY_DIR})
 
+  if(MOLD_SHOW_SKIPPED_TESTS)
+    set_property(TEST "${CMAKE_HOST_SYSTEM_PROCESSOR}-${TEST}" PROPERTY
+      SKIP_REGULAR_EXPRESSION "skipped"
+    )
+  endif()
+
   if(MOLD_ENABLE_QEMU_TESTS)
     add_qemu_test(${TEST} x86_64-linux-gnu x86_64)
     add_qemu_test(${TEST} i686-linux-gnu i386)

--- a/test/macho/CMakeLists.txt
+++ b/test/macho/CMakeLists.txt
@@ -7,4 +7,10 @@ foreach(TEST IN LISTS TESTS)
   add_test(NAME ${TEST}
     COMMAND bash -x ${CMAKE_CURRENT_LIST_DIR}/${TEST}
     WORKING_DIRECTORY ${mold_BINARY_DIR})
+
+  if(MOLD_SHOW_SKIPPED_TESTS)
+    set_property(TEST ${TEST} PROPERTY
+      SKIP_REGULAR_EXPRESSION "skipped"
+    )
+  endif()
 endforeach()


### PR DESCRIPTION
Second attempt; I'm making it opt-in this time. 🙂

This allows CTest to differentiate between tests that were executed successfully and tests that were skipped.

Since CTest prints a list of skipped tests at the very end of its output, skipping many tests may cause the overall result (e.g. '100% tests passed, 0 tests failed out of 275') to scroll out of sight. Hence, make this feature opt-in under the flag
`MOLD_SHOW_SKIPPED_TESTS`.

The `SKIP_REGULAR_EXPRESSION` test property was added in CMake 3.16, so make that minimum version a prerequisite for enabling `MOLD_SHOW_SKIPPED_TESTS`.