### PR TITLE
Fix out-of-bounds error on aarch64 with `_GLIBCXX_ASSERTIONS` enabled…

### DIFF
--- a/elf/thunks.cc
+++ b/elf/thunks.cc
@@ -222,7 +222,7 @@ void create_range_extension_thunks(Context<E> &ctx, OutputSection<E> &osec) {
     thunk.offset = offset;
 
     // Scan relocations between B and C to collect symbols that need thunks.
-    tbb::parallel_for_each(&m[b], &m[c], [&](InputSection<E> *isec) {
+    tbb::parallel_for_each(m.begin() + b, m.begin() + c, [&](InputSection<E> *isec) {
       scan_rels(ctx, *isec, thunk);
     });
 
@@ -244,7 +244,7 @@ void create_range_extension_thunks(Context<E> &ctx, OutputSection<E> &osec) {
     }
 
     // Scan relocations again to fix symbol offsets in the last thunk.
-    tbb::parallel_for_each(&m[b], &m[c], [&](InputSection<E> *isec) {
+    tbb::parallel_for_each(m.begin() + b, m.begin() + c, [&](InputSection<E> *isec) {
       std::span<Symbol<E> *> syms = isec->file.symbols;
       std::span<const ElfRel<E>> rels = isec->get_rels(ctx);
       std::span<RangeExtensionRef> range_extn = isec->extra.range_extn;


### PR DESCRIPTION
… (again)

The square-bracket operator of `std::span` has undefined behaviour for out-of-bounds element accesses. Resorting to iterators yields defined behaviour.

This issue (originally described in #298) had been fixed in the past by commit 03ba8f93255055adaf69984c17bcfea3b22340db, but it has since resurfaced with commit 193c245781df18e3c7d96efc1ea03e9760175681.