### PR TITLE
[ELF] Skip tests on target mismatch

### DIFF
--- a/test/elf/riscv64_obj-compatible.sh
+++ b/test/elf/riscv64_obj-compatible.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = riscv64 ] || skip
+
 set -x
 
 cat <<EOF | $CC -o $t/a.o -c -xc -

--- a/test/elf/riscv64_weak-undef.sh
+++ b/test/elf/riscv64_weak-undef.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = riscv64 ] || skip
+
 cat <<EOF | $CC -c -o $t/a.o -xassembler -
 .globl foo
 .weak bar

--- a/test/elf/x86_64_empty-mergeable-section.sh
+++ b/test/elf/x86_64_empty-mergeable-section.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = x86_64 ] || skip
+
 cat <<EOF | $CC -o $t/a.o -c -xassembler -
 .section .rodata.str1.1, "aMS", @progbits, 1
 EOF

--- a/test/elf/x86_64_gotpcrelx.sh
+++ b/test/elf/x86_64_gotpcrelx.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = x86_64 ] || skip
+
 cat <<EOF | $CC -o $t/a.o -c -xc - -fPIC
 char foo[4000L * 1000 * 1000];
 char bar[1000 * 1000];

--- a/test/elf/x86_64_ifunc-alias.sh
+++ b/test/elf/x86_64_ifunc-alias.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = x86_64 ] || skip
+
 supports_ifunc || skip
 test_cflags -static || skip
 

--- a/test/elf/x86_64_tls-gd-to-ie.sh
+++ b/test/elf/x86_64_tls-gd-to-ie.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+[ $MACHINE = x86_64 ] || skip
+
 cat <<EOF | $GCC -fPIC -c -o $t/a.o -xc - -mcmodel=large
 #include <stdio.h>
 


### PR DESCRIPTION
This makes sure the non-matching, target-specific tests are skipped when the shell scripts are directly executed.
