### PR TITLE
Install LICENSE.third-party when using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,9 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
   if(EXISTS "${CMAKE_SOURCE_DIR}/LICENSE")
     install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_DOCDIR})
   endif()
+  if(EXISTS "${CMAKE_SOURCE_DIR}/LICENSE.third-party")
+    install(FILES "LICENSE.third-party" DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+  endif()
 
   function(mold_install_relative_symlink OLD NEW)
     install(CODE "


### PR DESCRIPTION
`cmake --install` currently installs the `LICENSE` file, but it doesn't install the new `LICENSE.third-party` file added in a066fe25c6f9ccab11cd07345241492af70d6583.

It looks like even if everything else is dynamically linked from system libraries, we still always should install it since the `third-party/rust-demangle` component is always used https://github.com/rui314/mold/blob/3ed5b8ddf72285332ccb0fda3426dd2d71c20fda/CMakeLists.txt#L379

---

I encountered this while working on updating the Alpine Linux `mold` package to v2.0.0.

I hope the new MIT license brings a lot more users, both to `mold`, and then hopefully to the MacOS [sold linker](https://github.com/bluewhalesystems/sold)!