### PR TITLE
Add --encoded-package-metadata

### DIFF
--- a/test/elf/package-metadata.sh
+++ b/test/elf/package-metadata.sh
@@ -10,3 +10,6 @@ EOF
 
 $CC -B. -o $t/exe $t/a.o -Wl,-package-metadata='{"foo":"bar"}'
 readelf -x .note.package $t/exe | grep -Fq '{"foo":"bar"}'
+
+$CC -B. -o $t/exe2 $t/a.o -Wl,--encoded-package-metadata=%7B%22foo%22%3A%22bar%22%7D
+readelf -x .note.package $t/exe2 | grep -Fq '{"foo":"bar"}'


### PR DESCRIPTION
Specifying the compiler flag `-Wl,--package-metadata=<JSON>` might not work, because the shells might eat the quotation marks and the compiler splits the JSON at the commas.

Ubuntu tried to using a specs file to set `--package-metadata` but that turned out to be too fragile. autopkgtests might use the compiler flags but the needed environment variables are not set in the test environment. Debugging a crash of an application build with the -spec parameter lacks the environment variables. People like to iteratively continue building the software in the build directory while hacking on the package and then have no environment variable set.

So introduce a `--encoded-package-metadata` linker flag that takes a percent-encoded JSON. Percent-encoding is used because it is a standard and simple to implement.

Bug-Ubutru: https://bugs.launchpad.net/bugs/2071468