### PR TITLE
[ELF] Move main() and redo_main() into a separate compile unit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,7 @@ target_sources(mold PRIVATE
   elf/arch-sparc64.cc
   elf/arch-x86-64.cc
   elf/elf.cc
+  elf/main-mono.cc
   git-hash.cc
   third-party/rust-demangle/rust-demangle.c
   )

--- a/elf/main-mono.cc
+++ b/elf/main-mono.cc
@@ -1,0 +1,50 @@
+#include "mold.h"
+
+namespace mold::elf {
+
+// Since elf_main is a template, we can't run it without a type parameter.
+// We speculatively run elf_main with X86_64, and if the speculation was
+// wrong, re-run it with an actual machine type.
+int redo_main(int argc, char **argv, std::string_view target) {
+  if (target == I386::target_name)
+    return elf_main<I386>(argc, argv);
+  if (target == ARM64::target_name)
+    return elf_main<ARM64>(argc, argv);
+  if (target == ARM32::target_name)
+    return elf_main<ARM32>(argc, argv);
+  if (target == RV64LE::target_name)
+    return elf_main<RV64LE>(argc, argv);
+  if (target == RV64BE::target_name)
+    return elf_main<RV64BE>(argc, argv);
+  if (target == RV32LE::target_name)
+    return elf_main<RV32LE>(argc, argv);
+  if (target == RV32BE::target_name)
+    return elf_main<RV32BE>(argc, argv);
+  if (target == PPC32::target_name)
+    return elf_main<PPC32>(argc, argv);
+  if (target == PPC64V1::target_name)
+    return elf_main<PPC64V1>(argc, argv);
+  if (target == PPC64V2::target_name)
+    return elf_main<PPC64V2>(argc, argv);
+  if (target == S390X::target_name)
+    return elf_main<S390X>(argc, argv);
+  if (target == SPARC64::target_name)
+    return elf_main<SPARC64>(argc, argv);
+  if (target == M68K::target_name)
+    return elf_main<M68K>(argc, argv);
+  if (target == SH4::target_name)
+    return elf_main<SH4>(argc, argv);
+  if (target == ALPHA::target_name)
+    return elf_main<ALPHA>(argc, argv);
+  if (target == LOONGARCH32::target_name)
+    return elf_main<LOONGARCH32>(argc, argv);
+  if (target == LOONGARCH64::target_name)
+    return elf_main<LOONGARCH64>(argc, argv);
+  unreachable();
+}
+
+int main(int argc, char **argv) {
+  return elf_main<X86_64>(argc, argv);
+}
+
+} // namespace mold::elf

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -338,47 +338,6 @@ static void read_input_files(Context<E> &ctx, std::span<std::string> args) {
   ctx.tg.wait();
 }
 
-// Since elf_main is a template, we can't run it without a type parameter.
-// We speculatively run elf_main with X86_64, and if the speculation was
-// wrong, re-run it with an actual machine type.
-static int redo_main(int argc, char **argv, std::string_view target) {
-  if (target == I386::target_name)
-    return elf_main<I386>(argc, argv);
-  if (target == ARM64::target_name)
-    return elf_main<ARM64>(argc, argv);
-  if (target == ARM32::target_name)
-    return elf_main<ARM32>(argc, argv);
-  if (target == RV64LE::target_name)
-    return elf_main<RV64LE>(argc, argv);
-  if (target == RV64BE::target_name)
-    return elf_main<RV64BE>(argc, argv);
-  if (target == RV32LE::target_name)
-    return elf_main<RV32LE>(argc, argv);
-  if (target == RV32BE::target_name)
-    return elf_main<RV32BE>(argc, argv);
-  if (target == PPC32::target_name)
-    return elf_main<PPC32>(argc, argv);
-  if (target == PPC64V1::target_name)
-    return elf_main<PPC64V1>(argc, argv);
-  if (target == PPC64V2::target_name)
-    return elf_main<PPC64V2>(argc, argv);
-  if (target == S390X::target_name)
-    return elf_main<S390X>(argc, argv);
-  if (target == SPARC64::target_name)
-    return elf_main<SPARC64>(argc, argv);
-  if (target == M68K::target_name)
-    return elf_main<M68K>(argc, argv);
-  if (target == SH4::target_name)
-    return elf_main<SH4>(argc, argv);
-  if (target == ALPHA::target_name)
-    return elf_main<ALPHA>(argc, argv);
-  if (target == LOONGARCH32::target_name)
-    return elf_main<LOONGARCH32>(argc, argv);
-  if (target == LOONGARCH64::target_name)
-    return elf_main<LOONGARCH64>(argc, argv);
-  unreachable();
-}
-
 template <typename E>
 int elf_main(int argc, char **argv) {
   Context<E> ctx;
@@ -688,12 +647,6 @@ int elf_main(int argc, char **argv) {
   // Copy input sections to the output file and apply relocations.
   copy_chunks(ctx);
 
-  // Some part of .gdb_index couldn't be computed until other debug
-  // sections are complete. We have complete debug sections now, so
-  // write the rest of .gdb_index.
-  if (ctx.gdb_index)
-    ctx.gdb_index->write_address_areas(ctx);
-
   // Dynamic linker works better with sorted .rela.dyn section,
   // so we sort them.
   ctx.reldyn->sort(ctx);
@@ -748,36 +701,8 @@ int elf_main(int argc, char **argv) {
   return 0;
 }
 
-#ifdef MOLD_X86_64
-
-extern template int elf_main<I386>(int, char **);
-extern template int elf_main<ARM32>(int, char **);
-extern template int elf_main<ARM64>(int, char **);
-extern template int elf_main<RV32BE>(int, char **);
-extern template int elf_main<RV32LE>(int, char **);
-extern template int elf_main<RV64LE>(int, char **);
-extern template int elf_main<RV64BE>(int, char **);
-extern template int elf_main<PPC32>(int, char **);
-extern template int elf_main<PPC64V1>(int, char **);
-extern template int elf_main<PPC64V2>(int, char **);
-extern template int elf_main<S390X>(int, char **);
-extern template int elf_main<SPARC64>(int, char **);
-extern template int elf_main<M68K>(int, char **);
-extern template int elf_main<SH4>(int, char **);
-extern template int elf_main<ALPHA>(int, char **);
-extern template int elf_main<LOONGARCH32>(int, char **);
-extern template int elf_main<LOONGARCH64>(int, char **);
-
-int main(int argc, char **argv) {
-  return elf_main<X86_64>(argc, argv);
-}
-
-#else
-
 using E = MOLD_TARGET;
 
 template int elf_main<E>(int, char **);
-
-#endif
 
 } // namespace mold::elf

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1940,6 +1940,8 @@ void read_file(Context<E> &ctx, MappedFile<Context<E>> *mf);
 template <typename E>
 int elf_main(int argc, char **argv);
 
+int redo_main(int argc, char **argv, std::string_view target);
+
 int main(int argc, char **argv);
 
 template <typename E>


### PR DESCRIPTION
Despite the extern template items Clang 14 seems to insist on instantiating elf_main(), with the hilarious consequence of the function being duplicated quadratically to the number of archs.

Move this to a different CU so that the compiler cannot possibly instantiate it more than once. This significantly speeds up compilation related to main.cc.