### PR TITLE
fix cmake error with system tbb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ endif()
 
 # If atomics doesn't work by default, add -latomic.
 # We need the flag on riscv, armv6 and m68k.
+INCLUDE(CheckCXXSourceCompiles)
 check_cxx_source_compiles("#include <cstdint>
 int main() {
   uint64_t x = 1;


### PR DESCRIPTION
fixes cmake error `Unknown CMake command "check_cxx_source_compiles"` when compiling latest mold https://github.com/rui314/mold/commit/00acf3d2f6912f55c729a367dab905111c39b69f with system tbb, see https://reviews.llvm.org/D17961 for similar issue