### PR TITLE
Respect prefix set by `cmake --install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,17 +376,19 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
   install(TARGETS mold RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
   install(FILES docs/mold.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
-  install(CODE "
-    file(RELATIVE_PATH RELPATH
-       /${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold /${CMAKE_INSTALL_FULL_BINDIR}/mold)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
-      \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \${RELPATH}
-      \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold/ld)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink mold
-      \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR}/ld.mold)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink mold
-      \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR}/ld64.mold)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink mold.1
-      \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_MANDIR}/man1/ld.mold.1)")
+
+  function(mold_install_symlink OLD NEW)
+    install(CODE "
+      get_filename_component(PREFIX_ABS \${CMAKE_INSTALL_PREFIX} ABSOLUTE)
+      get_filename_component(NEW_DIR
+        \$ENV{DESTDIR}/\${PREFIX_ABS}/${NEW} DIRECTORY)
+      file(MAKE_DIRECTORY \${NEW_DIR})
+      file(CREATE_LINK ${OLD} \$ENV{DESTDIR}/\${PREFIX_ABS}/${NEW} SYMBOLIC)")
+  endfunction()
+  file(RELATIVE_PATH RELPATH
+       /${CMAKE_INSTALL_LIBEXECDIR}/mold /${CMAKE_INSTALL_BINDIR}/mold)
+  mold_install_symlink(${RELPATH} ${CMAKE_INSTALL_LIBEXECDIR}/mold/ld)
+  mold_install_symlink(mold ${CMAKE_INSTALL_BINDIR}/ld.mold)
+  mold_install_symlink(mold ${CMAKE_INSTALL_BINDIR}/ld64.mold)
+  mold_install_symlink(mold.1 ${CMAKE_INSTALL_MANDIR}/man1/ld.mold.1)
 endif()


### PR DESCRIPTION
It is noticed that the tarballs in 1.6.0 do not come with the symlinks (like `bin/ld.mold`). This is because the values of `CMAKE_INSTALL_FULL_{LIBEXEC,BIN,MAN}DIR` are already hardcoded in the rules defined in `cmake_install.cmake` during configuration. They are not updated when `cmake --install <build-dir> --prefix <prefix>` overrides the install prefix. So, despite the prefix override in `cmake --install . --prefix $dest --strip`, the symlinks went to `/usr/local` instead.

https://github.com/rui314/mold/blob/323ad30e25c2c81efdb07ab76601a119335a40c8/CMakeLists.txt#L365-L377

A trivial first attempt would be to make them evaluated during installation, like this:

```diff
      execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \${RELPATH}
-       \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold/ld)
+       \$ENV{DESTDIR}/\${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold/ld)
```

But unfortunately that does not work -- `${CMAKE_INSTALL_FULL_LIBEXECDIR}` is not available during installation. From CMake's manpage (["INSTALL A PROJECT", cmake(1)](https://cmake.org/cmake/help/latest/manual/cmake.1.html#install-a-project)), it seems only `CMAKE_INSTALL_PREFIX` will reflect the override. So this is the only thing we can rely on.

My second attempt was the following:

```diff
      execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \${RELPATH}
-       \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_LIBEXECDIR}/mold/ld)
+       \$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/mold/ld)
```

That, however, does not work when the `DESTDIR` environment variable is not set and the prefix is a relative path, because a bare slash `/` would be prepended.

Therefore, I am proposing this fix. The symlink creation logic is extracted into a function `mold_install_symlink(OLD NEW)`. It first sets a variable `PREFIX` depending on whether `DESTDIR` is defined or not. Specifically, if it is not, then `PREFIX` and all that follow are relative paths, which is fine. Then it creates a symlink that does the same thing as `ln -s ${PREFIX}${NEW} ${OLD}`, creating parent directories if they do not exist.

By the way, it seems okay to use the [`MAKE_DIRECTORY`](https://cmake.org/cmake/help/latest/command/file.html#make-directory) and [`CREATE_LINK`](https://cmake.org/cmake/help/latest/command/file.html#create-link) subcommands under command `file`. So, it shouldn't be needed to invoke a subprocess.

cc @jpalus, author of #738.

Signed-off-by: Zhong Ruoyu <zhongruoyu@outlook.com>
