### PR TITLE
Dockerfile: fix OpenSSL libdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN apt-get update && \
   \
   mkdir /openssl && cd /openssl && \
   wget -O- -q https://www.openssl.org/source/openssl-3.0.7.tar.gz | tar --strip-components=1 -xzf - && \
-  ./Configure --prefix=/usr/local && \
+  ./Configure --prefix=/usr/local --libdir=lib && \
   make -j$(nproc) && \
   make -j$(nproc) install && \
+  ldconfig && \
   mkdir /cmake && cd /cmake && \
   wget -O- -q https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.24.2.tar.gz | tar --strip-components=1 -xzf - && \
   ./bootstrap --parallel=$(nproc) && make -j$(nproc) && make -j$(nproc) install && \


### PR DESCRIPTION
In the current version of Docker image, OpenSSL libraries are installed to `/usr/local/lib64`. It is not present in the default dynamic linker search path, and thus results in the following error when libcrypto is not statically-linked:

`mold: error while loading shared libraries: libcrypto.so.3: cannot open shared object file: No such file or directory`

Fix that by overriding `libdir`, as suggested in https://github.com/openssl/openssl/blob/master/INSTALL.md#libdir. Also, run `ldconfig` to update dynamic linker cache.

Signed-off-by: Ruoyu Zhong <zhongruoyu@outlook.com>