### PR TITLE
Minor fixes for the Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,9 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
 
   # ccache needs this flag along with `sloppiness = pch_defines,time_macros`
   # to enable caching
-  target_compile_options(mold PRIVATE -fpch-preprocess)
+  if(NOT MSVC)
+    target_compile_options(mold PRIVATE -fpch-preprocess)
+  endif()
 endif()
 
 include(CTest)

--- a/common/main.cc
+++ b/common/main.cc
@@ -20,6 +20,11 @@
 # include <unistd.h>
 #endif
 
+#ifdef _WIN32
+# define unlink _unlink
+# define write _write
+#endif
+
 namespace mold {
 
 std::string mold_version_string = MOLD_VERSION;

--- a/common/perf.cc
+++ b/common/perf.cc
@@ -38,7 +38,7 @@ static i64 now_nsec() {
 static std::pair<i64, i64> get_usage() {
 #ifdef _WIN32
   auto to_nsec = [](FILETIME t) -> i64 {
-    return ((u64)t.dwHighDateTime << 32 + (u64)t.dwLowDateTime) * 100;
+    return (((u64)t.dwHighDateTime << 32) + (u64)t.dwLowDateTime) * 100;
   };
 
   FILETIME creation, exit, kernel, user;

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -9,7 +9,7 @@
 #include <unordered_set>
 
 #ifdef _WIN32
-# define _isatty isatty
+# define isatty _isatty
 # define STDERR_FILENO (_fileno(stderr))
 #else
 # include <unistd.h>

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -17,7 +17,7 @@
 
 #ifdef _WIN32
 # include <direct.h>
-# define _chdir chdir
+# define chdir _chdir
 #else
 # include <unistd.h>
 #endif


### PR DESCRIPTION
Removes some Windows build warnings.

Fixes conversion of Windows FILETIME to nsec in get_usage() used by
TimerRecord.