### PR TITLE
Fix atomic checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,14 +228,17 @@ endif()
 # If atomics doesn't work by default, add -latomic.
 # We need the flag on riscv, armv6 and m68k.
 include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("#include <cstdint>
+check_cxx_source_compiles("#include <atomic>
 int main() {
-  uint64_t x = 1;
-  __atomic_add_fetch(&x, 0, __ATOMIC_RELAXED);
-  return x;
-}" HAVE_ATOMIC_ADD_FETCH)
+  std::atomic<uint8_t> w1;
+  std::atomic<uint16_t> w2;
+  std::atomic<uint32_t> w4;
+  std::atomic<uint64_t> w8;
 
-if(NOT HAVE_ATOMIC_ADD_FETCH)
+  return ++w1 + ++w2 + ++w4 + ++w8;
+}" HAVE_FULL_ATOMIC_SUPPORT)
+
+if(NOT HAVE_FULL_ATOMIC_SUPPORT)
   target_link_libraries(mold PRIVATE atomic)
 endif()
 


### PR DESCRIPTION
Current atomic check only includes 64-bit atomic operations. For sub-word atomics, which is currently not available in GCC on riscv64, this test is not enough, as seen in [Debian buildd log](https://buildd.debian.org/status/fetch.php?pkg=mold&arch=riscv64&ver=1.7.0%2Bdfsg-1&stamp=1668788872&raw=0):

```
[100%] Linking CXX executable mold
/usr/bin/cmake -E cmake_link_script CMakeFiles/mold.dir/link.txt --verbose=1
/usr/bin/c++ -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wl,-z,relro -Wl,-z,now -Wl,--as-needed CMakeFiles/mold.dir/elf/cmdline.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.I386.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.S390X.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/cmdline.cc.M68K.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.I386.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.S390X.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/dwarf.cc.M68K.cc.o "CMakeFiles/mold.dir/elf/gc-sections.cc.X86_64.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.I386.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.ARM64.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.ARM32.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.RV32LE.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.RV32BE.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.RV64LE.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.RV64BE.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.PPC64V1.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.PPC64V2.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.S390X.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.SPARC64.cc.o" "CMakeFiles/mold.dir/elf/gc-sections.cc.M68K.cc.o" CMakeFiles/mold.dir/elf/icf.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/icf.cc.I386.cc.o CMakeFiles/mold.dir/elf/icf.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/icf.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/icf.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/icf.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/icf.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/icf.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/icf.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/icf.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/icf.cc.S390X.cc.o CMakeFiles/mold.dir/elf/icf.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/icf.cc.M68K.cc.o "CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.I386.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.ARM64.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.ARM32.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.RV32LE.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.RV32BE.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.RV64LE.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.RV64BE.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.PPC64V1.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.PPC64V2.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.S390X.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.SPARC64.cc.o" "CMakeFiles/mold.dir/elf/input-files.cc.M68K.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.X86_64.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.I386.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.ARM64.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.ARM32.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.RV32LE.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.RV32BE.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.RV64LE.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.RV64BE.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.PPC64V1.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.PPC64V2.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.S390X.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.SPARC64.cc.o" "CMakeFiles/mold.dir/elf/input-sections.cc.M68K.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.X86_64.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.I386.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.ARM64.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.ARM32.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.RV32LE.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.RV32BE.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.RV64LE.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.RV64BE.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.PPC64V1.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.PPC64V2.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.S390X.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.SPARC64.cc.o" "CMakeFiles/mold.dir/elf/linker-script.cc.M68K.cc.o" CMakeFiles/mold.dir/elf/lto.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/lto.cc.I386.cc.o CMakeFiles/mold.dir/elf/lto.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/lto.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/lto.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/lto.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/lto.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/lto.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/lto.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/lto.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/lto.cc.S390X.cc.o CMakeFiles/mold.dir/elf/lto.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/lto.cc.M68K.cc.o CMakeFiles/mold.dir/elf/main.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/main.cc.I386.cc.o CMakeFiles/mold.dir/elf/main.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/main.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/main.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/main.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/main.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/main.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/main.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/main.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/main.cc.S390X.cc.o CMakeFiles/mold.dir/elf/main.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/main.cc.M68K.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.I386.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.S390X.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/mapfile.cc.M68K.cc.o "CMakeFiles/mold.dir/elf/output-chunks.cc.X86_64.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.I386.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.ARM64.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.ARM32.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.RV32LE.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.RV32BE.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.RV64LE.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.RV64BE.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.PPC64V1.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.PPC64V2.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.S390X.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.SPARC64.cc.o" "CMakeFiles/mold.dir/elf/output-chunks.cc.M68K.cc.o" CMakeFiles/mold.dir/elf/passes.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/passes.cc.I386.cc.o CMakeFiles/mold.dir/elf/passes.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/passes.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/passes.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/passes.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/passes.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/passes.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/passes.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/passes.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/passes.cc.S390X.cc.o CMakeFiles/mold.dir/elf/passes.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/passes.cc.M68K.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.I386.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.S390X.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/relocatable.cc.M68K.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.I386.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.S390X.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/subprocess.cc.M68K.cc.o CMakeFiles/mold.dir/elf/thunks.cc.X86_64.cc.o CMakeFiles/mold.dir/elf/thunks.cc.I386.cc.o CMakeFiles/mold.dir/elf/thunks.cc.ARM64.cc.o CMakeFiles/mold.dir/elf/thunks.cc.ARM32.cc.o CMakeFiles/mold.dir/elf/thunks.cc.RV32LE.cc.o CMakeFiles/mold.dir/elf/thunks.cc.RV32BE.cc.o CMakeFiles/mold.dir/elf/thunks.cc.RV64LE.cc.o CMakeFiles/mold.dir/elf/thunks.cc.RV64BE.cc.o CMakeFiles/mold.dir/elf/thunks.cc.PPC64V1.cc.o CMakeFiles/mold.dir/elf/thunks.cc.PPC64V2.cc.o CMakeFiles/mold.dir/elf/thunks.cc.S390X.cc.o CMakeFiles/mold.dir/elf/thunks.cc.SPARC64.cc.o CMakeFiles/mold.dir/elf/thunks.cc.M68K.cc.o CMakeFiles/mold.dir/macho/cmdline.cc.X86_64.cc.o CMakeFiles/mold.dir/macho/cmdline.cc.ARM64.cc.o "CMakeFiles/mold.dir/macho/dead-strip.cc.X86_64.cc.o" "CMakeFiles/mold.dir/macho/dead-strip.cc.ARM64.cc.o" "CMakeFiles/mold.dir/macho/input-files.cc.X86_64.cc.o" "CMakeFiles/mold.dir/macho/input-files.cc.ARM64.cc.o" "CMakeFiles/mold.dir/macho/input-sections.cc.X86_64.cc.o" "CMakeFiles/mold.dir/macho/input-sections.cc.ARM64.cc.o" CMakeFiles/mold.dir/macho/lto.cc.X86_64.cc.o CMakeFiles/mold.dir/macho/lto.cc.ARM64.cc.o CMakeFiles/mold.dir/macho/main.cc.X86_64.cc.o CMakeFiles/mold.dir/macho/main.cc.ARM64.cc.o CMakeFiles/mold.dir/macho/mapfile.cc.X86_64.cc.o CMakeFiles/mold.dir/macho/mapfile.cc.ARM64.cc.o "CMakeFiles/mold.dir/macho/output-chunks.cc.X86_64.cc.o" "CMakeFiles/mold.dir/macho/output-chunks.cc.ARM64.cc.o" CMakeFiles/mold.dir/macho/tapi.cc.X86_64.cc.o CMakeFiles/mold.dir/macho/tapi.cc.ARM64.cc.o CMakeFiles/mold.dir/compress.cc.o CMakeFiles/mold.dir/demangle.cc.o "CMakeFiles/mold.dir/elf/arch-arm32.cc.o" "CMakeFiles/mold.dir/elf/arch-arm64.cc.o" "CMakeFiles/mold.dir/elf/arch-i386.cc.o" "CMakeFiles/mold.dir/elf/arch-m68k.cc.o" "CMakeFiles/mold.dir/elf/arch-ppc64v1.cc.o" "CMakeFiles/mold.dir/elf/arch-ppc64v2.cc.o" "CMakeFiles/mold.dir/elf/arch-riscv.cc.o" "CMakeFiles/mold.dir/elf/arch-s390x.cc.o" "CMakeFiles/mold.dir/elf/arch-sparc64.cc.o" "CMakeFiles/mold.dir/elf/arch-x86-64.cc.o" CMakeFiles/mold.dir/filepath.cc.o "CMakeFiles/mold.dir/git-hash.cc.o" CMakeFiles/mold.dir/glob.cc.o CMakeFiles/mold.dir/hyperloglog.cc.o "CMakeFiles/mold.dir/macho/arch-arm64.cc.o" "CMakeFiles/mold.dir/macho/arch-x86-64.cc.o" CMakeFiles/mold.dir/macho/yaml.cc.o CMakeFiles/mold.dir/main.cc.o "CMakeFiles/mold.dir/multi-glob.cc.o" CMakeFiles/mold.dir/perf.cc.o CMakeFiles/mold.dir/tar.cc.o "CMakeFiles/mold.dir/third-party/rust-demangle/rust-demangle.c.o" CMakeFiles/mold.dir/uuid.cc.o -o mold  -ldl /usr/lib/riscv64-linux-gnu/libz.so third-party/zstd/build/cmake/lib/libzstd.a third-party/mimalloc/libmimalloc.a gnu_12.2_cxx11_64_none/libtbb.a -lm /usr/lib/riscv64-linux-gnu/libcrypto.so /usr/lib/riscv64-linux-gnu/libpthread.a /usr/lib/riscv64-linux-gnu/librt.a -ldl 
/usr/bin/ld: gnu_12.2_cxx11_64_none/libtbb.a(arena.cpp.o): in function `tbb::detail::r1::arena::occupy_free_slot_in_range(tbb::detail::r1::thread_data&, unsigned long, unsigned long)':
./obj-riscv64-linux-gnu/third-party/tbb/src/tbb/./third-party/tbb/src/tbb/arena.cpp:79: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: ./obj-riscv64-linux-gnu/third-party/tbb/src/tbb/./third-party/tbb/src/tbb/arena.cpp:79: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: gnu_12.2_cxx11_64_none/libtbb.a(arena.cpp.o): in function `tbb::detail::r1::isolate_within_arena(tbb::detail::d1::delegate_base&, long)':
./obj-riscv64-linux-gnu/third-party/tbb/src/tbb/./third-party/tbb/src/tbb/arena.cpp:758: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: gnu_12.2_cxx11_64_none/libtbb.a(arena.cpp.o): in function `tbb::detail::r1::task_dispatcher::get_stream_or_critical_task(tbb::detail::r1::execution_data_ext&, tbb::detail::r1::arena&, tbb::detail::r1::task_stream<(tbb::detail::r1::task_stream_accessor_type)0>&, unsigned int&, long, bool)':
./obj-riscv64-linux-gnu/third-party/tbb/src/tbb/./third-party/tbb/src/tbb/task_dispatcher.h:145: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: ./obj-riscv64-linux-gnu/third-party/tbb/src/tbb/./third-party/tbb/src/tbb/task_dispatcher.h:155: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: gnu_12.2_cxx11_64_none/libtbb.a(arena.cpp.o):/usr/include/c++/12/bits/stl_deque.h:273: more undefined references to `__atomic_exchange_1' follow
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o: in function `std::__atomic_base<unsigned char>::compare_exchange_weak(unsigned char&, unsigned char, std::memory_order, std::memory_order)':
/usr/include/c++/12/bits/atomic_base.h:523: undefined reference to `__atomic_compare_exchange_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o: in function `std::__atomic_base<bool>::exchange(bool, std::memory_order)':
/usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: /usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: /usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: /usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: /usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o:/usr/include/c++/12/bits/atomic_base.h:506: more undefined references to `__atomic_exchange_1' follow
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o: in function `std::__atomic_base<unsigned char>::compare_exchange_weak(unsigned char&, unsigned char, std::memory_order, std::memory_order)':
/usr/include/c++/12/bits/atomic_base.h:523: undefined reference to `__atomic_compare_exchange_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o: in function `std::__atomic_base<bool>::load(std::memory_order) const':
/usr/include/c++/12/bits/atomic_base.h:488: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o: in function `std::__atomic_base<unsigned char>::operator|=(unsigned char)':
/usr/include/c++/12/bits/atomic_base.h:425: undefined reference to `__atomic_fetch_or_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.X86_64.cc.o: in function `std::__atomic_base<bool>::exchange(bool, std::memory_order)':
/usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: /usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.I386.cc.o: in function `std::__atomic_base<unsigned char>::compare_exchange_weak(unsigned char&, unsigned char, std::memory_order, std::memory_order)':
/usr/include/c++/12/bits/atomic_base.h:523: undefined reference to `__atomic_compare_exchange_1'
/usr/bin/ld: CMakeFiles/mold.dir/elf/input-files.cc.I386.cc.o: in function `std::__atomic_base<bool>::exchange(bool, std::memory_order)':
/usr/include/c++/12/bits/atomic_base.h:506: undefined reference to `__atomic_exchange_1'
(...even more atomic errors omitted)
```

This PR adds sub-word atomic (e.g. `uint8_t`) operations to the test. Successfully built on my qemu-system-riscv64 machine.