### PR TITLE
Update command-line argument for compilers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ If you can specify an additional command line option to your compiler
 driver by modifying build system's config files, add one of the
 following flags to use `mold` instead of `/usr/bin/ld`:
 
-- Clang: pass `-fuse-ld=mold`
+- Clang 12.0.0 or later: pass `--ld-path=mold`
+  
+- Clang before 12.0.0: pass `-fuse-ld=mold`
 
 - GCC 12.1.0 or later: pass `-fuse-ld=mold`
 


### PR DESCRIPTION
I found the latest clang reports this warning

```
clang: warning: '-fuse-ld=' taking a path is deprecated; use '--ld-path=' instead [-Wfuse-ld-path]
```

It should be supported from clang 12.0.0 since I cannot find `--ld-path=` at clang 11.1.0.

reference:

- https://releases.llvm.org/11.1.0/tools/clang/docs/ClangCommandLineReference.html#cmdoption-clang-fuse-ld
- https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html#cmdoption-clang-ld-path
- https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html#cmdoption-clang-fuse-ld