### PR TITLE
support correctly -fno-use-linker-plugin

### DIFF
--- a/archive-file.h
+++ b/archive-file.h
@@ -166,7 +166,7 @@ read_fat_archive_members(C &ctx, MappedFile<C> *mf) {
 template <typename C>
 std::vector<MappedFile<C> *>
 read_archive_members(C &ctx, MappedFile<C> *mf) {
-  switch (get_file_type(mf)) {
+  switch (get_file_type(mf, !ctx.arg.plugin.empty())) {
   case FileType::AR:
     return read_fat_archive_members(ctx, mf);
   case FileType::THIN_AR:

--- a/test/elf/lto-gcc.sh
+++ b/test/elf/lto-gcc.sh
@@ -23,3 +23,15 @@ int main() {
 EOF
 
 $GCC -B. -o $t/exe2 $t/b.o --verbose 2>&1 | grep -q -- -fwpa
+
+# Test FAT objects if -fno-use-linker-plugin is used
+
+cat <<EOF | $GCC -flto -fno-use-linker-plugin -c -o $t/c.o -xc -
+#include <stdio.h>
+int main() {
+  printf("Hello world\n");
+}
+EOF
+
+$GCC -B. -o $t/exe3 -flto -fno-use-linker-plugin $t/c.o
+$QEMU $t/exe3 | grep -q 'Hello world'


### PR DESCRIPTION
Right now, mold linker does not work with -fno-use-linker-plugin and thus use assembly for GCC FAT LTO objects. I noticed that when running GCC test-suite with mold.

Fixes: 804b8439833604981a55d56346e5d1a86e43823c

Signed-off-by: Martin Liska <mliska@suse.cz>