### PR TITLE
[ELF][m68k] Linking against libatomic is required on m68k

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if(NOT APPLE AND NOT WIN32 AND NOT MOLD_MOSTLY_STATIC)
   target_link_libraries(mold PRIVATE OpenSSL::Crypto)
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64|armv6)")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64|armv6|m68k)")
   target_link_libraries(mold PRIVATE atomic)
 endif()
 


### PR DESCRIPTION
Signed-off-by: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>