### PR TITLE
Fix default versioned symbol

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1262,11 +1262,13 @@ void SharedFile<E>::parse(Context<E> &ctx) {
     this->elf_syms2.push_back(esyms[i]);
     this->versyms.push_back(ver);
 
-    if (is_hidden) {
-      std::string_view mangled_name = save_string(
-        ctx, std::string(name) + "@" + std::string(version_strings[ver]));
-      this->symbols.push_back(get_symbol(ctx, mangled_name, name));
-    } else {
+    std::string_view mangled_name = save_string(
+      ctx, std::string(name) + "@" + std::string(version_strings[ver]));
+    this->symbols.push_back(get_symbol(ctx, mangled_name, name));
+
+    if (!is_hidden) {
+      this->elf_syms2.push_back(esyms[i]);
+      this->versyms.push_back(ver);
       this->symbols.push_back(get_symbol(ctx, name));
     }
   }

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -1226,23 +1226,6 @@ void claim_unresolved_symbols(Context<E> &ctx) {
         if (!sym.esym().is_undef() || sym.file->priority <= file->priority)
           continue;
 
-      // If a symbol name is in the form of "foo@version", search for
-      // symbol "foo" and check if the symbol has version "version".
-      if (file->has_symver.get(i - file->first_global)) {
-        std::string_view str = file->symbol_strtab.data() + esym.st_name;
-        i64 pos = str.find('@');
-        assert(pos != str.npos);
-
-        std::string_view name = str.substr(0, pos);
-        std::string_view ver = str.substr(pos + 1);
-
-        Symbol<E> *sym2 = get_symbol(ctx, name);
-        if (sym2->file && sym2->file->is_dso && sym2->get_version() == ver) {
-          file->symbols[i] = sym2;
-          continue;
-        }
-      }
-
       auto claim = [&](bool is_imported) {
         if (sym.is_traced)
           SyncOut(ctx) << "trace-symbol: " << *file << ": unresolved"

--- a/test/elf/symbol-version4.sh
+++ b/test/elf/symbol-version4.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -c -o $t/a.o -xc -
+
+void foo1() {}
+void foo2() {}
+
+__asm__(".symver foo1, foo@VER1");
+__asm__(".symver foo2, foo@@VER2");
+EOF
+
+echo 'VER1 { global: foo; }; VER2 { global: foo; };' > $t/b.ver
+$CC -B. -shared -o $t/b.so $t/a.o -Wl,--version-script=$t/b.ver
+
+cat <<EOF | $CC -o $t/c.o -c -xc -
+void foo();
+__asm__(".symver foo, foo@VER1");
+int main() { foo(); }
+EOF
+
+cat <<EOF | $CC -o $t/d.o -c -xc -
+void foo();
+__asm__(".symver foo, foo@VER2");
+int main() { foo(); }
+EOF
+
+cat <<EOF | $CC -o $t/e.o -c -xc -
+void foo();
+int main() { foo(); }
+EOF
+
+$CC -B. -o $t/exe1 $t/c.o $t/b.so
+$CC -B. -o $t/exe2 $t/d.o $t/b.so
+$CC -B. -o $t/exe3 $t/e.o $t/b.so
+
+$QEMU $t/exe1
+$QEMU $t/exe2
+$QEMU $t/exe3


### PR DESCRIPTION
A default versioned symbol like `foo@@version` should produce `foo` and `foo@version`.

Fix #998