### PR TITLE
CMake: Only add `-latomic` for armv6, not armv7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ if(NOT APPLE AND NOT WIN32 AND NOT MOLD_MOSTLY_STATIC)
   target_link_libraries(mold PRIVATE OpenSSL::Crypto)
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64|armv)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64|armv6)")
   target_link_libraries(mold PRIVATE atomic)
 endif()
 


### PR DESCRIPTION
This matches what was done in `Makefile` in #561, but the check was extended in the CMake port.

It builds fine without `-latomic` on Mageia 9 armv7hl nodes, fails with explicit `-latomic`.