### PR TITLE
[LoongArch] support relaxation of pcalau12i/addi.d->pcaddi.d and alignment

### DIFF
--- a/elf/input-sections.cc
+++ b/elf/input-sections.cc
@@ -456,6 +456,8 @@ void InputSection<E>::write_to(Context<E> &ctx, u8 *buf) {
   // Copy data
   if constexpr (is_riscv<E>)
     copy_contents_riscv(ctx, buf);
+  else if constexpr (is_loongarch<E>)
+    copy_contents_loongarch(ctx, buf);
   else
     copy_contents(ctx, buf);
 

--- a/elf/main.cc
+++ b/elf/main.cc
@@ -621,6 +621,9 @@ int elf_main(int argc, char **argv) {
   if constexpr (is_riscv<E>)
     filesize = riscv_resize_sections(ctx);
 
+  if constexpr (is_loongarch<E>)
+    filesize = loongarch_resize_sections(ctx);
+
   // At this point, memory layout is fixed.
 
   // Set actual addresses to linker-synthesized symbols.

--- a/elf/mold.h
+++ b/elf/mold.h
@@ -232,13 +232,20 @@ struct FdeRecord {
 template <typename E>
 struct InputSectionExtras {};
 
-template <needs_thunk E>
+template <typename E> requires (!is_loongarch<E>) && needs_thunk<E>
 struct InputSectionExtras<E> {
   std::vector<ThunkRef> thunk_refs;
 };
 
 template <is_riscv E>
 struct InputSectionExtras<E> {
+  std::vector<i32> r_deltas;
+};
+
+template <is_loongarch E>
+struct InputSectionExtras<E> {
+  std::vector<ThunkRef> thunk_refs;
+  // The number of removed bytes before each reloc after relaxation
   std::vector<i32> r_deltas;
 };
 
@@ -325,6 +332,8 @@ private:
                      u8 *loc, u64 S, i64 A, u64 P, ElfRel<E> **dynrel);
 
   void copy_contents_riscv(Context<E> &ctx, u8 *buf);
+
+  void copy_contents_loongarch(Context<E> &ctx, u8 *buf);
 
   u64 get_thunk_addr(i64 idx);
 
@@ -1633,6 +1642,12 @@ private:
   std::vector<Entry> entries;
   std::mutex mu;
 };
+
+//
+// arch-loongarch.cc
+//
+template <is_loongarch E>
+i64 loongarch_resize_sections(Context<E> &ctx);
 
 //
 // main.cc


### PR DESCRIPTION
Support relaxation on LoongArch.

Now just a few case of relaxation has been added to see if these works finely: 1) pcalau12i/addi.d->pcaddi.d, 2)alignment. If we do not apply any other relaxation except alignment, then alignment relaxation may not be applied nither.