### PR TITLE
fix 2 -Wextra warnings

### DIFF
--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -22,7 +22,7 @@ static char *get_mold_path() {
   exit(1);
 }
 
-static void debug_print(char *fmt, ...) {
+static void debug_print(const char *fmt, ...) {
   if (!getenv("MOLD_WRAPPER_DEBUG"))
     return;
 

--- a/macho/mold.h
+++ b/macho/mold.h
@@ -233,7 +233,7 @@ public:
   u32 nrels = 0;
   u32 unwind_offset = 0;
   u32 nunwind = 0;
-  Subsection<E> *replacer; // Used if is_coalesced is true
+  Subsection<E> *replacer = nullptr; // Used if is_coalesced is true
 
   std::atomic_uint8_t p2align = 0;
   std::atomic_bool is_alive = true;


### PR DESCRIPTION
Fixes:
macho/input-files.cc:310:31: warning: missing initializer for member ‘mold::macho::Subsection<mold::macho::ARM64>::replacer’ [-Wmissing-field-initializers] elf/mold-wrapper.c:68:15: warning: passing argument 1 of ‘debug_print’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]

Signed-off-by: Martin Liska <mliska@suse.cz>