### PR TITLE
Feat: use accumulate address on sections with SHT_NOBITS

### DIFF
--- a/elf/passes.cc
+++ b/elf/passes.cc
@@ -2457,6 +2457,8 @@ static i64 set_file_offsets(Context<E> &ctx) {
     }
 
     if (first.shdr.sh_type == SHT_NOBITS) {
+      fileoff = align_to(fileoff, first.shdr.sh_addralign);
+      first.shdr.sh_offset = fileoff;
       i++;
       continue;
     }
@@ -2497,8 +2499,11 @@ static i64 set_file_offsets(Context<E> &ctx) {
 
     while (i < chunks.size() &&
            (chunks[i]->shdr.sh_flags & SHF_ALLOC) &&
-           chunks[i]->shdr.sh_type == SHT_NOBITS)
+           chunks[i]->shdr.sh_type == SHT_NOBITS) {
+      fileoff = align_to(fileoff, chunks[i]->shdr.sh_addralign);
+      chunks[i]->shdr.sh_offset = fileoff;
       i++;
+	}
   }
 
   return fileoff;


### PR DESCRIPTION
I fix the bug in #456.

The reason is caused by the offset of sections with SHT_NOBITS. 

As the following picture shows:

The left side is the output of mold and the right side is the output of lld. We can see that file offset of the sections with SHT_NOTIBS is all zero in mold. This cause   the sections enter this [`function`](https://github.com/freebsd/freebsd-src/blob/main/contrib/elftoolchain/elfcopy/segments.c#L54) in FreeBSD strip returned ``unloaded=0`` thus discard in the segment as the second picture shows.

![20240203_22h23m53s_grim](https://github.com/rui314/mold/assets/16476727/cd2ea3c7-dff5-4035-8294-a98b326761ac)

This pictures .bss is discarded in left side.

![20240203_22h28m32s_grim](https://github.com/rui314/mold/assets/16476727/850529f7-594e-4002-ae23-a7846bdeb927)

