### PR TITLE
[CI] Use clang++-12 to suppress warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
     - name: build and test
       run: |
         echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+        sudo apt-get install -y clang++-12
         mkdir build
         cd build
-        cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ${{ matrix.target }} ..
+        cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++-12 ${{ matrix.target }} ..
         cmake --build . -j$(nproc)
         ctest . -j$(nproc)
 


### PR DESCRIPTION
Currently, CI is generating [a lot of warnings](https://github.com/rui314/mold/actions/runs/4149711503/jobs/7178863516#step:6:188) due to the use of `[[unlikely]]`, this patch uses clang++-12 to fix that.