### PR TITLE
[LoongArch] adjust the range of R_LARCH_B26 relocation

### DIFF
--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -305,7 +305,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       break;
     case R_LARCH_B26: {
       i64 val = S + A - P;
-      if (val < -(1 << 27) || (1 << 27) <= val)
+      if (val < (i32)0xf8000000 || val > (i32)0x07fffffc)
         val = get_thunk_addr(i) + A - P;
       write_d10k16(loc, val >> 2);
       break;


### PR DESCRIPTION
Hi, Rui.
Thanks for enhancing R_LARCH_B26 relocation of Loongarch.
The immediate number field of the bl/b instruction occupies 26 bits, and the jump target value is the immediate number followed by two bit 0s, so I think the range of value-pc should be (0xf8000000~0x07fffffc).