### PR TITLE
[ELF] Add support for more .gnu.note.property variants.

### DIFF
--- a/elf/elf.h
+++ b/elf/elf.h
@@ -271,8 +271,17 @@ static constexpr u32 NT_GNU_GOLD_VERSION = 4;
 static constexpr u32 NT_GNU_PROPERTY_TYPE_0 = 5;
 static constexpr u32 NT_FDO_PACKAGING_METADATA = 0xcafe1a7e;
 
-static constexpr u32 GNU_PROPERTY_AARCH64_FEATURE_1_AND = 0xc0000000;
-static constexpr u32 GNU_PROPERTY_X86_FEATURE_1_AND = 0xc0000002;
+static constexpr u32 GNU_PROPERTY_X86_UINT32_AND_LO = 0xc0000002;
+static constexpr u32 GNU_PROPERTY_X86_UINT32_AND_HI = 0xc0007fff;
+
+static constexpr u32 GNU_PROPERTY_X86_UINT32_OR_LO = 0xc0008000;
+static constexpr u32 GNU_PROPERTY_X86_UINT32_OR_HI = 0xc000ffff;
+
+static constexpr u32 GNU_PROPERTY_X86_UINT32_OR_AND_LO = 0xc0010000;
+static constexpr u32 GNU_PROPERTY_X86_UINT32_OR_AND_HI = 0xc0017fff;
+
+static constexpr u32 GNU_PROPERTY_X86_FEATURE_1_AND
+    = (GNU_PROPERTY_X86_UINT32_AND_LO + 0);
 
 static constexpr u32 GNU_PROPERTY_X86_FEATURE_1_IBT = 1;
 static constexpr u32 GNU_PROPERTY_X86_FEATURE_1_SHSTK = 2;

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -997,7 +997,10 @@ public:
   void update_shdr(Context<E> &ctx) override;
   void copy_buf(Context<E> &ctx) override;
 
-  u32 features = 0;
+  std::vector<std::pair<u32, u32>> properties;
+
+private:
+  static constexpr i64 entry_size = E::is_64 ? 16 : 12;
 };
 
 struct GdbIndexName {
@@ -1243,7 +1246,7 @@ public:
   std::vector<const char *> symvers;
   std::vector<std::pair<ComdatGroup *, std::span<U32<E>>>> comdat_groups;
   bool exclude_libs = false;
-  u32 features = 0;
+  std::vector<std::pair<u32, u32>> gnu_properties;
   bool is_lto_obj = false;
   bool needs_executable_stack = false;
 
@@ -1280,7 +1283,7 @@ private:
   void initialize_symbols(Context<E> &ctx);
   void sort_relocations(Context<E> &ctx);
   void initialize_ehframe_sections(Context<E> &ctx);
-  u32 read_note_gnu_property(Context<E> &ctx, const ElfShdr<E> &shdr);
+  void read_note_gnu_property(Context <E> &ctx, const ElfShdr <E> &shdr, std::vector<std::pair<u32, u32>> &out);
   void read_ehframe(Context<E> &ctx, InputSection<E> &isec);
   void override_symbol(Context<E> &ctx, Symbol<E> &sym,
                        const ElfSym<E> &esym, i64 symidx);

--- a/test/elf/x86_64_note-property2.sh
+++ b/test/elf/x86_64_note-property2.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Skip if target is not x86-64
+[ $MACHINE = x86_64 ] || skip
+
+# Binutils 2.32 injects their own .note.gnu.property section interfering with the tests
+test_cflags -Xassembler -mx86-used-note=no && CFLAGS="-Xassembler -mx86-used-note=no" || CFLAGS=""
+
+# This test requires the new ISA constants defined in Binutils 2.36
+readelf -v | grep -q -E "GNU readelf .+ (2\.3[6-9]|2\.[4-9]|[3-9])" || skip
+
+cat <<EOF | $CC $CFLAGS -c -o $t/a.o -xassembler-with-cpp  -
+#define NT_GNU_PROPERTY_TYPE_0 5
+#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
+#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+#define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+
+	.section ".note.gnu.property", "a"
+	.p2align 3
+	.long 4
+	.long 1f - 0f
+	.long NT_GNU_PROPERTY_TYPE_0
+	.asciz "GNU"
+0:	.long GNU_PROPERTY_X86_ISA_1_NEEDED
+	.long 4
+	.long 0x7
+	.p2align 3
+	.long GNU_PROPERTY_X86_ISA_1_USED
+	.long 4
+	.long 0x7
+	.p2align 3
+	.long GNU_PROPERTY_X86_FEATURE_1_AND
+	.long 4
+	.long 0x3
+	.p2align 3
+1:
+EOF
+
+cat <<EOF | $CC $CFLAGS -c -o $t/b.o -xassembler-with-cpp -
+#define NT_GNU_PROPERTY_TYPE_0 5
+#define GNU_PROPERTY_X86_ISA_1_USED 0xc0010002
+#define GNU_PROPERTY_X86_ISA_1_NEEDED 0xc0008002
+#define GNU_PROPERTY_X86_FEATURE_1_AND 0xc0000002
+
+	.section ".note.gnu.property", "a"
+	.p2align 3
+	.long 4
+	.long 1f - 0f
+	.long NT_GNU_PROPERTY_TYPE_0
+	.asciz "GNU"
+0:	.long GNU_PROPERTY_X86_ISA_1_NEEDED
+	.long 4
+	.long 0x8
+	.p2align 3
+	.long GNU_PROPERTY_X86_ISA_1_USED
+	.long 4
+	.long 0x8
+	.p2align 3
+	.long GNU_PROPERTY_X86_FEATURE_1_AND
+  .long 4
+  .long 0x2
+  .p2align 3
+1:
+EOF
+
+cat <<EOF | $CC $CFLAGS -c -o $t/c.o -xassembler-with-cpp -
+EOF
+
+./mold -nostdlib -o $t/exe1 $t/a.o $t/b.o
+readelf -n $t/exe1 | grep -q 'x86 feature: SHSTK'
+readelf -n $t/exe1 | grep -q 'x86 ISA needed: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4'
+readelf -n $t/exe1 | grep -q 'x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4'
+
+./mold -nostdlib -o $t/exe2 $t/a.o $t/b.o $t/c.o
+! readelf -n $t/exe2 | grep -q 'x86 feature: SHSTK' || false
+readelf -n $t/exe2 | grep -q 'x86 ISA needed: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4' || false
+! readelf -n $t/exe2 | grep -q 'x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3, x86-64-v4'

--- a/test/elf/x86_64_note.sh
+++ b/test/elf/x86_64_note.sh
@@ -5,7 +5,10 @@ test_cflags -static || skip
 
 [ $MACHINE = x86_64 ] || skip
 
-cat <<EOF | $CC -o $t/a.o -c -x assembler -
+# Binutils 2.32 injects their own .note.gnu.property section interfering with the tests
+test_cflags -Xassembler -mx86-used-note=no && CFLAGS="-Xassembler -mx86-used-note=no" || CFLAGS=""
+
+cat <<EOF | $CC $CFLAGS -o $t/a.o -c -x assembler -
 .text
 .globl _start
 _start:

--- a/test/elf/x86_64_note2.sh
+++ b/test/elf/x86_64_note2.sh
@@ -3,25 +3,28 @@
 
 [ $MACHINE = x86_64 ] || skip
 
-cat <<EOF | $CC -o $t/a.o -c -x assembler -
+# Binutils 2.32 injects their own .note.gnu.property section interfering with the tests
+test_cflags -Xassembler -mx86-used-note=no && CFLAGS="-Xassembler -mx86-used-note=no" || CFLAGS=""
+
+cat <<EOF | $CC $CFLAGS -o $t/a.o -c -x assembler -
 .section .note.a, "a", @note
 .p2align 3
 .quad 42
 EOF
 
-cat <<EOF | $CC -o $t/b.o -c -x assembler -
+cat <<EOF | $CC $CFLAGS -o $t/b.o -c -x assembler -
 .section .note.b, "a", @note
 .p2align 2
 .quad 42
 EOF
 
-cat <<EOF | $CC -o $t/c.o -c -x assembler -
+cat <<EOF | $CC $CFLAGS -o $t/c.o -c -x assembler -
 .section .note.c, "a", @note
 .p2align 3
 .quad 42
 EOF
 
-cat <<EOF | $CC -o $t/d.o -c -xc -
+cat <<EOF | $CC $CFLAGS -o $t/d.o -c -xc -
 int main() {}
 EOF
 


### PR DESCRIPTION
This makes .gnu.note.property handling generic instead of hardcoded against the
GNU_PROPERTY_X86_FEATURE_1_AND value.
The behavior is based on specification inside GNU gold header comments;
unfortunately a formal document does not exist yet and the comments seem to be
the best reference that can be found.

The support for the actual properties in wild seems scarce; neither gcc nor
clang emits the correct property even when passed -march=x86-64-v3 and using
__builtin_popcnt, for example. Therefore, this does not include a test yet for
the new properties. I'm not sure if we want to resort to [manually written .s files](https://github.com/bminor/binutils-gdb/blob/3451a2d7a3501e9c3fc344cbc4950c495f30c16d/gold/testsuite/gnu_property_b.S)
just for this purpose.

Close #824 