### PR TITLE
fix -Wunused-variable warning

### DIFF
--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -1515,7 +1515,6 @@ void sort_output_sections_by_order(Context<E> &ctx) {
   };
 
   auto get_rank = [&](Chunk<E> *chunk) -> i64 {
-    u64 type = chunk->shdr.sh_type;
     u64 flags = chunk->shdr.sh_flags;
 
     if (chunk == ctx.ehdr)


### PR DESCRIPTION
Fixes:
elf/passes.cc:1516:9: warning: unused variable 'type' [-Wunused-variable]