### PR TITLE
Add `--trace-symbol` to the help message

### DIFF
--- a/docs/mold.1
+++ b/docs/mold.1
@@ -366,6 +366,9 @@ Set target system root directory to \fIdir\fR\.
 \fB\-\-trace\fR
 Print name of each input file\.
 .TP
+\fB\-y\fR \fIsymbol\fR, \fB\-\-trace\fR=\fIsymbol\fR
+Trace references to \fIsymbols\fR.
+.TP
 \fB\-\-undefined\-version\fR, \fB\-\-no\-undefined\-version\fR
 By default, \fBmold\fR warns on a symbol specified by a version script or by \fB\-\-export\-dynamic\-symbol\fR if it is not defined\. You can silence the warning by \fB\-\-undefined\-version\fR\.
 .TP

--- a/docs/mold.md
+++ b/docs/mold.md
@@ -597,6 +597,9 @@ arguments.
 * `--trace`:
   Print name of each input file.
 
+* `-y` _symbol_, `--trace-symbol`=_symbol_:
+  Trace references to symbols.
+
 * `--undefined-version`, `--no-undefined-version`:
   By default, `mold` warns on a symbol specified by a version script or by
   `--export-dynamic-symbol` if it is not defined. You can silence the warning

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -150,6 +150,8 @@ Options:
   --threads                   Use multiple threads (default)
     --no-threads
   --trace                     Print name of each input file
+  -y SYMBOL, --trace-symbol SYMBOL
+                              Trace references to symbols
   --undefined-version         Do not report version scripts that refer undefined symbols
     --no-undefined-version    Report version scripts that refer undefined symbols (default)
   --unique PATTERN            Don't merge input sections that match a given pattern


### PR DESCRIPTION
Noticed that this command line option was missing from the help message.