### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/common/filepath.cc
+++ b/common/filepath.cc
@@ -7,6 +7,10 @@
 # include <mach-o/dyld.h>
 #endif
 
+#ifdef __FreeBSD__
+# include <sys/sysctl.h>
+#endif
+
 namespace mold {
 
 std::string get_realpath(std::string_view path) {


### PR DESCRIPTION
It's broken on FreeBSD `14.0-RELEASE`:

    FAILED: CMakeFiles/mold.dir/common/filepath.cc.o 
    /usr/bin/c++ -DTBB_USE_DEBUG -DUSE_SYSTEM_MIMALLOC -Imold-2.31.0/third-party/blake3/c -I.build -pipe -g -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing -isystem /usr/local/include -pipe -g -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing -isystem /usr/local/include -std=gnu++20 -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -Wall -Wextra -Wno-sign-compare -Wno-unused-function -Wno-unused-parameter -Wno-missing-field-initializers -ggnu-pubnames -D_GLIBCXX_ASSERTIONS -pthread -fpch-preprocess -MD -MT CMakeFiles/mold.dir/common/filepath.cc.o -MF CMakeFiles/mold.dir/common/filepath.cc.o.d -o CMakeFiles/mold.dir/common/filepath.cc.o -c mold-2.31.0/common/filepath.cc
    mold-2.31.0/common/filepath.cc:47:12: error: use of undeclared identifier 'CTL_KERN'
      mib[0] = CTL_KERN;
               ^
    mold-2.31.0/common/filepath.cc:48:12: error: use of undeclared identifier 'KERN_PROC'
      mib[1] = KERN_PROC;
               ^
    mold-2.31.0/common/filepath.cc:49:12: error: use of undeclared identifier 'KERN_PROC_PATHNAME'
      mib[2] = KERN_PROC_PATHNAME;
               ^
    mold-2.31.0/common/filepath.cc:53:3: error: use of undeclared identifier 'sysctl'
      sysctl(mib, 4, NULL, &size, NULL, 0);
      ^
    mold-2.31.0/common/filepath.cc:57:3: error: use of undeclared identifier 'sysctl'
      sysctl(mib, 4, path.data(), &size, NULL, 0);
      ^
    5 errors generated.
