### PR TITLE
Enable strict compiler warnings by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,11 @@ if(NOT "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
     -fno-exceptions
     -fno-unwind-tables
     -fno-asynchronous-unwind-tables
+    -Wall
+    -Wextra
     -Wno-sign-compare
     -Wno-unused-function
-    -Wunused-variable
+    -Wno-unused-parameter
     -ggnu-pubnames)
 endif()
 

--- a/elf/arch-ppc64v1.cc
+++ b/elf/arch-ppc64v1.cc
@@ -521,7 +521,7 @@ struct OpdSymbol {
 };
 
 static Symbol<E> *
-get_opd_sym_at(Context<E> &ctx, std::span<OpdSymbol> syms, u64 offset) {
+get_opd_sym_at(std::span<OpdSymbol> syms, u64 offset) {
   auto it = std::lower_bound(syms.begin(), syms.end(), OpdSymbol{offset});
   if (it == syms.end())
     return nullptr;
@@ -616,7 +616,7 @@ void ppc64v1_rewrite_opd(Context<E> &ctx) {
         if (sym.get_input_section() != opd)
           continue;
 
-        Symbol<E> *real_sym = get_opd_sym_at(ctx, opd_syms, r.r_addend);
+        Symbol<E> *real_sym = get_opd_sym_at(opd_syms, r.r_addend);
         if (!real_sym)
           Fatal(ctx) << *isec << ": cannot find a symbol in .opd for " << r
                      << " at offset 0x" << std::hex << (u64)r.r_addend;

--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -838,7 +838,7 @@ u64 get_eflags(Context<E> &ctx) {
   return ret;
 }
 
-static bool is_resizable(Context<E> &ctx, InputSection<E> *isec) {
+static bool is_resizable(InputSection<E> *isec) {
   return isec && isec->is_alive && (isec->shdr().sh_flags & SHF_ALLOC) &&
          (isec->shdr().sh_flags & SHF_EXECINSTR);
 }
@@ -1038,7 +1038,7 @@ i64 riscv_resize_sections<E>(Context<E> &ctx) {
   // This step should only shrink sections.
   tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
     for (std::unique_ptr<InputSection<E>> &isec : file->sections)
-      if (is_resizable(ctx, isec.get()))
+      if (is_resizable(isec.get()))
         shrink_section(ctx, *isec, use_rvc);
   });
 

--- a/elf/dwarf.cc
+++ b/elf/dwarf.cc
@@ -362,7 +362,7 @@ u64 DebugInfoReader<E>::read(u64 form) {
 // Read a range list from .debug_ranges starting at the given offset.
 template <typename E>
 static std::vector<u64>
-read_debug_range(Context<E> &ctx, ObjectFile<E> &file, Word<E> *range) {
+read_debug_range(Word<E> *range) {
   std::vector<u64> vec;
   u64 base = 0;
 
@@ -381,8 +381,7 @@ read_debug_range(Context<E> &ctx, ObjectFile<E> &file, Word<E> *range) {
 // Read a range list from .debug_rnglists starting at the given offset.
 template <typename E>
 static std::vector<u64>
-read_rnglist_range(Context<E> &ctx, ObjectFile<E> &file, u8 *rnglist,
-                   Word<E> *addrx) {
+read_rnglist_range(u8 *rnglist, Word<E> *addrx) {
   std::vector<u64> vec;
   u64 base = 0;
 
@@ -486,20 +485,20 @@ read_address_areas(Context<E> &ctx, ObjectFile<E> &file, i64 offset) {
     if (dwarf_version <= 4) {
        Word<E> *range_begin =
         (Word<E> *)(get_buffer(ctx, ctx.debug_ranges) + ranges.value);
-      return read_debug_range(ctx, file, range_begin);
+      return read_debug_range<E>(range_begin);
     }
 
     assert(dwarf_version == 5);
 
     u8 *buf = get_buffer(ctx, ctx.debug_rnglists);
     if (ranges.form == DW_FORM_sec_offset)
-      return read_rnglist_range(ctx, file, buf + ranges.value, addrx);
+      return read_rnglist_range<E>(buf + ranges.value, addrx);
 
     if (!rnglists_base)
       Fatal(ctx) << file << ": --gdb-index: missing DW_AT_rnglists_base";
 
     u8 *base = buf + *rnglists_base;
-    return read_rnglist_range(ctx, file, base + *(U32<E> *)base, addrx);
+    return read_rnglist_range<E>(base + *(U32<E> *)base, addrx);
   }
 
   // Handle a contiguous address range.

--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -314,7 +314,7 @@ void ObjectFile<E>::initialize_sections(Context<E> &ctx) {
       if (ctx.arg.oformat_binary && !(shdr.sh_flags & SHF_ALLOC))
         continue;
 
-      this->sections[i] = std::make_unique<InputSection<E>>(ctx, *this, name, i);
+      this->sections[i] = std::make_unique<InputSection<E>>(ctx, *this, i);
 
       // Save .llvm_addrsig for --icf=safe.
       if (shdr.sh_type == SHT_LLVM_ADDRSIG && !ctx.arg.relocatable) {
@@ -1097,13 +1097,9 @@ void ObjectFile<E>::convert_common_symbols(Context<E> &ctx) {
     ElfShdr<E> &shdr = elf_sections2.back();
     memset(&shdr, 0, sizeof(shdr));
 
-    std::string_view name;
-
     if (sym.get_type() == STT_TLS) {
-      name = ".tls_common";
       shdr.sh_flags = SHF_ALLOC | SHF_WRITE | SHF_TLS;
     } else {
-      name = ".common";
       shdr.sh_flags = SHF_ALLOC | SHF_WRITE;
     }
 
@@ -1113,7 +1109,7 @@ void ObjectFile<E>::convert_common_symbols(Context<E> &ctx) {
 
     i64 idx = this->elf_sections.size() + elf_sections2.size() - 1;
     std::unique_ptr<InputSection<E>> isec =
-      std::make_unique<InputSection<E>>(ctx, *this, name, idx);
+      std::make_unique<InputSection<E>>(ctx, *this, idx);
 
     sym.file = this;
     sym.set_input_section(isec.get());

--- a/elf/input-sections.cc
+++ b/elf/input-sections.cc
@@ -37,8 +37,7 @@ static i64 to_p2align(u64 alignment) {
 }
 
 template <typename E>
-InputSection<E>::InputSection(Context<E> &ctx, ObjectFile<E> &file,
-                              std::string_view name, i64 shndx)
+InputSection<E>::InputSection(Context<E> &ctx, ObjectFile<E> &file, i64 shndx)
   : file(file), shndx(shndx) {
   if (shndx < file.elf_sections.size())
     contents = {(char *)file.mf->data + shdr().sh_offset, (size_t)shdr().sh_size};

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -224,8 +224,7 @@ struct InputSectionExtras<E> {
 template <typename E>
 class InputSection {
 public:
-  InputSection(Context<E> &ctx, ObjectFile<E> &file, std::string_view name,
-               i64 shndx);
+  InputSection(Context<E> &ctx, ObjectFile<E> &file, i64 shndx);
 
   void uncompress(Context<E> &ctx);
   void uncompress_to(Context<E> &ctx, u8 *buf);

--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -982,8 +982,8 @@ void check_symbol_types(Context<E> &ctx) {
       const ElfSym<E> &esym1 = sym.esym();
       const ElfSym<E> &esym2 = file->elf_syms[i];
 
-      u32 ty1 = (esym1.st_type == STT_GNU_IFUNC) ? STT_FUNC : esym1.st_type;
-      u32 ty2 = (esym2.st_type == STT_GNU_IFUNC) ? STT_FUNC : esym2.st_type;
+      u32 ty1 = (esym1.st_type == STT_GNU_IFUNC) ? (u32)STT_FUNC : esym1.st_type;
+      u32 ty2 = (esym2.st_type == STT_GNU_IFUNC) ? (u32)STT_FUNC : esym2.st_type;
 
       if (ty1 != STT_NOTYPE && ty2 != STT_NOTYPE && ty1 != ty2)
         Warn(ctx) << "symbol type mismatch: " << sym << '\n'


### PR DESCRIPTION
I'm a fan of leveraging compiler warnings as a lightweight means of static code analysis. For instance, the bug fixed by commit 49f38828d1eec8cd37507792b83254f2c4d64b90 could have been detected and reported by GCC.

Obviously, there is a trade-off between the uncovering of real issues on the one hand and unhelpful warning spam on the other hand. This PR is meant to serve as a ground for discussions.

My personal preference is to go all the way and set `-Wall -Wextra` by default, then deal with the fallout in the following ways:
1. For all legitimate warnings, fix the code.
2. For dubious warnings that are sufficiently rare, massage the code to avoid them.
3. For excessive spam of a certain warning category, selectively disable that category (`-Wno-...`).

For the mold code base, setting `-Wall -Wextra` has had the following consequences (which are addressed by the three additional commits in this PR):
* Several unused parameters being identified. *- I have remove these parameters.*
* A bunch of additional 'unused parameter' warnings for methods whose interface cannot be changed. *- I have suppressed them by commenting-out their names.*
* Two warnings related to differing types in a ternary operator. *- I have suppressed them by adding explicit casts; the warnings per se seem uncritical.*

