### PR TITLE
mold-wrapper: Wrap ld.mold as well.

### DIFF
--- a/elf/mold-wrapper.c
+++ b/elf/mold-wrapper.c
@@ -61,7 +61,8 @@ static bool is_ld(const char *path) {
     ptr--;
 
   return !strcmp(ptr, "ld") || !strcmp(ptr, "ld.lld") ||
-         !strcmp(ptr, "ld.gold") || !strcmp(ptr, "ld.bfd");
+         !strcmp(ptr, "ld.gold") || !strcmp(ptr, "ld.bfd") ||
+         !strcmp(ptr, "ld.mold");
 }
 
 int execvpe(const char *file, char *const *argv, char *const *envp) {


### PR DESCRIPTION
Convenient if you have configured to use mold for a particular project but want to test a new local build.