### PR TITLE
Ignore addrsig sections corrupted by strip

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -356,7 +356,12 @@ void ObjectFile<E>::initialize_sections(Context<E> &ctx) {
 
       // Save .llvm_addrsig for --icf=safe.
       if (shdr.sh_type == SHT_LLVM_ADDRSIG && !ctx.arg.relocatable) {
-        llvm_addrsig = std::move(this->sections[i]);
+        if (shdr.sh_link != 0) {
+          llvm_addrsig = std::move(this->sections[i]);
+        } else {
+          Warn(ctx) << *this << ": Ignoring .llvm_addrsig section without SH_LINK; " <<
+              "was the file processed by strip or objcopy -r?";
+        }
         continue;
       }
 


### PR DESCRIPTION
When removing symbols, the indices in .llvm_addrsig also needs to be updated, but binutils is not aware of this and leaves the table in a corrupt state.

Use the same test as what LLD uses to reject potentially corrupted addrsig sections.

Unfortunately, testing this seems tricky. While producing a file with OOB addrsig index is not hard, it's hard to consistently trigger a segfault with that access.

Signed-off-by: Tatsuyuki Ishi <ishitatsuyuki@gmail.com>

Closes #1174 