### PR TITLE
[ELF] Keep a reference to the defsym target. 

### DIFF
--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -704,7 +704,8 @@ void add_synthetic_symbols(Context<E> &ctx) {
   // Make all synthetic symbols relative ones by associating them to
   // a dummy output section.
   for (Symbol<E> *sym : obj.symbols)
-    sym->set_output_section(ctx.symtab);
+    if (sym->file == &obj)
+      sym->set_output_section(ctx.symtab);
 
   // Handle --defsym symbols.
   for (i64 i = 0; i < ctx.arg.defsyms.size(); i++) {

--- a/test/elf/defsym-lto.sh
+++ b/test/elf/defsym-lto.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+echo 'int main() {}' | $CC -flto -o /dev/null -xc - >& /dev/null \
+  || skip
+
+cat <<EOF | $CC -flto -fPIC -o $t/a.o -c -xc -
+#include <stdio.h>
+
+extern void live_func();
+void dead_func() {
+  printf("OK\n");
+}
+
+int main() {
+  live_func();
+}
+EOF
+
+$CC -B. -flto -o $t/exe $t/a.o -Wl,-defsym,live_func=dead_func
+
+$QEMU $t/exe | grep -q "^OK$"


### PR DESCRIPTION
Add an undefined symbol to keep a reference to the defsym target. This prevents
elimination by e.g. LTO or gc-sections. A test is added for the case of LTO
dead-code elimination.

Closes #829 