### PR TITLE
test: use `command -v`, not non-portable `which`

### DIFF
--- a/test/elf/exception-multiple-ehframe.sh
+++ b/test/elf/exception-multiple-ehframe.sh
@@ -3,7 +3,7 @@
 
 nm mold | grep -q '__tsan_init' && skip
 
-which perl > /dev/null || skip
+command -v perl > /dev/null || skip
 
 [ $MACHINE = m68k ] && skip
 [ $MACHINE = sh4 ] && skip


### PR DESCRIPTION
`which` isn't in POSIX and several Linux distributions are trying to remove it from their base system, see e.g. https://lwn.net/Articles/874049/.

Just use `command -v` which is POSIX.