### PR TITLE
illumos: Treat absolute symbols specially

### DIFF
--- a/third-party/mimalloc/src/prim/unix/prim.c
+++ b/third-party/mimalloc/src/prim/unix/prim.c
@@ -311,7 +311,7 @@ static void* unix_mmap(void* addr, size_t size, size_t try_alignment, int protec
       #elif defined(__sun)
       if (allow_large && _mi_os_use_large_page(size, try_alignment)) {
         struct memcntl_mha cmd = {0};
-        cmd.mha_pagesize = large_os_page_size;
+        cmd.mha_pagesize = _mi_os_large_page_size();
         cmd.mha_cmd = MHA_MAPSIZE_VA;
         if (memcntl((caddr_t)p, size, MC_HAT_ADVISE, (caddr_t)&cmd, 0, 0) == 0) {
           *is_large = true;


### PR DESCRIPTION
illumos is a descendent of Solaris/OpenSolaris, and treats symbols with shndx=SHN_ABS and st_value=0 specially, such that they should be marked imported.  This change adds a special case for this behavior, wrapped up in a function that #ifdef's out on other platforms.  With this patch, executables linked with mold on illumos run; without it, they do not.

The original behavior was spotted by Luqman Aden (@luqmana). This also patches a small bogon in the third-party `mimalloc` code.  I've sent that same fix upstream, but so far the maintainer has not resonded, so replicate here.

Fixes #1183