### PR TITLE
[ELF] Rework version_specified handling.

### DIFF
--- a/elf/linker-script.cc
+++ b/elf/linker-script.cc
@@ -272,7 +272,6 @@ template <typename E>
 static void
 read_version_script_commands(Context<E> &ctx, std::span<std::string_view> &tok,
                              u16 ver_idx, bool is_cpp) {
-  ctx.version_specified = true;
   bool is_global = true;
 
   while (!tok.empty() && tok[0] != "}") {
@@ -306,6 +305,7 @@ read_version_script_commands(Context<E> &ctx, std::span<std::string_view> &tok,
 
     if (tok[0] == "*") {
       ctx.default_version = (is_global ? ver_idx : VER_NDX_LOCAL);
+      ctx.default_version_from_version_script = true;
     } else if (is_global) {
       ctx.version_patterns.push_back({unquote(tok[0]), ver_idx, is_cpp});
     } else {
@@ -357,8 +357,6 @@ void parse_version_script(Context<E> &ctx, std::string path) {
 template <typename E>
 void read_dynamic_list_commands(Context<E> &ctx, std::span<std::string_view> &tok,
                                 bool is_cpp) {
-  ctx.version_specified = true;
-
   while (!tok.empty() && tok[0] != "}") {
     if (tok[0] == "extern") {
       tok = tok.subspan(1);

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -276,7 +276,6 @@ static void read_input_files(Context<E> &ctx, std::span<std::string> args) {
         ctx.default_version = VER_NDX_GLOBAL;
       else
         ctx.version_patterns.push_back({arg, VER_NDX_GLOBAL, false});
-      ctx.version_specified = true;
     } else if (remove_prefix(arg, "--export-dynamic-symbol-list=")) {
       parse_dynamic_list(ctx, std::string(arg));
     } else if (arg == "--push-state") {

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1592,7 +1592,7 @@ struct Context {
 
   std::vector<VersionPattern> version_patterns;
   u16 default_version = VER_NDX_GLOBAL;
-  bool version_specified = false;
+  bool default_version_from_version_script = false; // true if default_version is set by a wildcard in version script.
   i64 page_size = -1;
 
   // Reader context

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -1214,7 +1214,7 @@ void compute_import_export(Context<E> &ctx) {
     tbb::parallel_for_each(ctx.dsos, [&](SharedFile<E> *file) {
       for (Symbol<E> *sym : file->symbols) {
         if (sym->file && !sym->file->is_dso && sym->visibility != STV_HIDDEN) {
-          if (sym->ver_idx != VER_NDX_LOCAL || !ctx.version_specified) {
+          if (sym->ver_idx != VER_NDX_LOCAL || !ctx.default_version_from_version_script) {
             std::scoped_lock lock(sym->mu);
             sym->is_exported = true;
           }


### PR DESCRIPTION
We should only override the default export behavior in executable if the default version was actually overridden by a linker script (i.e. local: *;). Other options, such as --dynamic-list and --export-dynamic-symbol[-list], doesn't actually change this default, and should not be considered for this override.

This should fix the regression part of #606, however there's still the question where specifying a version script for C++ binaries can almost certainly get you an ODR violation, since stripping the `WEAK` ODR symbols isn't actually safe.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>