### PR TITLE
MappedFile: Fail on open() errors other than ENOENT.

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -876,8 +876,11 @@ MappedFile<Context> *MappedFile<Context>::open(Context &ctx, std::string path) {
     fd = ::open(path.c_str(), O_RDONLY);
 #endif
 
-  if (fd == -1)
+  if (fd == -1) {
+    if (errno != ENOENT)
+      Fatal(ctx) << "opening " << path << " failed: " << errno_string();
     return nullptr;
+  }
 
   struct stat st;
   if (fstat(fd, &st) == -1)


### PR DESCRIPTION
open() can fail with transient reasons, such as running out of file descriptor limit. Previously, this was treated the same as file not being found, which caused confusing error messages [1].

With this change anything but ENOENT will be treated as a fatal error. This will also include e.g. permission errors, but if there's something within the search path that is not accessible, it's likely better to tell the user instead of silently skipping it.

[1]: https://github.com/rui314/mold/issues/1026