### PR TITLE
Add precompiled headers for CMake builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       matrix:
         target:
-        - ''
+        # Disable PCH for the default configuration. This prevents relying on implicit includes.
+        - '-DCMAKE_DISABLE_PRECOMPILE_HEADERS=On'
         - '-DMOLD_USE_ASAN=On'
         - '-DMOLD_USE_TSAN=On'
     runs-on: ubuntu-20.04
@@ -156,7 +157,8 @@ jobs:
     strategy:
       matrix:
         target:
-        - ''
+        # Disable PCH for the default configuration. This prevents relying on implicit includes.
+        - '-DCMAKE_DISABLE_PRECOMPILE_HEADERS=On'
         - '-DMOLD_USE_ASAN=On'
     steps:
     - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,13 @@ target_sources(mold PRIVATE
   uuid.cc
   )
 
+# Add frequently included header files for pre-compiling.
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0") # for target_precompile_headers
+target_precompile_headers(mold PRIVATE
+  "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/elf/mold.h>"
+  "$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SOURCE_DIR}/macho/mold.h>")
+endif()
+
 include(CTest)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Since we're having lots of arch-generic permutations, headers seems to be a goodplace where potential perf improvement are possible.

The feature is gated against CMake 3.16.0 or later, which is when it was implemented.

Measured on 3990X, with this change it takes:
```
ninja  1166.22s user 34.45s system 5378% cpu 22.322 total
```
While before it took:
```
ninja  1776.81s user 51.30s system 7172% cpu 25.489 total
```

So a 10% improvement for workstation users and even more if you don't.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>