### PR TITLE
Use correct location of global config for Nim

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ example, `gcc` is used as the linker driver. Use the `-fuse-ld` option if your
 GCC is recent enough to recognize this option.
 
 If you want to use mold for all projects, add the above snippet to
-`~/.config/config.nims`.
+`~/.config/nim/config.nims`.
 
 </details>
 


### PR DESCRIPTION
Correct path is listed [here](https://nim-lang.org/docs/nimc.html#compiler-usage-configuration-files) (See number 2).

While it says `nim.cfg` in the docs, `config.nims` is the correct file for this purpose