### PR TITLE
RISCV: Filter out existing __global_pointer$ when resolving symbols

### DIFF
--- a/elf/input-files.cc
+++ b/elf/input-files.cc
@@ -1434,6 +1434,9 @@ template <typename E>
 void SharedFile<E>::resolve_symbols(Context<E> &ctx) {
   for (i64 i = 0; i < this->symbols.size(); i++) {
     Symbol<E> &sym = *this->symbols[i];
+    if constexpr (is_riscv<E>)
+      if (sym.name() == "__global_pointer$")
+        continue;
     const ElfSym<E> &esym = this->elf_syms[i];
     if (esym.is_undef())
       continue;


### PR DESCRIPTION
To conform to the psABI specification, the `__global_pointer$` symbol became exported in commit 3df7c8e8 if the object file is executable.

A shared object can also be executable, and the `__global_pointer$` symbol may be exported. When linking with such a shared object, mold will segfault due to the duplicate symbols from real file and `<internal>` file. I ran into this issue when linking DynamoRIO RV64.

This PR filters out the existing `__global_pointer$` in the object file when resolving symbols to avoid this issue. But if this is not a proper way to solve the issue, please feel free to consider this a bug report.