### PR TITLE
Use $CXX to detect cxxflags

### DIFF
--- a/test/elf/common.inc
+++ b/test/elf/common.inc
@@ -69,6 +69,10 @@ test_cflags() {
   echo 'int main() {}' | $CC "$@" -o /dev/null -xc - >& /dev/null
 }
 
+test_cxxflags() {
+  echo 'int main() {}' | $CXX "$@" -o /dev/null -xc++ - >& /dev/null
+}
+
 is_musl() {
   ldd --version 2>&1 | grep -q musl
 }

--- a/test/elf/exception.sh
+++ b/test/elf/exception.sh
@@ -5,7 +5,7 @@
 [ $MACHINE = sh4 ] && skip
 
 static=
-test_cflags -static && static=-static
+test_cxxflags -static && static=-static
 
 # I don't know why, but we need -pthread on m68k
 static="$static -pthread"

--- a/test/elf/x86_64_exception-mcmodel-large.sh
+++ b/test/elf/x86_64_exception-mcmodel-large.sh
@@ -15,7 +15,7 @@ EOF
 $CXX -B. -o $t/exe $t/a.o -mcmodel=large
 $QEMU $t/exe
 
-if echo 'int main() {}' | $CC -o /dev/null -xc - -static >& /dev/null; then
+if test_cxxflags -static; then
   $CXX -B. -o $t/exe $t/a.o -static -mcmodel=large
   $QEMU $t/exe
 fi


### PR DESCRIPTION
Use $CXX instead of $CC to detect whether C++ programs could be built statically. Add function test_cxxflags for convenience.

Fix test error in an environment where C++ programs cannot be built statically, with error like:

  mold: fatal: library not found: c++