### PR TITLE
Update `README.md` installation instructions for CMake 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ cd mold/build
 git checkout v2.1.0
 ../install-build-deps.sh
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
-cmake --build . -j $(nproc)
-sudo cmake --install .
+sudo cmake --build . --target install -j $(nproc)
 ```
 
 You might need to pass a C++20 compiler command name to `cmake`. In the


### PR DESCRIPTION
`CMakeLists.txt` declares a minimum CMake dependency on 3.14.

```
cmake_minimum_required(VERSION 3.13)
```

But the `--install` switch is only available since CMake 3.15, see <https://stackoverflow.com/a/56457739>.

This commit updates the installation instructions in `README.md` so that they work with CMake 3.14.