### PR TITLE
tests: add missing MACHINE check in x86_64_large-bss.sh

### DIFF
--- a/test/elf/x86_64_large-bss.sh
+++ b/test/elf/x86_64_large-bss.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = x86_64 ] || skip
+
 cat <<EOF | $CC -o $t/a.o -c -xc - 2> /dev/null || skip
 volatile char arr[0x100000000];
 int main() {


### PR DESCRIPTION
Signed-off-by: Martin Liska <mliska@suse.cz>