### PR TITLE
Makes xcode tests run

### DIFF
--- a/macho/main.cc
+++ b/macho/main.cc
@@ -785,6 +785,13 @@ static void read_input_files(Context<E> &ctx, std::span<std::string> args) {
     read_file(ctx, mf);
   };
 
+  auto read_bundle = [&](std::string name) {
+    MappedFile<Context<E>> *mf = MappedFile<Context<E>>::open(ctx, name);
+    if (!mf)
+      Fatal(ctx) << "library not found: -l" << name;
+    read_file(ctx, mf);
+  };
+
   auto find_framework = [&](std::string name) -> MappedFile<Context<E>> * {
     std::string suffix;
     std::tie(name, suffix) = split_string(name, ',');
@@ -886,7 +893,7 @@ static void read_input_files(Context<E> &ctx, std::span<std::string> args) {
 
   // With -bundle_loader, we can import symbols from a main executable.
   if (!ctx.arg.bundle_loader.empty())
-    read_library(ctx.arg.bundle_loader);
+    read_bundle(ctx.arg.bundle_loader);
 
   // An object file can contain linker directives to load other object
   // files or libraries, so process them if any.


### PR DESCRIPTION
Fixes: https://github.com/rui314/mold/issues/748

It looks like reading a bundle was being treated as a library even though the bundle is emitted as a single object. I don't have technical knowledge of linkers, but I'm trying to learn here. Tests are passing, but I don't know if I should add more. My example Xcode project tests are working fine now too. 😁

For the main project I'm working on, individual test targets are working fine as well but I found another bug I'm gonna file separately. 