### PR TITLE
[ELF] Move ElfSym memset to inside of loop.

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1535,7 +1535,6 @@ template <typename E>
 void SharedFile<E>::populate_symtab(Context<E> &ctx) {
   ElfSym<E> *symtab =
     (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->global_symtab_idx;
-  memset(symtab, 0, sizeof(ElfSym<E>) * this->num_global_symtab);
 
   u8 *strtab = ctx.buf + ctx.strtab->shdr.sh_offset + this->strtab_offset;
 
@@ -1545,6 +1544,7 @@ void SharedFile<E>::populate_symtab(Context<E> &ctx) {
       continue;
 
     ElfSym<E> &esym = *symtab++;
+    memset(&esym, 0, sizeof(esym));
     esym.st_name = strtab - (ctx.buf + ctx.strtab->shdr.sh_offset);
     esym.st_value = 0;
     esym.st_size = 0;

--- a/elf/output-chunks.cc
+++ b/elf/output-chunks.cc
@@ -1094,7 +1094,6 @@ void OutputSection<E>::populate_symtab(Context<E> &ctx) {
   if constexpr (needs_thunk<E>) {
     ElfSym<E> *esym =
       (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->local_symtab_idx;
-    memset(esym, 0, this->num_local_symtab * sizeof(ElfSym<E>));
 
     u8 *strtab_base = ctx.buf + ctx.strtab->shdr.sh_offset;
     u8 *strtab = strtab_base + this->strtab_offset;
@@ -1112,6 +1111,7 @@ void OutputSection<E>::populate_symtab(Context<E> &ctx) {
         Symbol<E> &sym = *thunk->symbols[i];
 
         auto write_esym = [&](i64 st_name, i64 off) {
+          memset(esym, 0, sizeof(*esym));
           esym->st_name = st_name;
           esym->st_type = STT_FUNC;
           esym->st_shndx = this->shndx;
@@ -1378,12 +1378,12 @@ void GotSection<E>::populate_symtab(Context<E> &ctx) {
 
   ElfSym<E> *esym =
     (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->local_symtab_idx;
-  memset(esym, 0, this->num_local_symtab * sizeof(ElfSym<E>));
 
   u8 *strtab_base = ctx.buf + ctx.strtab->shdr.sh_offset;
   u8 *strtab = strtab_base + this->strtab_offset;
 
   auto write = [&](std::string_view name, std::string_view suffix, i64 value) {
+    memset(esym, 0, sizeof(*esym));
     esym->st_name = strtab - strtab_base;
     esym->st_type = STT_OBJECT;
     esym->st_shndx = this->shndx;
@@ -1481,12 +1481,12 @@ void PltSection<E>::populate_symtab(Context<E> &ctx) {
 
   ElfSym<E> *esym =
     (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->local_symtab_idx;
-  memset(esym, 0, symbols.size() * sizeof(ElfSym<E>));
 
   u8 *strtab_base = ctx.buf + ctx.strtab->shdr.sh_offset;
   u8 *strtab = strtab_base + this->strtab_offset;
 
   for (Symbol<E> *sym : symbols) {
+    memset(esym, 0, sizeof(*esym));
     esym->st_name = strtab - strtab_base;
     esym->st_type = STT_FUNC;
     esym->st_shndx = this->shndx;
@@ -1534,12 +1534,12 @@ void PltGotSection<E>::populate_symtab(Context<E> &ctx) {
 
   ElfSym<E> *esym =
     (ElfSym<E> *)(ctx.buf + ctx.symtab->shdr.sh_offset) + this->local_symtab_idx;
-  memset(esym, 0, symbols.size() * sizeof(ElfSym<E>));
 
   u8 *strtab_base = ctx.buf + ctx.strtab->shdr.sh_offset;
   u8 *strtab = strtab_base + this->strtab_offset;
 
   for (Symbol<E> *sym : symbols) {
+    memset(esym, 0, sizeof(*esym));
     esym->st_name = strtab - strtab_base;
     esym->st_type = STT_FUNC;
     esym->st_shndx = this->shndx;


### PR DESCRIPTION
Should eliminate redundant assignments and improve memory locality.

Suggested by https://github.com/rui314/mold/pull/807#discussion_r1002442603.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>