### PR TITLE
[ELF] Replace killed_by_icf with is_killed_by_icf().

### DIFF
--- a/elf/icf.cc
+++ b/elf/icf.cc
@@ -595,7 +595,6 @@ void icf_sections(Context<E> &ctx) {
           InputSection<E> *isec = sym->get_input_section();
           if (isec && isec->leader && isec->leader != isec) {
             isec->kill();
-            isec->killed_by_icf = true;
           }
         }
       }

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1599,7 +1599,7 @@ ElfSym<E> to_output_esym(Context<E> &ctx, Symbol<E> &sym) {
     if (InputSection<E> *isec = sym.get_input_section()) {
       if (isec->is_alive)
         return isec->output_section->shndx;
-      else if (isec->killed_by_icf)
+      else if (isec->is_killed_by_icf())
         return isec->leader->output_section->shndx;
     }
 


### PR DESCRIPTION
One less bit of state and should be clearer how the property is computed.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>