### PR TITLE
Add explanation for `-fuse-ld-mold` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ following flags to use `mold` instead of `/usr/bin/ld`. When using
   `-B/usr/libexec/mold` (or `-B/usr/local/libexec/mold`) to GCC.
 
 GCC does not take an absolute path as an argument for `-fuse-ld` though.
-GCC also does not support `--ld-path=`.
+GCC also does not support `--ld-path`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ invoked indirectly by the compiler driver (which is usually `cc`,
 
 If you can specify an additional command line option to your compiler
 driver by modifying build system's config files, add one of the
-following flags to use `mold` instead of `/usr/bin/ld`:
+following flags to use `mold` instead of `/usr/bin/ld`. When using
+`-fuse-ld=mold`, both `mold` and `ld.mold` should be in your path: 
 
 - Clang: pass `-fuse-ld=mold`
+  
+- Clang 12.0.0 or later: pass `--ld-path=/path/to/mold`
 
 - GCC 12.1.0 or later: pass `-fuse-ld=mold`
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ invoked indirectly by the compiler driver (which is usually `cc`,
 If you can specify an additional command line option to your compiler
 driver by modifying build system's config files, add one of the
 following flags to use `mold` instead of `/usr/bin/ld`. When using
-`-fuse-ld=mold`, both `mold` and `ld.mold` should be in your path: 
+`-fuse-ld=mold`, `ld.mold` should be in your path: 
 
 - Clang: pass `-fuse-ld=mold`
   
-- Clang 12.0.0 or later: pass `--ld-path=/path/to/mold`
+- Clang 12.0.0 or later: pass `--ld-path=path/to/mold`
 
 - GCC 12.1.0 or later: pass `-fuse-ld=mold`
 
@@ -128,9 +128,8 @@ following flags to use `mold` instead of `/usr/bin/ld`. When using
   `ld` is actually a symlink to `mold`. So, all you need is to pass
   `-B/usr/libexec/mold` (or `-B/usr/local/libexec/mold`) to GCC.
 
-If you haven't installed `mold` to any `$PATH`, you can still pass
-`-fuse-ld=/absolute/path/to/mold` to clang to use mold. GCC does not
-take an absolute path as an argument for `-fuse-ld` though.
+GCC does not take an absolute path as an argument for `-fuse-ld` though.
+GCC also does not support `--ld-path=`.
 
 </details>
 


### PR DESCRIPTION
This may be useful for new users (e.g. me) who tried `mold` from github [releases](https://github.com/rui314/mold/releases) rather than building and installing from the source.

`-fuse-ld=mold` can only be used when both `mold` and `ld.mold` are in your PATH (See Clang's [source](https://github.com/llvm/llvm-project/blob/a63b7247299ce6edfbbf47c4a2773e5ca7eb7f11/clang/lib/Driver/ToolChain.cpp#L673) on finding the linker). GCC 12.1.0 has the same behavior.

To use an absolute path (rather than adding them to PATH), use `--ld-path=` which is introduced in Clang 12.