### PR TITLE
[ELF] Fix absolute paths handling in linker scripts

### DIFF
--- a/filepath.cc
+++ b/filepath.cc
@@ -20,7 +20,7 @@ std::string path_clean(std::string_view path) {
 
 std::filesystem::path to_abs_path(std::filesystem::path path) {
   if (path.is_absolute())
-    return path;
+    return path.lexically_normal();
   return (std::filesystem::current_path() / path).lexically_normal();
 }
 

--- a/test/elf/sysroot2.sh
+++ b/test/elf/sysroot2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
-mkdir -p $t/sysroot/foo
+mkdir -p $t/bin $t/sysroot/foo
 
 cat <<EOF > $t/a.script
 INPUT(=/foo/x.o)
@@ -36,4 +36,7 @@ int main() {
 EOF
 
 $CC -B. -o $t/exe -Wl,--sysroot=$t/sysroot \
+  $t/a.script $t/sysroot/b.script $t/c.o
+
+$CC -B. -o $t/exe -Wl,--sysroot=$(realpath $t)/bin/../sysroot \
   $t/a.script $t/sysroot/b.script $t/c.o


### PR DESCRIPTION
With toolchains using a relative sysroot, like crosstool-ng, gcc/clang will call the linker with something like "--sysroot=/path/bin/../machine/sysroot". The is_in_sysroot detection wasn't working in this case.

Since to_abs_path() uses lexically_normal() for relative paths, it seems consistent to do the same for absolute paths instead of modifying is_in_sysroot().