### PR TITLE
Dockerfile: perform cleanup at the end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN apt-get update && \
   wget -O- -q https://www.openssl.org/source/openssl-3.0.7.tar.gz | tar --strip-components=1 -xzf - && \
   ./Configure --prefix=/usr/local && \
   make -j$(nproc) && \
-  make -j$(nproc) install
+  make -j$(nproc) install && \
+  rm -rf /var/lib/apt/lists/* /openssl


### PR DESCRIPTION
As recommended in Docker's documentation [^1]:

> In addition, when you clean up the apt cache by removing `/var/lib/apt/lists` it reduces the image size, since the apt cache is not stored in a layer.

This reduces the image size by ~0.5GiB.

[^1]: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

Signed-off-by: Zhong Ruoyu <zhongruoyu@outlook.com>