### PR TITLE
Fix ld.sold symlink installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,10 +437,7 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
   if(MOLD_IS_SOLD)
     mold_install_relative_symlink(${CMAKE_INSTALL_BINDIR}/mold
       ${CMAKE_INSTALL_BINDIR}/ld64.mold)
-  endif()
-
-  if(NOT MOLD_PRODUCT_NAME STREQUAL "mold")
     mold_install_relative_symlink(${CMAKE_INSTALL_BINDIR}/mold
-      ${CMAKE_INSTALL_BINDIR}/ld.${MOLD_PRODUCT_NAME})
+      ${CMAKE_INSTALL_BINDIR}/ld.sold)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,5 +439,7 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
       ${CMAKE_INSTALL_BINDIR}/ld64.mold)
     mold_install_relative_symlink(${CMAKE_INSTALL_BINDIR}/mold
       ${CMAKE_INSTALL_BINDIR}/ld.sold)
+    mold_install_relative_symlink(${CMAKE_INSTALL_BINDIR}/mold
+      ${CMAKE_INSTALL_BINDIR}/ld64.sold)
   endif()
 endif()


### PR DESCRIPTION
Fixes #910. Also, add a `ld64.sold` symlink that wasn't present before.

Signed-off-by: Ruoyu Zhong <zhongruoyu@outlook.com>