### PR TITLE
Prefer --ld-path= to specify mold full path

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ following flags to use `mold` instead of `/usr/bin/ld`:
   `-B/usr/libexec/mold` (or `-B/usr/local/libexec/mold`) to GCC.
 
 If you haven't installed `mold` to any `$PATH`, you can still pass
-`-fuse-ld=/absolute/path/to/mold` to clang to use mold. GCC does not
+`--ld-path=/absolute/path/to/mold` to clang to use mold. GCC does not
 take an absolute path as an argument for `-fuse-ld` though.
 
 </details>


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/blob/4178671b2ed3d8c1ffec6f723808e22572601242/clang/include/clang/Basic/DiagnosticDriverKinds.td#L567, using `-fuse-ld=` to specify linker full path is deprecated in clang, `--ld-path` should be preferred in that case.