### PR TITLE
fix thunks.cc:81:32: warning: enum constant in boolean context [-Wint…

### DIFF
--- a/elf/thunks.cc
+++ b/elf/thunks.cc
@@ -78,7 +78,7 @@ static bool needs_thunk_rel(const ElfRel<E> &r) {
     return ty == R_PPC_REL24  || ty == R_PPC_PLTREL24 || ty == R_PPC_LOCAL24PC;
   } else {
     static_assert(is_ppc64<E>);
-    return ty == R_PPC64_REL24 || R_PPC64_REL24_NOTOC;
+    return ty == R_PPC64_REL24 || ty == R_PPC64_REL24_NOTOC;
   }
 }
 


### PR DESCRIPTION
…-in-bool-context]

Fixes the following error:
```
/elf/thunks.cc:81:32: warning: enum constant in boolean context [-Wint-in-bool-context]
  return ty == R_PPC64_REL24 || R_PPC64_REL24_NOTOC;
```