### PR TITLE
[ELF] Fix precedence with C++ version script rules. 

### DIFF
--- a/mold.h
+++ b/mold.h
@@ -567,7 +567,6 @@ private:
   std::vector<std::string> strings;
   std::unique_ptr<TrieNode> root;
   std::vector<std::pair<Glob, u32>> globs;
-  std::vector<u32> values;
   std::once_flag once;
   bool is_compiled = false;
 };

--- a/test/elf/version-script18.sh
+++ b/test/elf/version-script18.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Test version script precedence.
+
+cat <<'EOF' > $t/a.ver
+{ global: extern "C++" { *libalpha::*; }; local: *libbeta*; };
+EOF
+
+cat <<EOF | $CC -fPIC -c -o $t/b.o -xc++ -
+namespace libbeta {
+  struct Bar;
+}
+namespace libalpha {
+  template <typename T>
+  void foo() {}
+  template void foo<libbeta::Bar>();
+}
+EOF
+
+$CC -B. -shared -Wl,--version-script=$t/a.ver -o $t/c.so $t/b.o
+readelf --wide --dyn-syms $t/c.so | grep libalpha | grep -q Bar
+


### PR DESCRIPTION
Earlier entries in a version scripts always get the precedence. Don't let a
non-C++ symbol rule override a preceding C++ symbol rule.

MultiGlob is modified to return the necessary rule index information to the
caller. Since the rule index might not always be contiguous within a
MultiGlob instance (e.g. interleaving ordinary/C++ rules), the meaning of
MultiGlob's `val` is changed so that the minimum `val` itself is returned,
instead of the `val` with minimum index (the earliest added one).

MultiGlob is also used for the macOS backend, but since it does not care 
about order yet the code is left as-is.

Closes #850