### PR TITLE
Do not build `subprocess.cc` on macOS

### DIFF
--- a/elf/subprocess.cc
+++ b/elf/subprocess.cc
@@ -1,4 +1,4 @@
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 
 #include "mold.h"
 


### PR DESCRIPTION
IIUC, `subprocess.cc` exports `fork_child` and `process_run_subcommand`. While they are not used in Windows and macOS, the `ifndef` guard only excludes the former.

Signed-off-by: Zhong Ruoyu <zhongruoyu@outlook.com>
