### PR TITLE
Add an optimized mark function for faster GC passes.

### DIFF
--- a/elf/gc-sections.cc
+++ b/elf/gc-sections.cc
@@ -26,7 +26,7 @@ static bool is_init_fini(const InputSection<E> &isec) {
 
 template <typename E>
 static bool mark_section(InputSection<E> *isec) {
-  return isec && isec->is_alive && !isec->is_visited.exchange(true);
+  return isec && isec->is_alive && fast_mark(isec->is_visited);
 }
 
 template <typename E>

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -942,7 +942,7 @@ ObjectFile<E>::mark_live_objects(Context<E> &ctx,
       continue;
 
     bool keep = esym.is_undef() || (esym.is_common() && !sym.esym().is_common());
-    if (keep && !sym.file->is_alive.exchange(true)) {
+    if (keep && fast_mark(sym.file->is_alive)) {
       feeder(sym.file);
 
       if (sym.traced)
@@ -1468,7 +1468,7 @@ SharedFile<E>::mark_live_objects(Context<E> &ctx,
       print_trace_symbol(ctx, *this, esym, sym);
 
     if (esym.is_undef() && sym.file && !sym.file->is_dso &&
-        !sym.file->is_alive.exchange(true)) {
+        fast_mark(sym.file->is_alive)) {
       feeder(sym.file);
 
       if (sym.traced)

--- a/macho/dead-strip.cc
+++ b/macho/dead-strip.cc
@@ -48,7 +48,7 @@ static std::vector<Subsection<E> *> collect_root_set(Context<E> &ctx) {
 
 template <typename E>
 static void visit(Context<E> &ctx, Subsection<E> &subsec) {
-  if (subsec.is_alive.exchange(true))
+  if (!fast_mark(subsec.is_alive))
     return;
 
   for (Relocation<E> &rel : subsec.get_rels()) {

--- a/macho/input-files.cc
+++ b/macho/input-files.cc
@@ -658,7 +658,7 @@ ObjectFile<E>::mark_live_objects(Context<E> &ctx,
 
     if (msym.is_undef() || (msym.is_common() && !sym.is_common))
       if (InputFile<E> *file = sym.file)
-        if (!file->is_alive.exchange(true) && !file->is_dylib)
+        if (fast_mark(file->is_alive) && !file->is_dylib)
           feeder((ObjectFile<E> *)file);
   }
 
@@ -666,7 +666,7 @@ ObjectFile<E>::mark_live_objects(Context<E> &ctx,
     for (UnwindRecord<E> &rec : subsec->get_unwind_records())
       if (Symbol<E> *sym = rec.personality)
         if (InputFile<E> *file = sym->file)
-          if (!file->is_alive.exchange(true) && !file->is_dylib)
+          if (fast_mark(file->is_alive) && !file->is_dylib)
             feeder((ObjectFile<E> *)file);
 }
 


### PR DESCRIPTION
seq_cst atomic operations can take hundreds of cycles and tends to be massively slower than a fence-free alternative.

Add a fast_mark function that optimistically tests if the node is already visited first, which allows avoiding the fence penalty if we can early exit.

When testing on Chromium, this roughly improved the associated pass's runtime by 20--30%.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>