### PR TITLE
Fix `aarch64_variant-pcs.sh` test on Linux

### DIFF
--- a/test/elf/aarch64_variant-pcs.sh
+++ b/test/elf/aarch64_variant-pcs.sh
@@ -12,7 +12,7 @@ foo:
 EOF
 
 $CC -B. -shared -o $t/b.so $t/a.o
-readelf -W --dyn-syms $t/b.so | grep -Eq '\[VARIANT_PCS\].* foo$'
+readelf -W --dyn-syms $t/b.so | grep foo | grep -q '[VARIANT_PCS]'
 
 cat <<EOF | $CC -c -o $t/c.o -xc -
 void foo();


### PR DESCRIPTION
The test expects the output format given by `llvm-readelf`:
```
5: 0000000000010698     0 FUNC    GLOBAL DEFAULT [VARIANT_PCS]   13 foo
```

However, in GNU's `readelf` implementation the symbol name comes first:
```
5: 0000000000010698     0 FUNC    GLOBAL DEFAULT   13 foo  [VARIANT_PCS]
```

Replace the regular expression with two `grep` calls piped together to support both output formats.