### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ may be able to remove the `linker = "clang"` line.
 
 ```toml
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=/path/to/mold"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 ```
 
 If you want to use mold for all projects, add the above snippet to


### PR DESCRIPTION
GCC doesn't accept a path as an argument to `-fuse-ld`. It errors out by
```
cc: error: unrecognized command-line option '-fuse-ld=/usr/bin/mold'
```

Passing `-fuse-ld=mold` is enough.

Tested with
```
gcc (GCC) 13.2.1 20231205 (Red Hat 13.2.1-6)
```