### PR TITLE
Replace pow(2,x) by ldexp(1.0,x) in HyperLogLog for performance

### DIFF
--- a/common/hyperloglog.cc
+++ b/common/hyperloglog.cc
@@ -13,7 +13,7 @@ namespace mold {
 i64 HyperLogLog::get_cardinality() const {
   double z = 0;
   for (i64 val : buckets)
-    z += pow(2, -val);
+    z += std::ldexp(1.0, -val);
   return ALPHA * NBUCKETS * NBUCKETS / z;
 }
 


### PR DESCRIPTION
Dear mold developers,

I've noticed that in `HyperLogLog::get_cardinality()` the function `pow(2,.)` is used. In general `pow(2,.)` is slower than more specific alternatives, such as `exp2(.)` or `ldexp(1.0,.)`. To support this statement, I've ran several benchmarks and noticed that
* Clang 13 replaces `pow(2,.)` by `exp2(.)` when compiled with `-O3`.
* Using `ldexp(1.0,.)` instead of `pow(2,.)` or `exp2(.)` is faster on some machines.

This PR thus proposes to replace `pow(2,.)` by `ldexp(1.0,.)` for performance reasons.

Please find below the benchmark I've used to measure the performance of this PR:
~~~.cpp
#include <benchmark/benchmark.h>
#include <algorithm>
#include <cstdint>
#include <cstdlib>
#include <cmath>
#include <vector>

using i64 = int64_t;
using Bucket_t = std::vector<i64>;
using Func = i64 (*)(const Bucket_t& buckets);
static constexpr i64 NBUCKETS = 2048;
static constexpr double ALPHA = 0.79402;

static i64 get_cardinality_pow(const Bucket_t& buckets)
{
  double z = 0;
  for (i64 val : buckets)
    z += pow(2, -val);
  return ALPHA * NBUCKETS * NBUCKETS / z;
}

static i64 get_cardinality_exp2(const Bucket_t& buckets)
{
  double z = 0;
  for (i64 val : buckets)
    z += std::exp2(-val);
  return ALPHA * NBUCKETS * NBUCKETS / z;
}

static i64 get_cardinality_ldexp(const Bucket_t& buckets)
{
  double z = 0;
  for (i64 val : buckets)
    z += std::ldexp(1.0, -val);
  return ALPHA * NBUCKETS * NBUCKETS / z;
}

static i64 make_rand(i64 lo, i64 hi)
{
   return std::abs(hi - lo)*std::rand()/RAND_MAX + std::min(lo, hi);
}

static Bucket_t make_vec(std::size_t n, i64 lo, i64 hi)
{
   Bucket_t vec(n);
   std::generate(vec.begin(), vec.end(), [lo, hi] { return make_rand(lo, hi); });
   return vec;
}

static void benc(benchmark::State& state, Func f)
{
   const Bucket_t buckets = make_vec(state.range(0), 1, 1024);
   for (auto _ : state) {
      benchmark::DoNotOptimize(f(buckets));
   }
}

BENCHMARK_CAPTURE(benc, pow  , get_cardinality_pow  )->Range(8, 8<<14)->Unit(benchmark::kMillisecond);
BENCHMARK_CAPTURE(benc, exp2 , get_cardinality_exp2 )->Range(8, 8<<14)->Unit(benchmark::kMillisecond);
BENCHMARK_CAPTURE(benc, ldexp, get_cardinality_ldexp)->Range(8, 8<<14)->Unit(benchmark::kMillisecond);
BENCHMARK_MAIN();
~~~
On Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz with Debian 6.1.37-1, when compiled as
~~~.sh
g++ -Wall -O3 bench.cpp -lbenchmark
~~~
the benchmark gave the following output:
~~~.sh
Run on (4 X 3200 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x2)
  L1 Instruction 32 KiB (x2)
  L2 Unified 256 KiB (x2)
  L3 Unified 4096 KiB (x1)
Load Average: 0.62, 0.90, 0.88
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
------------------------------------------------------------
Benchmark                  Time             CPU   Iterations
------------------------------------------------------------
benc/pow/8             0.000 ms        0.000 ms      3531896
benc/pow/64            0.002 ms        0.002 ms       469202
benc/pow/512           0.013 ms        0.013 ms        53475
benc/pow/4096          0.110 ms        0.110 ms         6412
benc/pow/32768         0.876 ms        0.876 ms          795
benc/pow/131072         3.50 ms         3.50 ms          200
benc/exp2/8            0.000 ms        0.000 ms     13906497
benc/exp2/64           0.000 ms        0.000 ms      1885950
benc/exp2/512          0.003 ms        0.003 ms       216155
benc/exp2/4096         0.040 ms        0.040 ms        17722
benc/exp2/32768        0.345 ms        0.345 ms         2020
benc/exp2/131072        1.38 ms         1.38 ms          508
benc/ldexp/8           0.000 ms        0.000 ms     12833779
benc/ldexp/64          0.000 ms        0.000 ms      1625003
benc/ldexp/512         0.003 ms        0.003 ms       206323
benc/ldexp/4096        0.027 ms        0.027 ms        25615
benc/ldexp/32768       0.217 ms        0.217 ms         3238
benc/ldexp/131072      0.873 ms        0.873 ms          799
~~~
Please also find below the output from quickbench:
![canvas](https://github.com/rui314/mold/assets/225817/6717d7e8-2a8a-4fa6-a4ba-36abea4e2116)

The benchmarks support the statement that `ldexp(1.0,.)` is faster than `pow(2,.)` and `exp2(.)`, at least on the tested architectures with the tested compilers.

Best regards
Alex
