### PR TITLE
[ELF] Fix --emit-relocs r_sym indices.

### DIFF
--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -2878,7 +2878,7 @@ static i64 get_output_sym_idx(Symbol<E> &sym) {
   i64 idx2 = sym.file->output_sym_indices[sym.sym_idx];
   assert(idx2 != -1);
 
-  if (sym.sym_idx < sym.file->first_global)
+  if (sym.is_local())
     return sym.file->local_symtab_idx + idx2;
   return sym.file->global_symtab_idx + idx2;
 }

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -1055,24 +1055,6 @@ void create_reloc_sections(Context<E> &ctx) {
     ctx.chunks.push_back(r);
     ctx.chunk_pool.emplace_back(r);
   }
-
-  // Create a table to map input symbol indices to output symbol indices
-  auto set_indices = [&](InputFile<E> *file) {
-    file->output_sym_indices.resize(file->elf_syms.size(), -1);
-
-    for (i64 i = 1, j = 0; i < file->first_global; i++)
-      if (Symbol<E> &sym = *file->symbols[i];
-          sym.file == file && sym.write_to_symtab)
-        file->output_sym_indices[i] = j++;
-
-    for (i64 i = file->first_global, j = 0; i < file->elf_syms.size(); i++)
-      if (Symbol<E> &sym = *file->symbols[i];
-          sym.file == file && sym.write_to_symtab)
-        file->output_sym_indices[i] = j++;
-  };
-
-  tbb::parallel_for_each(ctx.objs, set_indices);
-  tbb::parallel_for_each(ctx.dsos, set_indices);
 }
 
 template <typename E>


### PR DESCRIPTION
536e0e7d ("[elf] Align .symtab's ELF attributes with .dynsym's.") fixed the issue of .dynsym and .symtab disagreeing with each other, but in the process introduced change to the symtab index. --emit-relocs was assuming the old assignment logic, which caused mismatches as soon as any global-to-local demotion happened.

Fix this to use the demotion-aware assignment logic by directly filling in the indices as we assign them to symtab, and by making get_output_sym_idx to test global/local using the new is_local() helper.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>