### PR TITLE
support -ffat-lto-objects for GCC compiler

### DIFF
--- a/test/elf/lto-gcc.sh
+++ b/test/elf/lto-gcc.sh
@@ -13,3 +13,12 @@ EOF
 
 $GCC -B. -o $t/exe -flto $t/a.o
 $QEMU $t/exe | grep -q 'Hello world'
+
+# Test that LTO is used for FAT LTO objects
+cat <<EOF | $GCC -flto -ffat-lto-objects -c -o $t/a.o -xc -
+#include <stdio.h>
+int main() {
+  printf("Hello world\n");
+}
+EOF
+$GCC -B. -o $t/exe $t/a.o --verbose 2>&1 | grep -- -fwpa


### PR DESCRIPTION
FAT LTO objects are objects that contain both native assembly and LTO bytecode. Identify such files as GCC_LTO_OBJ.

Signed-off-by: Martin Liska <mliska@suse.cz>