### PR TITLE
Add i386-psabi.pdf to arch-x86-64

### DIFF
--- a/elf/arch-x86-64.cc
+++ b/elf/arch-x86-64.cc
@@ -23,6 +23,7 @@
 // TLS block as TP (with some addend). As a result, offsets from TP to
 // thread-local variables (TLVs) in the main executable are all negative.
 //
+// https://github.com/rui314/mold/wiki/i386-psabi.pdf
 // https://github.com/rui314/mold/wiki/x86-64-psabi.pdf
 
 #include "mold.h"


### PR DESCRIPTION
Some parts (like .note.gnu.property section format) of the ABI are defined in i386 manual.

And please update https://github.com/rui314/mold/wiki/i386-psabi.pdf with the latest version:
https://gitlab.com/x86-psABIs/i386-ABI/-/wikis/uploads/14c05f1b1e156e0e46b61bfa7c1df1e2/intel386-psABI-2020-08-07.pdf

It's version `1.2` and it contains documentation of `GNU_PROPERTY_X86_FEATURE_1_AND`.