### PR TITLE
[ELF] Fix uninitialized ElfSym paddings

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1535,6 +1535,7 @@ template <typename E>
 void SharedFile<E>::populate_symtab(Context<E> &ctx) {
   ElfSym<E> *symtab =
     (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->global_symtab_idx;
+  memset(symtab, 0, sizeof(ElfSym<E>) * this->num_global_symtab);
 
   u8 *strtab = ctx.buf + ctx.strtab->shdr.sh_offset + this->strtab_offset;
 

--- a/elf/lto-unix.cc
+++ b/elf/lto-unix.cc
@@ -508,7 +508,8 @@ static void load_plugin(Context<E> &ctx) {
 
 template <typename E>
 static ElfSym<E> to_elf_sym(PluginSymbol &psym) {
-  ElfSym<E> esym = {};
+  ElfSym<E> esym;
+  memset(&esym, 0, sizeof(esym));
 
   switch (psym.def) {
   case LDPK_DEF:


### PR DESCRIPTION
Designated initializer doesn't initialize the padding; make sure we memset them by ourselves.

Fixes readelf complaning about garbage after the visibility field.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>