### PR TITLE
fix compiler warnings

### DIFF
--- a/elf/arch-ppc64v1.cc
+++ b/elf/arch-ppc64v1.cc
@@ -275,19 +275,11 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       continue;
 
     Symbol<E> &sym = *file.symbols[rel.r_sym];
-    u8 *loc = base + rel.r_offset;
 
     if (!sym.file) {
       record_undef_error(ctx, rel);
       continue;
     }
-
-    auto check = [&](i64 val, i64 lo, i64 hi) {
-      if (val < lo || hi <= val)
-        Error(ctx) << *this << ": relocation " << rel << " against "
-                   << sym << " out of range: " << val << " is not in ["
-                   << lo << ", " << hi << ")";
-    };
 
     SectionFragment<E> *frag;
     i64 frag_addend;

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1397,7 +1397,7 @@ void GotPltSection<E>::copy_buf(Context<E> &ctx) {
     if (ctx.dynamic)
       buf[0] = ctx.dynamic->shdr.sh_addr;
 
-    for (i64 i = 3; Symbol<E> *sym : ctx.plt->symbols)
+    for (i64 i = 3; [[maybe_unused]] Symbol<E> *sym : ctx.plt->symbols)
       buf[i++] = ctx.plt->shdr.sh_addr;
   }
 }


### PR DESCRIPTION
Fixes:

```
elf/arch-ppc64v1.cc:278:9: warning: unused variable 'loc' [-Wunused-variable]
elf/arch-ppc64v1.cc:285:10: warning: variable 'check' set but not used [-Wunused-but-set-variable]
elf/output-chunks.cc:1400:32: warning: unused variable 'sym' [-Wunused-variable]
```

Signed-off-by: Martin Liska <mliska@suse.cz>