### PR TITLE
Fix name lookup for section symbols when `st_shndx == SHN_XINDEX`

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -439,7 +439,7 @@ void ObjectFile<E>::initialize_symbols(Context<E> &ctx) {
 
     std::string_view name;
     if (esym.st_type == STT_SECTION)
-      name = this->shstrtab.data() + this->elf_sections[esym.st_shndx].sh_name;
+      name = this->shstrtab.data() + this->elf_sections[get_shndx(esym)].sh_name;
     else
       name = this->symbol_strtab.data() + esym.st_name;
 


### PR DESCRIPTION
When the section-header index has the escape value `SHN_XINDEX`, the actual index must be looked up in the separate `SHT_SYMTAB_SHNDX` table. Trying to use `SHN_XINDEX` (= 0xffff) as an index results in an out-of-bounds read. The error can be observed when running the `x86_64_many-sections.sh` test on RHEL 8 or 9 (but not on Fedora, because there the assembler doesn't emit section symbols).

Instead of using `st_shndx` directly, call the pre-existing helper method `get_shndx()` to get the correct behaviour.