### PR TITLE
[ELF] Warn on symbol type mismatches.

### DIFF
--- a/elf/elf.h
+++ b/elf/elf.h
@@ -130,6 +130,21 @@ static constexpr u32 STT_TLS = 6;
 static constexpr u32 STT_GNU_IFUNC = 10;
 static constexpr u32 STT_SPARC_REGISTER = 13;
 
+inline std::string stt_to_string(u32 st_type) {
+  switch (st_type) {
+  case STT_NOTYPE:         return "STT_NOTYPE";
+  case STT_OBJECT:         return "STT_OBJECT";
+  case STT_FUNC:           return "STT_FUNC";
+  case STT_SECTION:        return "STT_SECTION";
+  case STT_FILE:           return "STT_FILE";
+  case STT_COMMON:         return "STT_COMMON";
+  case STT_TLS:            return "STT_TLS";
+  case STT_GNU_IFUNC:      return "STT_GNU_IFUNC";
+  case STT_SPARC_REGISTER: return "STT_SPARC_REGISTER";
+  default:                 return "unknown st_type (" + std::to_string(st_type) + ")";
+  }
+}
+
 static constexpr u32 STB_LOCAL = 0;
 static constexpr u32 STB_GLOBAL = 1;
 static constexpr u32 STB_WEAK = 2;

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -496,6 +496,9 @@ int elf_main(int argc, char **argv) {
   if (!ctx.arg.allow_multiple_definition)
     check_duplicate_symbols(ctx);
 
+  // Warn if symbols with different types are defined under the same name.
+  check_symbol_types(ctx);
+
   if constexpr (std::is_same_v<E, PPC64V1>)
     ppc64v1_rewrite_opd(ctx);
 

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1409,6 +1409,7 @@ template <typename E> void print_dependencies(Context<E> &);
 template <typename E> void print_dependencies_full(Context<E> &);
 template <typename E> void write_repro_file(Context<E> &);
 template <typename E> void check_duplicate_symbols(Context<E> &);
+template <typename E> void check_symbol_types(Context<E> &);
 template <typename E> void sort_init_fini(Context<E> &);
 template <typename E> void sort_ctor_dtor(Context<E> &);
 template <typename E> void shuffle_sections(Context<E> &);

--- a/test/elf/warn-symbol-type.sh
+++ b/test/elf/warn-symbol-type.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -c -fPIC -xc -o $t/a.o -
+#include <stdio.h>
+int times = -1; /* times collides with clock_t times(struct tms *buffer); */
+
+int
+main ()
+{
+  printf ("times: %d\n", times);
+  return 0;
+}
+EOF
+
+$CC -B. -shared -o $t/a.so $t/a.o >& $t/log
+
+grep -q "warning: symbol type mismatch: times" $t/log


### PR DESCRIPTION
Linking symbols with differing types will almost always lead to a crash; warn to
make it easier for the user to figure out the cause.

Closes: https://github.com/rui314/mold/issues/825