### PR TITLE
Remove lock from clear_symbols and add a justification for disabling TSan

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -49,10 +49,15 @@ ElfShdr<E> *InputFile<E>::find_section(i64 type) {
   return nullptr;
 }
 
+// This function is actually racy, in that "tearing" might be observed during the read or write of `sym->file`.
+// However, on most platforms read/write of pointers never tears, and even if it did, it would be harmless, as
+// `sym->file` will not become equal to `sym`, or even if it did by chance, we just wipe a symbol twice.
+// Doing this in a standard-compliant way is too cumbersome, hence here we just pretend a compiler will never optimize
+// this into a form that actually exploits the UB.
 template <typename E>
+__attribute__((no_sanitize("thread")))
 void InputFile<E>::clear_symbols() {
   for (Symbol<E> *sym : get_global_syms()) {
-    std::scoped_lock lock(sym->mu);
     if (sym->file == this)
       sym->clear();
   }


### PR DESCRIPTION
As discussed in #813, doing a mutex lock is too pessimistic here but having a correct fix would also be cumbersome. Hence we add a justification for it and prevent TSan from complaining about the harmless race.