### PR TITLE
Added a linker flag to favor static libraries over dynamic ones.

### DIFF
--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -55,6 +55,7 @@ Options:
                               Trace references to SYMBOL
   --Bdynamic, --dy            Link against shared libraries (default)
   --Bstatic, --dn, --static   Do not link against shared libraries
+  --Bstatic_preferred         Link against static if available, and shared otherwise
   --Bsymbolic                 Bind global symbols locally
   --Bsymbolic-functions       Bind global functions locally
   --Bno-symbolic              Cancel --Bsymbolic and --Bsymbolic-functions
@@ -696,9 +697,14 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.print_map = true;
     } else if (read_flag("Bstatic") || read_flag("dn") || read_flag("static")) {
       ctx.arg.is_static = true;
+      ctx.arg.is_static_preferred = false;
       remaining.push_back("--Bstatic");
+    } else if (read_flag("Bstatic_preferred")) {
+      ctx.arg.is_static_preferred = true;
+      remaining.push_back("--Bstatic_preferred");
     } else if (read_flag("Bdynamic") || read_flag("dy")) {
       ctx.arg.is_static = false;
+      ctx.arg.is_static_preferred = false;
       remaining.push_back("--Bdynamic");
     } else if (read_flag("shared") || read_flag("Bshareable")) {
       ctx.arg.shared = true;

--- a/elf/cmdline.cc
+++ b/elf/cmdline.cc
@@ -55,7 +55,7 @@ Options:
                               Trace references to SYMBOL
   --Bdynamic, --dy            Link against shared libraries (default)
   --Bstatic, --dn, --static   Do not link against shared libraries
-  --Bstatic_preferred         Link against static if available, and shared otherwise
+  --Bstatic-preferred         Link against static if available, and shared otherwise
   --Bsymbolic                 Bind global symbols locally
   --Bsymbolic-functions       Bind global functions locally
   --Bno-symbolic              Cancel --Bsymbolic and --Bsymbolic-functions
@@ -699,9 +699,9 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.is_static = true;
       ctx.arg.is_static_preferred = false;
       remaining.push_back("--Bstatic");
-    } else if (read_flag("Bstatic_preferred")) {
+    } else if (read_flag("Bstatic-preferred")) {
       ctx.arg.is_static_preferred = true;
-      remaining.push_back("--Bstatic_preferred");
+      remaining.push_back("--Bstatic-preferred");
     } else if (read_flag("Bdynamic") || read_flag("dy")) {
       ctx.arg.is_static = false;
       ctx.arg.is_static_preferred = false;

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -310,7 +310,7 @@ static void read_input_files(Context<E> &ctx, std::span<std::string> args) {
     } else if (arg == "--Bstatic") {
       ctx.is_static = true;
       ctx.arg.is_static_preferred = false;
-    } else if (arg == "--Bstatic_preferred") {
+    } else if (arg == "--Bstatic-preferred") {
       ctx.arg.is_static_preferred = true;
     } else if (arg == "--Bdynamic") {
       ctx.is_static = false;

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -1674,6 +1674,7 @@ struct Context {
     bool icf_all = false;
     bool ignore_data_address_equality = false;
     bool is_static = false;
+    bool is_static_preferred = false;
     bool lto_pass2 = false;
     bool nmagic = false;
     bool noinhibit_exec = false;
@@ -1772,6 +1773,7 @@ struct Context {
   bool as_needed = false;
   bool whole_archive = false;
   bool is_static;
+  bool is_static_preferred;
   bool in_lib = false;
   i64 file_priority = 10000;
   MappedFile *script_file = nullptr;


### PR DESCRIPTION
Hi there!

(For my usage) This addition is primarily to support the generation of AppImages.  For an AppImage, it's better to statically link and optimize as much of the executable as possible, but not every library the executable depends upon is available as an archive (.a) file.

The change adds a flag tentatively called ```--Bstatic_preferred``` which reverses the standard behavior when searching for libraries.  When the flag is set, the ```main.cc::find_library()``` function looks for .a files first, but will return a .so if no .a is found.

* This behavior is opposite from the default which searches for .so files first, but returns .a if no .so is found.
* This behavior is different from the ```--Bstatic``` flag that ignores all .so and declares an error if the expected .a is not found.

For testing I linked my local application, and also mold itself and checked results using the dependency listing from ldd.
For initial testing I added debug to be sure that command line variables resulted in the expected library types being returned from ```main.cc::find_library()```.  This pull request version has the test debug removed.
* ```--Bstatic```  result: mold ignores .so files
* ```--Bstatic_preferred```  result: mold looks for .a then .so in each folder
* ```no argument```  result: mold looks for .so then .a in each folder