### PR TITLE
Fix corrupted .riscv.attributes ISA string

### DIFF
--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -1250,7 +1250,7 @@ static bool extn_version_less(const Extn &e1, const Extn &e2) {
 
 static std::optional<Extn> read_extn_string(std::string_view &str) {
   auto flags = std::regex_constants::optimize | std::regex_constants::ECMAScript;
-  static std::regex re(R"(^([a-z0-9]+)(\d+)p(\d+))", flags);
+  static std::regex re(R"(^([a-z][a-z0-9]*)(\d+)p(\d+))", flags);
 
   std::cmatch m;
   if (std::regex_search(str.data(), str.data() + str.size(), m, re)) {

--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -1261,21 +1261,14 @@ static std::optional<Extn> read_extn_string(std::string_view &str) {
 }
 
 static std::vector<Extn> parse_arch_string(std::string_view str) {
-  if (str.size() < 5)
-    return {};
-
-  // Parse the base part
-  std::string_view base = str.substr(0, 5);
-  if (base != "rv32i" && base != "rv32e" && base != "rv64i" && base != "rv64e")
-    return {};
-  str = str.substr(4);
-
   std::optional<Extn> extn = read_extn_string(str);
   if (!extn)
     return {};
+  auto &base = extn->name;
+  if (base != "rv32i" && base != "rv32e" && base != "rv64i" && base != "rv64e")
+    return {};
 
   std::vector<Extn> vec;
-  extn->name = base;
   vec.push_back(*extn);
 
   // Parse extensions

--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -1250,7 +1250,7 @@ static bool extn_version_less(const Extn &e1, const Extn &e2) {
 
 static std::optional<Extn> read_extn_string(std::string_view &str) {
   auto flags = std::regex_constants::optimize | std::regex_constants::ECMAScript;
-  static std::regex re(R"(^([a-z][a-z0-9]*)(\d+)p(\d+))", flags);
+  static std::regex re(R"(^([a-z]|[a-z][a-z0-9]*[a-z])(\d+)p(\d+))", flags);
 
   std::cmatch m;
   if (std::regex_search(str.data(), str.data() + str.size(), m, re)) {

--- a/elf/arch-riscv.cc
+++ b/elf/arch-riscv.cc
@@ -1250,7 +1250,7 @@ static bool extn_version_less(const Extn &e1, const Extn &e2) {
 
 static std::optional<Extn> read_extn_string(std::string_view &str) {
   auto flags = std::regex_constants::optimize | std::regex_constants::ECMAScript;
-  static std::regex re(R"(^([a-z]+)(\d+)p(\d+))", flags);
+  static std::regex re(R"(^([a-z0-9]+)(\d+)p(\d+))", flags);
 
   std::cmatch m;
   if (std::regex_search(str.data(), str.data() + str.size(), m, re)) {


### PR DESCRIPTION
extension name can contain digits

Fix #1275 