### PR TITLE
[ELF] Assign the correct SHNDX to symbols killed by ICF.

### DIFF
--- a/elf/mold.h
+++ b/elf/mold.h
@@ -329,6 +329,13 @@ public:
   std::atomic_bool is_visited = false;
 
   // For ICF
+  //
+  // `leader` is the section that this section has been merged with.
+  // Three kind of values are possible:
+  // - `leader == nullptr`: This section was not eligible for ICF.
+  // - `leader == this`: This section was retained.
+  // - `leader != this`: This section was merged with another idential section.
+  //                     Implies `killed_by_icf`.
   InputSection<E> *leader = nullptr;
   u32 icf_idx = -1;
   bool icf_eligible = false;

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1596,9 +1596,13 @@ ElfSym<E> to_output_esym(Context<E> &ctx, Symbol<E> &sym) {
       if (sym.has_opd(ctx))
         return ctx.ppc64_opd->shndx;
 
-    if (InputSection<E> *isec = sym.get_input_section())
+    if (InputSection<E> *isec = sym.get_input_section()) {
       if (isec->is_alive)
         return isec->output_section->shndx;
+      else if (isec->killed_by_icf)
+        return isec->leader->output_section->shndx;
+    }
+
     return SHN_UNDEF;
   };
 


### PR DESCRIPTION
We have been setting the symbol value and size correctly, but the SHNDX was
erroneously set to UND, potentially causing undefined symbol errors. Fix this by
forwarding the appropriate value from the `leader`.

Closes: #779 