### PR TITLE
Do not try to run executables created with --section-order

### DIFF
--- a/test/elf/section-order.sh
+++ b/test/elf/section-order.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
-# qemu crashes if the ELF header is not mapped to memory
-[ -z "$QEMU" ] || skip
-
 cat <<EOF | $CC -o $t/a.o -c -xc -fno-PIC $flags -
 #include <stdio.h>
 
@@ -17,7 +14,6 @@ EOF
 
 $CC -B. -o $t/exe1 $t/a.o -no-pie \
   -Wl,--section-order='=0x100000 PHDR =0x200000 .fn2 TEXT =0x300000 .fn1 DATA BSS RODATA'
-$QEMU $t/exe1 | grep -q Hello
 
 readelf -SW $t/exe1 | grep -q '\.fn2 .*00200000'
 readelf -SW $t/exe1 | grep -q '\.fn1 .*00300000'


### PR DESCRIPTION
Executables with an unmapped ELF header crash when run in qemu.

Signed-off-by: Andreas Schwab <schwab@suse.de>