### PR TITLE
Add loongarch basic support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # on a multicore machine.
 list(APPEND MOLD_ELF_TARGETS
   X86_64 I386 ARM64 ARM32 RV32LE RV32BE RV64LE RV64BE PPC32 PPC64V1 PPC64V2
-  S390X SPARC64 M68K SH4 ALPHA MIPS64LE MIPS64BE)
+  S390X SPARC64 M68K SH4 ALPHA MIPS64LE MIPS64BE LOONGARCH32 LOONGARCH64)
 
 list(APPEND MOLD_ELF_TEMPLATE_FILES
   elf/cmdline.cc
@@ -364,6 +364,7 @@ target_sources(mold PRIVATE
   elf/arch-arm32.cc
   elf/arch-arm64.cc
   elf/arch-i386.cc
+  elf/arch-loongarch.cc
   elf/arch-m68k.cc
   elf/arch-mips64.cc
   elf/arch-ppc32.cc

--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -1,0 +1,783 @@
+// This file contains LoongArch-specific code. LoongArch is a clean RISC
+// ISA. It supports PC-relative load/store instructions. All instructions
+// are 4 bytes long.
+//
+// This file support LoongArch psABI v2 with relaxation not implemented.
+// The reloactions from 20 to 46, 49 and 54 are deprecated in psABI v2.
+//
+// The TLSGD and TLSLD relocation type share GOT relocation type, which
+// means can not think the symbol value as relocation value directly. It
+// needs judgement like has_tlsgd(). How they share relocation types follows.
+// a), TLS_{LD, GD}_PC_HI20 + GOT_PC_LO12 + GOT64_PC_LO20 + GOT64_PC_HI12,
+// b), TLS_{LD, GD}_HI20 + GOT_LO12 + GOT64_LO20, GOT64_HI12.
+//
+// LoongArch use 2 instructions to get a 32bits address, and use 4 instruc-
+// tions to get a 64bits address. It gets the 4K-page of the address plus
+// 2KB at first. Then absolute instructions (ld, st, addi) get the detail.
+// When the loaded address from got is local address, relaxation will
+// relax it from pcalau12i+ld to pcalau12i+addi.
+// When the load address range is PC ±1MB and 4bytes-align, relaxation
+// will relax it from pcalau12i+addi to pcaddi.
+// At present, relaxation is not implemented.
+//
+// https://reviews.llvm.org/D138135
+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
+
+#include "mold.h"
+
+namespace mold::elf {
+
+static u32 hi20(u32 val) { return (val + 0x800) >> 12; }
+static u32 lo12(u32 val) { return val & 0xfff; }
+
+static i64 alau32_hi20(i64 val, i64 pc) {
+  return ((val + ((val & 0x800) << 1)) & ~0xfffl) - (pc & ~0xfffl);
+}
+
+static i64 alau64_hi32(i64 val, i64 pc) {
+  return (val - ((val & 0x800l) << 21)) - (pc & ~0xffffffffl);
+}
+
+static void writeJ20(u8 *loc, u32 val) {
+  *(ul32 *)loc &= 0b11111110'00000000'00000000'00011111;
+  *(ul32 *)loc |= (val & 0xfffff) << 5;
+}
+
+static void writeK12(u8 *loc, u32 val) {
+  *(ul32 *)loc &= 0b11111111'11110000'00000011'11111111;
+  *(ul32 *)loc |= (val & 0xfff) << 10;
+}
+
+static void writeD5k16(u8 *loc, u32 val) {
+  u32 hi = val >> 16;
+  *(ul32 *)loc &= 0b11111100'00000000'00000011'11100000;
+  *(ul32 *)loc |= ((val & 0xffff) << 10) | (hi & 0x1f);
+}
+
+static void writeD10k16(u8 *loc, u32 val) {
+  u32 hi = val >> 16;
+  *(ul32 *)loc &= 0b11111100'00000000'00000000'00000000;
+  *(ul32 *)loc |= ((val & 0xffff) << 10) | (hi & 0x3ff);
+}
+
+static void writeK16(u8 *loc, u32 val) {
+  *(ul32 *)loc &= 0b11111100'00000000'00000011'11111111;
+  *(ul32 *)loc |= (val & 0xffff) << 10;
+}
+
+static void overwrite_uleb(u8 *loc, u64 val) {
+  while (*loc & 0b1000'0000) {
+    *loc++ = 0b1000'0000 | (val & 0b0111'1111);
+    val >>= 7;
+  }
+  *loc = val & 0b0111'1111;
+}
+
+template <typename E>
+void write_plt_header(Context<E> &ctx, u8 *buf) {
+  static const ul32 insn_64[] = {
+    0x1c00'000e, // pcaddu12i $t2, %hi(%pcrel(.got.plt))
+    0x0011'bdad, // sub.d     $t1, $t1, $t3
+    0x28c0'01cf, // ld.d      $t3, $t2, %lo(%pcrel(.got.plt)) # _dl_runtime_resolve
+    0x02ff'51ad, // addi.d    $t1, $t1, -44                   # .plt entry
+    0x02c0'01cc, // addi.d    $t0, $t2, %lo(%pcrel(.got.plt)) # &.got.plt
+    0x0045'05ad, // srli.d    $t1, $t1, 1                     # .plt entry offset
+    0x28c0'218c, // ld.d      $t0, $t0, 8                     # link map
+    0x4c00'01e0, // jr        $t3
+  };
+
+  static const ul32 insn_32[] = {
+    0x1c00'000e, // pcaddu12i $t2, %hi(%pcrel(.got.plt))
+    0x0011'3dad, // sub.w     $t1, $t1, $t3
+    0x2880'01cf, // ld.w      $t3, $t2, %lo(%pcrel(.got.plt)) # _dl_runtime_resolve
+    0x02bf'51ad, // addi.w    $t1, $t1, -44                   # .plt entry
+    0x0280'01cc, // addi.w    $t0, $t2, %lo(%pcrel(.got.plt)) # &.got.plt
+    0x0044'89ad, // srli.w    $t1, $t1, 2                     # .plt entry offset
+    0x2880'118c, // ld.w      $t0, $t0, 4                     # link map
+    0x4c00'01e0, // jr        $t3
+  };
+
+  u64 gotplt = ctx.gotplt->shdr.sh_addr;
+  u64 plt = ctx.plt->shdr.sh_addr;
+  u32 offset = gotplt - plt;
+
+  if constexpr (E::is_64)
+    if (gotplt - plt + 0x8000'0800 > 0xffff'ffff)
+      Error(ctx) << "Overflow when make plt header";
+
+  if constexpr (E::is_64)
+    memcpy(buf, insn_64, sizeof(insn_64));
+  else
+    memcpy(buf, insn_32, sizeof(insn_32));
+
+  writeJ20(buf, hi20(offset));
+  writeK12(buf + 8, lo12(offset));
+  writeK12(buf + 16, lo12(offset));
+}
+
+static const ul32 plt_entry_64[] = {
+  0x1c00000f, // pcaddu12i $t3, %hi(%pcrel(func@.got.plt))
+  0x28c001ef, // ld.d      $t3, $t3, %lo(%pcrel(func@.got.plt))
+  0x4c0001ed, // jirl      $t1, $t3, 0
+  0x03400000, // nop
+};
+
+static const ul32 plt_entry_32[] = {
+  0x1c00000f, // pcaddu12i $t3, %hi(%pcrel(func@.got.plt))
+  0x288001ef, // ld.w      $t3, $t3, %lo(%pcrel(func@.got.plt))
+  0x4c0001ed, // jirl      $t1, $t3, 0
+  0x03400000, // nop
+};
+
+template <typename E>
+void write_plt_entry(Context<E> &ctx, u8 *buf, Symbol<E> &sym) {
+  u64 gotplt = sym.get_gotplt_addr(ctx);
+  u64 plt = sym.get_plt_addr(ctx);
+  u32 offset = gotplt - plt;
+
+  if constexpr (E::is_64)
+    if (gotplt - plt + 0x8000'0800 > 0xffff'ffff)
+      Error(ctx) << "Overflow when make plt entry";
+
+  if constexpr (E::is_64)
+    memcpy(buf, plt_entry_64, sizeof(plt_entry_64));
+  else
+    memcpy(buf, plt_entry_32, sizeof(plt_entry_32));
+
+  writeJ20(buf, hi20(offset));
+  writeK12(buf + 4, lo12(offset));
+}
+
+template <typename E>
+void write_pltgot_entry(Context<E> &ctx, u8 *buf, Symbol<E> &sym) {
+  u64 got = sym.get_got_addr(ctx);
+  u64 plt = sym.get_plt_addr(ctx);
+  u32 offset = got - plt;
+
+  if constexpr (E::is_64)
+    if (got - plt + 0x8000'0800 > 0xffff'ffff)
+      Error(ctx) << "Overflow when make pltgot entry";
+
+  if constexpr (E::is_64)
+    memcpy(buf, plt_entry_64, sizeof(plt_entry_64));
+  else
+    memcpy(buf, plt_entry_32, sizeof(plt_entry_32));
+
+  writeJ20(buf, hi20(offset));
+  writeK12(buf + 4, lo12(offset));
+}
+
+template <typename E>
+void EhFrameSection<E>::apply_eh_reloc(Context<E> &ctx, const ElfRel<E> &rel,
+                                    u64 offset, u64 val) {
+  u8 *loc = ctx.buf + this->shdr.sh_offset + offset;
+
+  switch (rel.r_type) {
+  case R_NONE:
+    break;
+  case R_LARCH_ADD6:
+    *loc = (*loc & 0b1100'0000) | (((*loc & 0b0011'1111) + val) & 0b0011'1111);
+    break;
+  case R_LARCH_ADD8:
+    *loc += val;
+    break;
+  case R_LARCH_ADD16:
+    *(U16<E> *)loc += val;
+    break;
+  case R_LARCH_ADD32:
+    *(U32<E> *)loc += val;
+    break;
+  case R_LARCH_ADD64:
+    *(U64<E> *)loc += val;
+    break;
+  case R_LARCH_SUB6:
+    *loc = (*loc & 0b1100'0000) | (((*loc & 0b0011'1111) - val) & 0b0011'1111);
+    break;
+  case R_LARCH_SUB8:
+    *loc -= val;
+    break;
+  case R_LARCH_SUB16:
+    *(U16<E> *)loc -= val;
+    break;
+  case R_LARCH_SUB32:
+    *(U32<E> *)loc -= val;
+    break;
+  case R_LARCH_SUB64:
+    *(U64<E> *)loc -= val;
+    break;
+  case R_LARCH_32_PCREL:
+    *(U32<E> *)loc = val - this->shdr.sh_addr - offset;
+    break;
+  case R_LARCH_64_PCREL:
+    *(U64<E> *)loc = val - this->shdr.sh_addr - offset;
+    break;
+  default:
+    Fatal(ctx) << "unsupported relocation in .eh_frame: " << rel;
+  }
+}
+
+template <typename E>
+void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
+  std::span<const ElfRel<E>> rels = get_rels(ctx);
+
+  ElfRel<E> *dynrel = nullptr;
+  if (ctx.reldyn)
+    dynrel = (ElfRel<E> *)(ctx.buf + ctx.reldyn->shdr.sh_offset +
+                           file.reldyn_offset + this->reldyn_offset);
+
+  for (i64 i = 0; i < rels.size(); i++) {
+    const ElfRel<E> &rel = rels[i];
+    if (rel.r_type == R_NONE)
+      continue;
+
+    // Maybe do something in the future.
+    if (rel.r_type == R_LARCH_RELAX)
+      continue;
+
+    // Relocation notes, ignore them.
+    if (rel.r_type == R_LARCH_MARK_LA || rel.r_type == R_LARCH_MARK_PCREL)
+      continue;
+
+    Symbol<E> &sym = *file.symbols[rel.r_sym];
+    u8 *loc = base + rel.r_offset;
+
+    auto checkrange = [&](i64 val, i64 lo, i64 hi) {
+      if (val < lo || hi <= val)
+        Error(ctx) << *this << ": relocation " << rel << " against "
+                   << sym << " out of range: " << val << " is not in ["
+                   << lo << ", " << hi << ")";
+    };
+
+    auto checkalign = [&](i64 val, i64 align) {
+      if (val & (align - 1))
+        Error(ctx) << *this << ": relocation " << rel << " against "
+                   << sym << " unaligned: " << val << " needs "
+                   << align << " bytes aligned";
+    };
+
+    u64 S = sym.get_addr(ctx);
+    u64 A = rel.r_addend;
+    u64 P = get_addr() + rel.r_offset;
+    u64 G = sym.get_got_idx(ctx) * sizeof(Word<E>);
+    u64 GP = ctx.got->shdr.sh_addr;
+    u64 TP = ctx.tp_addr;
+    u64 GD = sym.has_tlsgd(ctx) ? sym.get_tlsgd_addr(ctx) : 0;
+    u64 IE = sym.has_gottp(ctx) ? sym.get_gottp_addr(ctx) : 0;
+
+    auto get_got_or_gd = [&]() {
+      if (sym.has_tlsgd(ctx))
+        return GD;
+      else
+        return GP + G;
+    };
+
+    switch (rel.r_type) {
+    case R_LARCH_32: {
+      if constexpr (E::is_64)
+        *(U32<E> *)loc = S + A;
+      else
+        apply_dyn_absrel(ctx, sym, rel, loc, S, A, P, &dynrel);
+      break;
+    }
+    case R_LARCH_64: {
+      assert(E::is_64);
+      apply_dyn_absrel(ctx, sym, rel, loc, S, A, P, &dynrel);
+      break;
+    }
+    case R_LARCH_B16: {
+      i64 val = S + A - P;
+      checkrange(val, -(1ll << 17), 1ll << 17);
+      checkalign(val, 4);
+      writeK16(loc, val >> 2);
+      break;
+    }
+    case R_LARCH_B21: {
+      i64 val = S + A - P;
+      checkrange(val, -(1ll << 22), 1ll << 22);
+      checkalign(val, 4);
+      writeD5k16(loc, val >> 2);
+      break;
+    }
+    case R_LARCH_B26: {
+      i64 val = S + A - P;
+      checkrange(val, -(1ll << 27), 1ll << 27);
+      checkalign(val, 4);
+      writeD10k16(loc, val >> 2);
+      break;
+    }
+    case R_LARCH_ABS_HI20: {
+      i64 val = S + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_ABS_LO12: {
+      i64 val = S + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_ABS64_LO20: {
+      i64 val = S + A;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_ABS64_HI12: {
+      i64 val = S + A;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_PCALA_HI20: {
+      i64 val = alau32_hi20(S + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_PCALA_LO12: {
+      i64 val = S + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_PCALA64_LO20: {
+      i64 val = alau64_hi32(S + A, P);
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_PCALA64_HI12: {
+      i64 val = alau64_hi32(S + A, P);
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_GOT_PC_HI20: {
+      i64 val = alau32_hi20(GP + G + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_GOT_PC_LO12: {
+      i64 val = get_got_or_gd() + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_GOT64_PC_LO20: {
+      i64 val = alau64_hi32(get_got_or_gd() + A, P);
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_GOT64_PC_HI12: {
+      i64 val = alau64_hi32(get_got_or_gd() + A, P);
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_GOT_HI20: {
+      i64 val = GP + G + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_GOT_LO12: {
+      i64 val = get_got_or_gd() + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_GOT64_LO20: {
+      i64 val = get_got_or_gd() + A;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_GOT64_HI12: {
+      i64 val = get_got_or_gd() + A;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_LE_HI20: {
+      i64 val = S + A - TP;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_LE_LO12: {
+      i64 val = S + A - TP;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_TLS_LE64_LO20: {
+      i64 val = S + A - TP;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_TLS_LE64_HI12: {
+      i64 val = S + A - TP;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_IE_PC_HI20: {
+      i64 val = alau32_hi20(IE + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_IE_PC_LO12: {
+      i64 val = IE + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_TLS_IE64_PC_LO20: {
+      i64 val = alau64_hi32(IE + A, P);
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_TLS_IE64_PC_HI12: {
+      i64 val = alau64_hi32(IE + A, P);
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_IE_HI20: {
+      i64 val = IE + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_IE_LO12: {
+      i64 val = IE + A;
+      writeK12(loc, val);
+      break;
+    }
+    case R_LARCH_TLS_IE64_LO20: {
+      i64 val = IE + A;
+      writeJ20(loc, val >> 32);
+      break;
+    }
+    case R_LARCH_TLS_IE64_HI12: {
+      i64 val = IE + A;
+      writeK12(loc, val >> 52);
+      break;
+    }
+    case R_LARCH_TLS_LD_PC_HI20:
+    case R_LARCH_TLS_GD_PC_HI20: {
+      i64 val = alau32_hi20(GD + A, P);
+      checkrange(val, -(1ll << 31), 1ll << 31);
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_TLS_LD_HI20:
+    case R_LARCH_TLS_GD_HI20: {
+      i64 val = GD + A;
+      writeJ20(loc, val >> 12);
+      break;
+    }
+    case R_LARCH_ADD6:
+      *loc = (*loc & 0b1100'0000) | (((*loc & 0b0011'1111) + S + A) & 0b0011'1111);
+      break;
+    case R_LARCH_ADD8:
+      *loc += S + A;
+      break;
+    case R_LARCH_ADD16:
+      *(U16<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD32:
+      *(U32<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD64:
+      *(U64<E> *)loc += S + A;
+      break;
+    case R_LARCH_SUB6:
+      *loc = (*loc & 0b1100'0000) | (((*loc & 0b0011'1111) - S - A) & 0b0011'1111);
+      break;
+    case R_LARCH_SUB8:
+      *loc -= S + A;
+      break;
+    case R_LARCH_SUB16:
+      *(U16<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB32:
+      *(U32<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB64:
+      *(U64<E> *)loc -= S + A;
+      break;
+    case R_LARCH_32_PCREL:
+      *(U32<E> *)loc = S + A - P;
+      break;
+    case R_LARCH_64_PCREL:
+      *(U64<E> *)loc = S + A - P;
+      break;
+    case R_LARCH_ADD_ULEB128:
+      overwrite_uleb(loc, read_uleb(loc) + S + A);
+      break;
+    case R_LARCH_SUB_ULEB128:
+      overwrite_uleb(loc, read_uleb(loc) - S - A);
+      break;
+    // A stack machine (read: global mutable state) is necessary for properly
+    // computing these relocs, and these relocs are already deprecated after
+    // the release of LoongArch ELF psABI v2.00, so we are not going to
+    // implement them.
+    case R_LARCH_SOP_PUSH_PCREL:
+    case R_LARCH_SOP_PUSH_ABSOLUTE:
+    case R_LARCH_SOP_PUSH_DUP:
+    case R_LARCH_SOP_PUSH_GPREL:
+    case R_LARCH_SOP_PUSH_TLS_TPREL:
+    case R_LARCH_SOP_PUSH_TLS_GOT:
+    case R_LARCH_SOP_PUSH_TLS_GD:
+    case R_LARCH_SOP_PUSH_PLT_PCREL:
+    case R_LARCH_SOP_ASSERT:
+    case R_LARCH_SOP_NOT:
+    case R_LARCH_SOP_SUB:
+    case R_LARCH_SOP_SL:
+    case R_LARCH_SOP_SR:
+    case R_LARCH_SOP_ADD:
+    case R_LARCH_SOP_AND:
+    case R_LARCH_SOP_IF_ELSE:
+    case R_LARCH_SOP_POP_32_S_10_5:
+    case R_LARCH_SOP_POP_32_U_10_12:
+    case R_LARCH_SOP_POP_32_S_10_12:
+    case R_LARCH_SOP_POP_32_S_10_16:
+    case R_LARCH_SOP_POP_32_S_10_16_S2:
+    case R_LARCH_SOP_POP_32_S_5_20:
+    case R_LARCH_SOP_POP_32_S_0_5_10_16_S2:
+    case R_LARCH_SOP_POP_32_S_0_10_10_16_S2:
+    case R_LARCH_SOP_POP_32_U:
+    // Nor are we implementing these two reloc types that were probably added
+    // without much thought, and already proposed to be removed.
+    // See https://github.com/loongson/LoongArch-Documentation/issues/51
+    case R_LARCH_ADD24:
+    case R_LARCH_SUB24:
+    // Similarly for these two, long deprecated and unused even before the
+    // inception of LoongArch.
+    case R_LARCH_GNU_VTINHERIT:
+    case R_LARCH_GNU_VTENTRY:
+      Error(ctx) << *this << ": cannot handle deprecated relocation "
+                 << rel << " against symbol " << sym;
+      break;
+    default:
+      unreachable();
+    }
+
+  }
+}
+
+template <typename E>
+void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
+  std::span<const ElfRel<E>> rels = get_rels(ctx);
+
+  for (i64 i = 0; i < rels.size(); i++) {
+    const ElfRel<E> &rel = rels[i];
+    if (rel.r_type == R_NONE)
+      continue;
+
+    Symbol<E> &sym = *file.symbols[rel.r_sym];
+    u8 *loc = base + rel.r_offset;
+
+    if (!sym.file) {
+      record_undef_error(ctx, rel);
+      continue;
+    }
+
+    SectionFragment<E> *frag;
+    i64 frag_addend;
+    std::tie(frag, frag_addend) = get_fragment(ctx, rel);
+
+    u64 S = frag ? frag->get_addr(ctx) : sym.get_addr(ctx);
+    u64 A = frag ? frag_addend : (i64)rel.r_addend;
+
+    switch (rel.r_type) {
+    case R_LARCH_32:
+      *(U32<E> *)loc = S + A;
+      break;
+    case R_LARCH_64:
+      if (std::optional<u64> val = get_tombstone(sym, frag))
+        *(U64<E> *)loc = *val;
+      else
+        *(U64<E> *)loc = S + A;
+      break;
+    case R_LARCH_ADD6:
+      *loc = (*loc & 0b1100'0000) | (((*loc & 0b0011'1111) + S + A) & 0b0011'1111);
+      break;
+    case R_LARCH_ADD8:
+      *loc += S + A;
+      break;
+    case R_LARCH_ADD16:
+      *(U16<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD32:
+      *(U32<E> *)loc += S + A;
+      break;
+    case R_LARCH_ADD64:
+      *(U64<E> *)loc += S + A;
+      break;
+    case R_LARCH_SUB6:
+      *loc = (*loc & 0b1100'0000) | (((*loc & 0b0011'1111) - S - A) & 0b0011'1111);
+      break;
+    case R_LARCH_SUB8:
+      *loc -= S + A;
+      break;
+    case R_LARCH_SUB16:
+      *(U16<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB32:
+      *(U32<E> *)loc -= S + A;
+      break;
+    case R_LARCH_SUB64:
+      *(U64<E> *)loc -= S + A;
+      break;
+    case R_LARCH_TLS_DTPREL32:
+      if (std::optional<u64> val = get_tombstone(sym, frag))
+        *(U32<E> *)loc = *val;
+      else
+        *(U32<E> *)loc = S + A - ctx.dtp_addr;
+      break;
+    case R_LARCH_TLS_DTPREL64:
+      if (std::optional<u64> val = get_tombstone(sym, frag))
+        *(U64<E> *)loc = *val;
+      else
+        *(U64<E> *)loc = S + A - ctx.dtp_addr;
+      break;
+    case R_LARCH_ADD_ULEB128:
+      overwrite_uleb(loc, read_uleb(loc) + S + A);
+      break;
+    case R_LARCH_SUB_ULEB128:
+      overwrite_uleb(loc, read_uleb(loc) - S - A);
+      break;
+    default:
+      Fatal(ctx) << *this << ": invalid relocation for non-allocated sections: "
+                 << rel;
+      break;
+    }
+
+  }
+}
+
+template <typename E>
+void InputSection<E>::scan_relocations(Context<E> &ctx) {
+  assert(shdr().sh_flags & SHF_ALLOC);
+
+  this->reldyn_offset = file.num_dynrel * sizeof(ElfRel<E>);
+  std::span<const ElfRel<E>> rels = get_rels(ctx);
+
+  // Scan relocations
+  for (i64 i = 0; i < rels.size(); i++) {
+    const ElfRel<E> &rel = rels[i];
+    if (rel.r_type == R_NONE)
+      continue;
+
+    if (rel.r_type == R_LARCH_RELAX)
+      continue;
+
+    if (rel.r_type == R_LARCH_MARK_LA || rel.r_type == R_LARCH_MARK_PCREL)
+      continue;
+
+    if (record_undef_error(ctx, rel))
+      continue;
+
+    Symbol<E> &sym = *file.symbols[rel.r_sym];
+
+    if (!sym.file) {
+      record_undef_error(ctx, rel);
+      continue;
+    }
+
+    if (sym.is_ifunc())
+      sym.flags |= (NEEDS_GOT | NEEDS_PLT);
+
+    switch (rel.r_type) {
+    case R_LARCH_32:
+      if constexpr (E::is_64)
+        scan_absrel(ctx, sym, rel);
+      else
+        scan_dyn_absrel(ctx, sym, rel);
+      break;
+    case R_LARCH_64:
+      assert(E::is_64);
+      scan_dyn_absrel(ctx, sym, rel);
+      break;
+    case R_LARCH_B26:
+      if (sym.is_imported)
+        sym.flags |= NEEDS_PLT;
+      break;
+    case R_LARCH_GOT_HI20:
+    case R_LARCH_GOT_PC_HI20:
+      sym.flags |= NEEDS_GOT;
+      break;
+    case R_LARCH_TLS_IE_HI20:
+    case R_LARCH_TLS_IE_PC_HI20:
+      sym.flags |= NEEDS_GOTTP;
+      break;
+    case R_LARCH_TLS_LD_PC_HI20:
+    case R_LARCH_TLS_GD_PC_HI20:
+    case R_LARCH_TLS_LD_HI20:
+    case R_LARCH_TLS_GD_HI20:
+      sym.flags |= NEEDS_TLSGD;
+      break;
+    case R_LARCH_32_PCREL:
+    case R_LARCH_64_PCREL:
+      scan_pcrel(ctx, sym, rel);
+      break;
+    case R_LARCH_TLS_LE_HI20:
+    case R_LARCH_TLS_LE_LO12:
+    case R_LARCH_TLS_LE64_LO20:
+    case R_LARCH_TLS_LE64_HI12:
+      check_tlsle(ctx, sym, rel);
+      break;
+    case R_LARCH_B16:
+    case R_LARCH_B21:
+    case R_LARCH_ABS_HI20:
+    case R_LARCH_ABS_LO12:
+    case R_LARCH_ABS64_LO20:
+    case R_LARCH_ABS64_HI12:
+    case R_LARCH_PCALA_HI20:
+    case R_LARCH_PCALA_LO12:
+    case R_LARCH_PCALA64_LO20:
+    case R_LARCH_PCALA64_HI12:
+    case R_LARCH_GOT_PC_LO12:
+    case R_LARCH_GOT64_PC_LO20:
+    case R_LARCH_GOT64_PC_HI12:
+    case R_LARCH_GOT_LO12:
+    case R_LARCH_GOT64_LO20:
+    case R_LARCH_GOT64_HI12:
+    case R_LARCH_TLS_IE_PC_LO12:
+    case R_LARCH_TLS_IE64_PC_LO20:
+    case R_LARCH_TLS_IE64_PC_HI12:
+    case R_LARCH_TLS_IE_LO12:
+    case R_LARCH_TLS_IE64_LO20:
+    case R_LARCH_TLS_IE64_HI12:
+    case R_LARCH_ADD6:
+    case R_LARCH_SUB6:
+    case R_LARCH_ADD8:
+    case R_LARCH_SUB8:
+    case R_LARCH_ADD16:
+    case R_LARCH_SUB16:
+    case R_LARCH_ADD32:
+    case R_LARCH_SUB32:
+    case R_LARCH_ADD64:
+    case R_LARCH_SUB64:
+    case R_LARCH_ADD_ULEB128:
+    case R_LARCH_SUB_ULEB128:
+      break;
+    case R_LARCH_PCREL20_S2:
+    case R_LARCH_ALIGN:
+      Error(ctx) << *this << ": cannot handle " << rel << " relocation";
+      break;
+    case R_LARCH_SOP_PUSH_PCREL ... R_LARCH_SOP_POP_32_U:
+    case R_LARCH_ADD24:
+    case R_LARCH_SUB24:
+    case R_LARCH_GNU_VTINHERIT:
+    case R_LARCH_GNU_VTENTRY:
+    case R_LARCH_CFA:
+    case R_LARCH_DELETE:
+      Error(ctx) << *this << ": cannot handle deprecated relocation "
+                 << rel << " against symbol " << sym;
+      break;
+    default:
+      Error(ctx) << *this << ": unknown relocation: " << rel;
+    }
+  }
+}
+
+#define INSTANTIATE(E)                                                          \
+  template void write_plt_header(Context<E> &, u8 *);                           \
+  template void write_plt_entry(Context<E> &, u8 *, Symbol<E> &);               \
+  template void write_pltgot_entry(Context<E> &, u8 *, Symbol<E> &);            \
+  template void                                                                 \
+  EhFrameSection<E>::apply_eh_reloc(Context<E> &, const ElfRel<E> &, u64, u64); \
+  template void InputSection<E>::apply_reloc_alloc(Context<E> &, u8 *);         \
+  template void InputSection<E>::apply_reloc_nonalloc(Context<E> &, u8 *);      \
+  template void InputSection<E>::scan_relocations(Context<E> &);
+
+INSTANTIATE(LOONGARCH64);
+INSTANTIATE(LOONGARCH32);
+} // namespace mold::elf

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -201,8 +201,8 @@ Options:
     -z notext
     -z textoff
 
-mold: supported targets: elf32-i386 elf64-x86-64 elf32-littlearm elf64-littleaarch64 elf32-littleriscv elf32-bigriscv elf64-littleriscv elf64-bigriscv elf32-powerpc elf64-powerpc elf64-powerpc elf64-powerpcle elf64-s390 elf64-sparc elf32-m68k elf32-sh-linux elf64-alpha
-mold: supported emulations: elf_i386 elf_x86_64 armelf_linux_eabi aarch64linux aarch64elf elf32lriscv elf32briscv elf64lriscv elf64briscv elf32ppc elf32ppclinux elf64ppc elf64lppc elf64_s390 elf64_sparc m68kelf shlelf_linux elf64alpha)";
+mold: supported targets: elf32-i386 elf64-x86-64 elf32-littlearm elf64-littleaarch64 elf32-littleriscv elf32-bigriscv elf64-littleriscv elf64-bigriscv elf32-powerpc elf64-powerpc elf64-powerpc elf64-powerpcle elf64-s390 elf64-sparc elf32-m68k elf32-sh-linux elf64-alpha elf32-loongarch elf64-loongarch
+mold: supported emulations: elf_i386 elf_x86_64 armelf_linux_eabi aarch64linux aarch64elf elf32lriscv elf32briscv elf64lriscv elf64briscv elf32ppc elf32ppclinux elf64ppc elf64lppc elf64_s390 elf64_sparc m68kelf shlelf_linux elf64alpha elf32loongarch elf64loongarch)";
 
 static std::vector<std::string> add_dashes(std::string name) {
   // Single-letter option
@@ -526,7 +526,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
                    << "   elf64briscv\n   elf32lriscv\n   elf32briscv\n"
                    << "   elf32ppc\n   elf64ppc\n   elf64lppc\n   elf64_s390\n"
                    << "   elf64_sparc\n   m68kelf\n   shlelf_linux\n"
-                   << "   elf64alpha\n   elf64ltsmip\n   elf64btsmip";
+                   << "   elf64alpha\n   elf64ltsmip\n   elf64btsmip\n"
+                   << "   elf32loongarch\n   elf64loongarch";
       version_shown = true;
     } else if (read_flag("mips32") || read_flag("mips32r2") ||
                read_flag("mips32r3") || read_flag("mips32r4") ||
@@ -572,6 +573,10 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
         ctx.arg.emulation = MIPS64LE::target_name;
       } else if (arg == "elf64btsmip") {
         ctx.arg.emulation = MIPS64BE::target_name;
+      } else if (arg == "elf32loongarch") {
+        ctx.arg.emulation = LOONGARCH32::target_name;
+      } else if (arg == "elf64loongarch") {
+        ctx.arg.emulation = LOONGARCH64::target_name;
       } else {
         Fatal(ctx) << "unknown -m argument: " << arg;
       }

--- a/elf/elf.cc
+++ b/elf/elf.cc
@@ -1012,4 +1012,114 @@ std::string rel_to_string<MIPS64BE>(u32 r_type) {
   return rel_to_string<MIPS64LE>(r_type);
 }
 
+template <>
+std::string rel_to_string<LOONGARCH64>(u32 r_type) {
+  switch (r_type) {
+  case R_LARCH_NONE: return "R_LARCH_NONE";
+  case R_LARCH_32: return "R_LARCH_32";
+  case R_LARCH_64: return "R_LARCH_64";
+  case R_LARCH_RELATIVE: return "R_LARCH_RELATIVE";
+  case R_LARCH_COPY: return "R_LARCH_COPY";
+  case R_LARCH_JUMP_SLOT: return "R_LARCH_JUMP_SLOT";
+  case R_LARCH_TLS_DTPMOD32: return "R_LARCH_TLS_DTPMOD32";
+  case R_LARCH_TLS_DTPMOD64: return "R_LARCH_TLS_DTPMOD64";
+  case R_LARCH_TLS_DTPREL32: return "R_LARCH_TLS_DTPREL32";
+  case R_LARCH_TLS_DTPREL64: return "R_LARCH_TLS_DTPREL64";
+  case R_LARCH_TLS_TPREL32: return "R_LARCH_TLS_TPREL32";
+  case R_LARCH_TLS_TPREL64: return "R_LARCH_TLS_TPREL64";
+  case R_LARCH_IRELATIVE: return "R_LARCH_IRELATIVE";
+  case R_LARCH_MARK_LA: return "R_LARCH_MARK_LA";
+  case R_LARCH_MARK_PCREL: return "R_LARCH_MARK_PCREL";
+  case R_LARCH_SOP_PUSH_PCREL: return "R_LARCH_SOP_PUSH_PCREL";
+  case R_LARCH_SOP_PUSH_ABSOLUTE: return "R_LARCH_SOP_PUSH_ABSOLUTE";
+  case R_LARCH_SOP_PUSH_DUP: return "R_LARCH_SOP_PUSH_DUP";
+  case R_LARCH_SOP_PUSH_GPREL: return "R_LARCH_SOP_PUSH_GPREL";
+  case R_LARCH_SOP_PUSH_TLS_TPREL: return "R_LARCH_SOP_PUSH_TLS_TPREL";
+  case R_LARCH_SOP_PUSH_TLS_GOT: return "R_LARCH_SOP_PUSH_TLS_GOT";
+  case R_LARCH_SOP_PUSH_TLS_GD: return "R_LARCH_SOP_PUSH_TLS_GD";
+  case R_LARCH_SOP_PUSH_PLT_PCREL: return "R_LARCH_SOP_PUSH_PLT_PCREL";
+  case R_LARCH_SOP_ASSERT: return "R_LARCH_SOP_ASSERT";
+  case R_LARCH_SOP_NOT: return "R_LARCH_SOP_NOT";
+  case R_LARCH_SOP_SUB: return "R_LARCH_SOP_SUB";
+  case R_LARCH_SOP_SL: return "R_LARCH_SOP_SL";
+  case R_LARCH_SOP_SR: return "R_LARCH_SOP_SR";
+  case R_LARCH_SOP_ADD: return "R_LARCH_SOP_ADD";
+  case R_LARCH_SOP_AND: return "R_LARCH_SOP_AND";
+  case R_LARCH_SOP_IF_ELSE: return "R_LARCH_SOP_IF_ELSE";
+  case R_LARCH_SOP_POP_32_S_10_5: return "R_LARCH_SOP_POP_32_S_10_5";
+  case R_LARCH_SOP_POP_32_U_10_12: return "R_LARCH_SOP_POP_32_U_10_12";
+  case R_LARCH_SOP_POP_32_S_10_12: return "R_LARCH_SOP_POP_32_S_10_12";
+  case R_LARCH_SOP_POP_32_S_10_16: return "R_LARCH_SOP_POP_32_S_10_16";
+  case R_LARCH_SOP_POP_32_S_10_16_S2: return "R_LARCH_SOP_POP_32_S_10_16_S2";
+  case R_LARCH_SOP_POP_32_S_5_20: return "R_LARCH_SOP_POP_32_S_5_20";
+  case R_LARCH_SOP_POP_32_S_0_5_10_16_S2: return "R_LARCH_SOP_POP_32_S_0_5_10_16_S2";
+  case R_LARCH_SOP_POP_32_S_0_10_10_16_S2: return "R_LARCH_SOP_POP_32_S_0_10_10_16_S2";
+  case R_LARCH_SOP_POP_32_U: return "R_LARCH_SOP_POP_32_U";
+  case R_LARCH_ADD8: return "R_LARCH_ADD8";
+  case R_LARCH_ADD16: return "R_LARCH_ADD16";
+  case R_LARCH_ADD24: return "R_LARCH_ADD24";
+  case R_LARCH_ADD32: return "R_LARCH_ADD32";
+  case R_LARCH_ADD64: return "R_LARCH_ADD64";
+  case R_LARCH_SUB8: return "R_LARCH_SUB8";
+  case R_LARCH_SUB16: return "R_LARCH_SUB16";
+  case R_LARCH_SUB24: return "R_LARCH_SUB24";
+  case R_LARCH_SUB32: return "R_LARCH_SUB32";
+  case R_LARCH_SUB64: return "R_LARCH_SUB64";
+  case R_LARCH_GNU_VTINHERIT: return "R_LARCH_GNU_VTINHERIT";
+  case R_LARCH_GNU_VTENTRY: return "R_LARCH_GNU_VTENTRY";
+  case R_LARCH_B16: return "R_LARCH_B16";
+  case R_LARCH_B21: return "R_LARCH_B21";
+  case R_LARCH_B26: return "R_LARCH_B26";
+  case R_LARCH_ABS_HI20: return "R_LARCH_ABS_HI20";
+  case R_LARCH_ABS_LO12: return "R_LARCH_ABS_LO12";
+  case R_LARCH_ABS64_LO20: return "R_LARCH_ABS64_LO20";
+  case R_LARCH_ABS64_HI12: return "R_LARCH_ABS64_HI12";
+  case R_LARCH_PCALA_HI20: return "R_LARCH_PCALA_HI20";
+  case R_LARCH_PCALA_LO12: return "R_LARCH_PCALA_LO12";
+  case R_LARCH_PCALA64_LO20: return "R_LARCH_PCALA64_LO20";
+  case R_LARCH_PCALA64_HI12: return "R_LARCH_PCALA64_HI12";
+  case R_LARCH_GOT_PC_HI20: return "R_LARCH_GOT_PC_HI20";
+  case R_LARCH_GOT_PC_LO12: return "R_LARCH_GOT_PC_LO12";
+  case R_LARCH_GOT64_PC_LO20: return "R_LARCH_GOT64_PC_LO20";
+  case R_LARCH_GOT64_PC_HI12: return "R_LARCH_GOT64_PC_HI12";
+  case R_LARCH_GOT_HI20: return "R_LARCH_GOT_HI20";
+  case R_LARCH_GOT_LO12: return "R_LARCH_GOT_LO12";
+  case R_LARCH_GOT64_LO20: return "R_LARCH_GOT64_LO20";
+  case R_LARCH_GOT64_HI12: return "R_LARCH_GOT64_HI12";
+  case R_LARCH_TLS_LE_HI20: return "R_LARCH_TLS_LE_HI20";
+  case R_LARCH_TLS_LE_LO12: return "R_LARCH_TLS_LE_LO12";
+  case R_LARCH_TLS_LE64_LO20: return "R_LARCH_TLS_LE64_LO20";
+  case R_LARCH_TLS_LE64_HI12: return "R_LARCH_TLS_LE64_HI12";
+  case R_LARCH_TLS_IE_PC_HI20: return "R_LARCH_TLS_IE_PC_HI20";
+  case R_LARCH_TLS_IE_PC_LO12: return "R_LARCH_TLS_IE_PC_LO12";
+  case R_LARCH_TLS_IE64_PC_LO20: return "R_LARCH_TLS_IE64_PC_LO20";
+  case R_LARCH_TLS_IE64_PC_HI12: return "R_LARCH_TLS_IE64_PC_HI12";
+  case R_LARCH_TLS_IE_HI20: return "R_LARCH_TLS_IE_HI20";
+  case R_LARCH_TLS_IE_LO12: return "R_LARCH_TLS_IE_LO12";
+  case R_LARCH_TLS_IE64_LO20: return "R_LARCH_TLS_IE64_LO20";
+  case R_LARCH_TLS_IE64_HI12: return "R_LARCH_TLS_IE64_HI12";
+  case R_LARCH_TLS_LD_PC_HI20: return "R_LARCH_TLS_LD_PC_HI20";
+  case R_LARCH_TLS_LD_HI20: return "R_LARCH_TLS_LD_HI20";
+  case R_LARCH_TLS_GD_PC_HI20: return "R_LARCH_TLS_GD_PC_HI20";
+  case R_LARCH_TLS_GD_HI20: return "R_LARCH_TLS_GD_HI20";
+  case R_LARCH_32_PCREL: return "R_LARCH_32_PCREL";
+  case R_LARCH_RELAX: return "R_LARCH_RELAX";
+  case R_LARCH_DELETE: return "R_LARCH_DELETE";
+  case R_LARCH_ALIGN: return "R_LARCH_ALIGN";
+  case R_LARCH_PCREL20_S2: return "R_LARCH_PCREL20_S2";
+  case R_LARCH_CFA: return "R_LARCH_CFA";
+  case R_LARCH_ADD6: return "R_LARCH_ADD6";
+  case R_LARCH_SUB6: return "R_LARCH_SUB6";
+  case R_LARCH_ADD_ULEB128: return "R_LARCH_ADD_ULEB128";
+  case R_LARCH_SUB_ULEB128: return "R_LARCH_SUB_ULEB128";
+  case R_LARCH_64_PCREL: return "R_LARCH_64_PCREL";
+  }
+  return "unknown (" + std::to_string(r_type) + ")";
+}
+
+template <>
+std::string rel_to_string<LOONGARCH32>(u32 r_type) {
+  return rel_to_string<LOONGARCH64>(r_type);
+}
+
 } // namespace mold::elf

--- a/elf/elf.h
+++ b/elf/elf.h
@@ -26,6 +26,8 @@ struct SH4;
 struct ALPHA;
 struct MIPS64LE;
 struct MIPS64BE;
+struct LOONGARCH32;
+struct LOONGARCH64;
 
 template <typename E> struct ElfSym;
 template <typename E> struct ElfShdr;
@@ -232,6 +234,7 @@ enum : u32 {
   EM_X86_64 = 62,
   EM_AARCH64 = 183,
   EM_RISCV = 243,
+  EM_LOONGARCH = 258,
   EM_ALPHA = 0x9026,
 };
 
@@ -390,6 +393,15 @@ enum : u32 {
   ELF_TAG_RISCV_STACK_ALIGN = 4,
   ELF_TAG_RISCV_ARCH = 5,
   ELF_TAG_RISCV_UNALIGNED_ACCESS = 6,
+};
+
+enum : u32 {
+  EF_LOONGARCH_ABI_SOFT_FLOAT = 0x1,
+  EF_LOONGARCH_ABI_SINGLE_FLOAT = 0x2,
+  EF_LOONGARCH_ABI_DOUBLE_FLOAT = 0x3,
+  EF_LOONGARCH_ABI_MODIFIER_MASK = 0x7,
+  EF_LOONGARCH_OBJABI_V1 = 0x40,
+  EF_LOONGARCH_OBJABI_MASK = 0xC0,
 };
 
 //
@@ -1325,6 +1337,107 @@ enum : u32 {
   R_MIPS_EH = 249,
 };
 
+enum : u32 {
+  R_LARCH_NONE = 0,
+  R_LARCH_32 = 1,
+  R_LARCH_64 = 2,
+  R_LARCH_RELATIVE = 3,
+  R_LARCH_COPY = 4,
+  R_LARCH_JUMP_SLOT = 5,
+  R_LARCH_TLS_DTPMOD32 = 6,
+  R_LARCH_TLS_DTPMOD64 = 7,
+  R_LARCH_TLS_DTPREL32 = 8,
+  R_LARCH_TLS_DTPREL64 = 9,
+  R_LARCH_TLS_TPREL32 = 10,
+  R_LARCH_TLS_TPREL64 = 11,
+  R_LARCH_IRELATIVE = 12,
+  R_LARCH_MARK_LA = 20,
+  R_LARCH_MARK_PCREL = 21,
+  R_LARCH_SOP_PUSH_PCREL = 22,
+  R_LARCH_SOP_PUSH_ABSOLUTE = 23,
+  R_LARCH_SOP_PUSH_DUP = 24,
+  R_LARCH_SOP_PUSH_GPREL = 25,
+  R_LARCH_SOP_PUSH_TLS_TPREL = 26,
+  R_LARCH_SOP_PUSH_TLS_GOT = 27,
+  R_LARCH_SOP_PUSH_TLS_GD = 28,
+  R_LARCH_SOP_PUSH_PLT_PCREL = 29,
+  R_LARCH_SOP_ASSERT = 30,
+  R_LARCH_SOP_NOT = 31,
+  R_LARCH_SOP_SUB = 32,
+  R_LARCH_SOP_SL = 33,
+  R_LARCH_SOP_SR = 34,
+  R_LARCH_SOP_ADD = 35,
+  R_LARCH_SOP_AND = 36,
+  R_LARCH_SOP_IF_ELSE = 37,
+  R_LARCH_SOP_POP_32_S_10_5 = 38,
+  R_LARCH_SOP_POP_32_U_10_12 = 39,
+  R_LARCH_SOP_POP_32_S_10_12 = 40,
+  R_LARCH_SOP_POP_32_S_10_16 = 41,
+  R_LARCH_SOP_POP_32_S_10_16_S2 = 42,
+  R_LARCH_SOP_POP_32_S_5_20 = 43,
+  R_LARCH_SOP_POP_32_S_0_5_10_16_S2 = 44,
+  R_LARCH_SOP_POP_32_S_0_10_10_16_S2 = 45,
+  R_LARCH_SOP_POP_32_U = 46,
+  R_LARCH_ADD8 = 47,
+  R_LARCH_ADD16 = 48,
+  R_LARCH_ADD24 = 49,
+  R_LARCH_ADD32 = 50,
+  R_LARCH_ADD64 = 51,
+  R_LARCH_SUB8 = 52,
+  R_LARCH_SUB16 = 53,
+  R_LARCH_SUB24 = 54,
+  R_LARCH_SUB32 = 55,
+  R_LARCH_SUB64 = 56,
+  R_LARCH_GNU_VTINHERIT = 57,
+  R_LARCH_GNU_VTENTRY = 58,
+  R_LARCH_B16 = 64,
+  R_LARCH_B21 = 65,
+  R_LARCH_B26 = 66,
+  R_LARCH_ABS_HI20 = 67,
+  R_LARCH_ABS_LO12 = 68,
+  R_LARCH_ABS64_LO20 = 69,
+  R_LARCH_ABS64_HI12 = 70,
+  R_LARCH_PCALA_HI20 = 71,
+  R_LARCH_PCALA_LO12 = 72,
+  R_LARCH_PCALA64_LO20 = 73,
+  R_LARCH_PCALA64_HI12 = 74,
+  R_LARCH_GOT_PC_HI20 = 75,
+  R_LARCH_GOT_PC_LO12 = 76,
+  R_LARCH_GOT64_PC_LO20 = 77,
+  R_LARCH_GOT64_PC_HI12 = 78,
+  R_LARCH_GOT_HI20 = 79,
+  R_LARCH_GOT_LO12 = 80,
+  R_LARCH_GOT64_LO20 = 81,
+  R_LARCH_GOT64_HI12 = 82,
+  R_LARCH_TLS_LE_HI20 = 83,
+  R_LARCH_TLS_LE_LO12 = 84,
+  R_LARCH_TLS_LE64_LO20 = 85,
+  R_LARCH_TLS_LE64_HI12 = 86,
+  R_LARCH_TLS_IE_PC_HI20 = 87,
+  R_LARCH_TLS_IE_PC_LO12 = 88,
+  R_LARCH_TLS_IE64_PC_LO20 = 89,
+  R_LARCH_TLS_IE64_PC_HI12 = 90,
+  R_LARCH_TLS_IE_HI20 = 91,
+  R_LARCH_TLS_IE_LO12 = 92,
+  R_LARCH_TLS_IE64_LO20 = 93,
+  R_LARCH_TLS_IE64_HI12 = 94,
+  R_LARCH_TLS_LD_PC_HI20 = 95,
+  R_LARCH_TLS_LD_HI20 = 96,
+  R_LARCH_TLS_GD_PC_HI20 = 97,
+  R_LARCH_TLS_GD_HI20 = 98,
+  R_LARCH_32_PCREL = 99,
+  R_LARCH_RELAX = 100,
+  R_LARCH_DELETE = 101,
+  R_LARCH_ALIGN = 102,
+  R_LARCH_PCREL20_S2 = 103,
+  R_LARCH_CFA = 104,
+  R_LARCH_ADD6 = 105,
+  R_LARCH_SUB6 = 106,
+  R_LARCH_ADD_ULEB128 = 107,
+  R_LARCH_SUB_ULEB128 = 108,
+  R_LARCH_64_PCREL = 109,
+};
+
 //
 // DWARF data types
 //
@@ -1815,6 +1928,8 @@ template <typename E> static constexpr bool is_sh4 = std::is_same_v<E, SH4>;
 template <typename E> static constexpr bool is_alpha = std::is_same_v<E, ALPHA>;
 template <typename E> static constexpr bool is_mips64le = std::is_same_v<E, MIPS64LE>;
 template <typename E> static constexpr bool is_mips64be = std::is_same_v<E, MIPS64BE>;
+template <typename E> static constexpr bool is_loongarch32 = std::is_same_v<E, LOONGARCH32>;
+template <typename E> static constexpr bool is_loongarch64 = std::is_same_v<E, LOONGARCH64>;
 
 template <typename E> static constexpr bool is_x86 = is_x86_64<E> || is_i386<E>;
 template <typename E> static constexpr bool is_arm = is_arm64<E> || is_arm32<E>;
@@ -1826,6 +1941,7 @@ template <typename E> static constexpr bool is_ppc = is_ppc64<E> || is_ppc32<E>;
 template <typename E> static constexpr bool is_sparc = is_sparc64<E>;
 template <typename E> static constexpr bool is_mips64 = is_mips64le<E> || is_mips64be<E>;
 template <typename E> static constexpr bool is_mips = is_mips64<E>;
+template <typename E> static constexpr bool is_loongarch = is_loongarch32<E> || is_loongarch64<E>;
 
 struct X86_64 {
   static constexpr std::string_view target_name = "x86_64";
@@ -2247,6 +2363,52 @@ struct MIPS64BE {
   static constexpr u32 R_DTPOFF = R_MIPS_TLS_DTPREL64;
   static constexpr u32 R_TPOFF = R_MIPS_TLS_TPREL64;
   static constexpr u32 R_DTPMOD = R_MIPS_TLS_DTPMOD64;
+};
+
+struct LOONGARCH64 {
+  static constexpr std::string_view target_name = "loongarch64";
+  static constexpr bool is_64 = true;
+  static constexpr bool is_le = true;
+  static constexpr bool is_rela = true;
+  static constexpr u32 page_size = 16384;
+  static constexpr u32 e_machine = EM_LOONGARCH;
+  static constexpr u32 plt_hdr_size = 32;
+  static constexpr u32 plt_size = 16;
+  static constexpr u32 pltgot_size = 16;
+
+  static constexpr u32 R_COPY = R_LARCH_COPY;
+  static constexpr u32 R_GLOB_DAT = R_LARCH_64;
+  static constexpr u32 R_JUMP_SLOT = R_LARCH_JUMP_SLOT;
+  static constexpr u32 R_ABS = R_LARCH_64;
+  static constexpr u32 R_DYNAMIC = R_LARCH_64;
+  static constexpr u32 R_RELATIVE = R_LARCH_RELATIVE;
+  static constexpr u32 R_IRELATIVE = R_LARCH_IRELATIVE;
+  static constexpr u32 R_DTPOFF = R_LARCH_TLS_DTPREL64;
+  static constexpr u32 R_TPOFF = R_LARCH_TLS_TPREL64;
+  static constexpr u32 R_DTPMOD = R_LARCH_TLS_DTPMOD64;
+};
+
+struct LOONGARCH32 {
+  static constexpr std::string_view target_name = "loongarch32";
+  static constexpr bool is_64 = false;
+  static constexpr bool is_le = true;
+  static constexpr bool is_rela = true;
+  static constexpr u32 page_size = 16384;
+  static constexpr u32 e_machine = EM_LOONGARCH;
+  static constexpr u32 plt_hdr_size = 32;
+  static constexpr u32 plt_size = 16;
+  static constexpr u32 pltgot_size = 16;
+
+  static constexpr u32 R_COPY = R_LARCH_COPY;
+  static constexpr u32 R_GLOB_DAT = R_LARCH_32;
+  static constexpr u32 R_JUMP_SLOT = R_LARCH_JUMP_SLOT;
+  static constexpr u32 R_ABS = R_LARCH_32;
+  static constexpr u32 R_DYNAMIC = R_LARCH_32;
+  static constexpr u32 R_RELATIVE = R_LARCH_RELATIVE;
+  static constexpr u32 R_IRELATIVE = R_LARCH_IRELATIVE;
+  static constexpr u32 R_DTPOFF = R_LARCH_TLS_DTPREL32;
+  static constexpr u32 R_TPOFF = R_LARCH_TLS_TPREL32;
+  static constexpr u32 R_DTPMOD = R_LARCH_TLS_DTPMOD32;
 };
 
 } // namespace mold::elf

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -74,6 +74,8 @@ std::string_view get_machine_type(Context<E> &ctx, MappedFile<Context<E>> *mf) {
       if (is_64)
         return is_le ? MIPS64LE::target_name : MIPS64BE::target_name;
       return "";
+    case EM_LOONGARCH:
+      return is_64 ? LOONGARCH64::target_name : LOONGARCH32::target_name;
     default:
       return "";
     }
@@ -379,6 +381,10 @@ static int redo_main(int argc, char **argv, std::string_view target) {
     return elf_main<MIPS64LE>(argc, argv);
   if (target == MIPS64BE::target_name)
     return elf_main<MIPS64BE>(argc, argv);
+  if (target == LOONGARCH32::target_name)
+    return elf_main<LOONGARCH32>(argc, argv);
+  if (target == LOONGARCH64::target_name)
+    return elf_main<LOONGARCH64>(argc, argv);
   unreachable();
 }
 
@@ -775,6 +781,8 @@ extern template int elf_main<SH4>(int, char **);
 extern template int elf_main<ALPHA>(int, char **);
 extern template int elf_main<MIPS64LE>(int, char **);
 extern template int elf_main<MIPS64BE>(int, char **);
+extern template int elf_main<LOONGARCH32>(int, char **);
+extern template int elf_main<LOONGARCH64>(int, char **);
 
 int main(int argc, char **argv) {
   return elf_main<X86_64>(argc, argv);

--- a/elf/tls.cc
+++ b/elf/tls.cc
@@ -172,7 +172,7 @@ u64 get_tp_addr(Context<E> &ctx) {
     // TP. RISC-V load/store instructions usually take 12-bits signed
     // immediates, so the beginning of the TLS block ± 2 KiB is accessible
     // with a single load/store instruction.
-    static_assert(is_riscv<E>);
+    static_assert(is_riscv<E> || is_loongarch<E>);
     return phdr->p_vaddr;
   }
 }

--- a/test/elf/CMakeLists.txt
+++ b/test/elf/CMakeLists.txt
@@ -66,6 +66,7 @@ add_target(sh4-linux-gnu)
 add_target(alpha-linux-gnu)
 add_target(mips64-linux-gnuabi64)
 add_target(mips64el-linux-gnuabi64)
+add_target(loongarch64-linux-gnu)
 
 if(MOLD_ENABLE_QEMU_TESTS_RV32)
   add_target(riscv32-linux-gnu)

--- a/test/elf/abs-error.sh
+++ b/test/elf/abs-error.sh
@@ -8,6 +8,7 @@
 [ $MACHINE = alpha ] && skip
 [ $MACHINE = mips64el ] && skip
 [ $MACHINE = mips64 ] && skip
+[[ $MACHINE = loongarch* ]] && skip
 
 cat <<EOF | $CC -fPIC -c -o $t/a.o -xassembler -
 .globl foo

--- a/test/elf/copyrel-alignment.sh
+++ b/test/elf/copyrel-alignment.sh
@@ -5,6 +5,7 @@
 [ $MACHINE = ppc64le ] && skip
 [ $MACHINE = alpha ] && skip
 [[ $MACHINE = mips* ]] && skip
+[[ $MACHINE = loongarch* ]] && skip
 
 cat <<EOF | $CC -fPIC -shared -o $t/a.so -xc -
 __attribute__((aligned(32))) int foo = 5;

--- a/test/elf/copyrel-protected.sh
+++ b/test/elf/copyrel-protected.sh
@@ -5,6 +5,7 @@
 [ $MACHINE = ppc64le ] && skip
 [ $MACHINE = alpha ] && skip
 [[ $MACHINE = mips* ]] && skip
+[[ $MACHINE = loongarch* ]] && skip
 
 cat <<EOF | $CC -o $t/a.o -c -xc -fno-PIE -
 extern int foo;

--- a/test/elf/dt-init.sh
+++ b/test/elf/dt-init.sh
@@ -2,6 +2,7 @@
 . $(dirname $0)/common.inc
 
 [ $MACHINE = riscv64 -o $MACHINE = riscv32 ] && skip
+[[ $MACHINE = loongarch* ]] && skip
 
 # musl libc does not support init/fini on ARM
 # https://github.com/rui314/mold/issues/951

--- a/test/elf/nocopyreloc.sh
+++ b/test/elf/nocopyreloc.sh
@@ -9,6 +9,7 @@
 [ $MACHINE = sh4 ] && skip
 [ $MACHINE = alpha ] && skip
 [[ $MACHINE = mips* ]] && skip
+[[ $MACHINE = loongarch* ]] && skip
 
 cat <<EOF | $CC -shared -o $t/a.so -xc -
 int foo = 3;

--- a/test/elf/range-extension-thunk.sh
+++ b/test/elf/range-extension-thunk.sh
@@ -8,6 +8,9 @@
 # It looks like SPARC's runtime can't handle PLT if it's too far from GOT.
 [ $MACHINE = sparc64 ] && skip
 
+# The crt*.o compiled with B26 caused far form GOT.
+[[ $MACHINE = loongarch* ]] && skip
+
 cat <<EOF > $t/a.c
 #include <stdio.h>
 

--- a/test/elf/section-start.sh
+++ b/test/elf/section-start.sh
@@ -5,6 +5,9 @@
 # but instead refers "function descriptors" in .opd.
 [ $MACHINE = ppc64 ] && skip
 
+# The crt*.o compiled with B26 caused far form GOT.
+[[ $MACHINE = loongarch* ]] && skip
+
 [ $MACHINE = arm ] && flags=-marm
 
 cat <<EOF | $CC -o $t/a.o -c -xc -fno-PIC $flags -


### PR DESCRIPTION
Test on CLFS-7.1
$ gcc -v
  gcc version 13.0.0 20221018 (experimental) (GCC)
$ as -v
  GNU assembler version 2.39.50 (loongarch64-unknown-linux-gnu) using BFD version (GNU Binutils) 2.39.50.20221029
$ clang -v
  clang version 14.0.6

Test results: $ make test
99% tests passed, 1 tests failed out of 279

Total Test time (real) = 149.51 sec

The following tests did not run:
	  1 - loongarch64-abs-error (Skipped)
	 26 - loongarch64-copyrel-alignment (Skipped)
	 27 - loongarch64-copyrel-protected (Skipped)
	 42 - loongarch64-dt-init (Skipped)
	 98 - loongarch64-ifunc-static-pie (Skipped)
	123 - loongarch64-lto-llvm (Skipped)
	136 - loongarch64-nocopyreloc (Skipped)
	154 - loongarch64-range-extension-thunk (Skipped)
	177 - loongarch64-section-start (Skipped)
	187 - loongarch64-static-pie (Skipped)
	223 - loongarch64-tlsdesc-import (Skipped)
	224 - loongarch64-tlsdesc-static (Skipped)
	225 - loongarch64-tlsdesc (Skipped)

The following tests FAILED:
	143 - loongarch64-pack-dyn-relocs-relr (Failed)   <- The llvm-readelf version is low and can be passed in the upper version

link: https://github.com/sunhaiyong1978/CLFS-for-LoongArch
link: https://reviews.llvm.org/D138135
link: https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html