### PR TITLE
[ELF] Use to_output_esym for symtab entries from DSOs.

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1558,15 +1558,9 @@ void SharedFile<E>::populate_symtab(Context<E> &ctx) {
       continue;
 
     ElfSym<E> &esym = *symtab++;
-    memset(&esym, 0, sizeof(esym));
-    esym.st_name = strtab - (ctx.buf + ctx.strtab->shdr.sh_offset);
-    esym.st_value = 0;
-    esym.st_size = 0;
-    esym.st_type = STT_NOTYPE;
-    esym.st_bind = STB_GLOBAL;
-    esym.st_visibility = sym.visibility;
-    esym.st_shndx = SHN_UNDEF;
+    esym = to_output_esym(ctx, sym);
 
+    esym.st_name = strtab - (ctx.buf + ctx.strtab->shdr.sh_offset);
     write_string(strtab, sym.name());
     strtab += sym.name().size() + 1;
   }


### PR DESCRIPTION
DSO symtab handling was relatively simple, but it led to wrong entries when copyrel was used.

Seen in #827 and #789. BOLT dynreloc.s no longer asserts with this (but still fails because LLD and the expectation doesn't emit copyrel apparently).