### PR TITLE
README.md: mention that installing clang is not needed for Rust when using the latest GCC

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ Please make sure you have installed `clang`.
 If you want to use mold for all projects, put the above snippet to
 `~/.cargo/config.toml`.
 
+If you are using GCC 12.1.0 or later, installing `clang` is not necessary.
+The Cargo configuration snippet above can be simplified to the following:
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+```
+
 If you are using macOS, you can modify `config.toml` in a similar manner.
 Here is an example with `mold` installed via [Homebrew](https://brew.sh).
 


### PR DESCRIPTION
As explained in the "A classic way to use mold" usage instructions section, the latest GCC releases support `mold` out of the box. Rust can take advantage of this to use `mold` too, without going through a system-wide `clang` linker.

I've just tested this on my Linux workstation that runs Debian unstable.