### PR TITLE
[LoongArch] Support relax of pcalau12i/addi.d->pcaddi

### DIFF
--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -336,6 +336,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       write_k12(loc, (S + A) >> 52);
       break;
     case R_LARCH_PCALA_LO12:
+      if (removed_bytes == 4)
+        break;
       // It looks like R_LARCH_PCALA_LO12 is sometimes used for JIRL even
       // though the instruction takes a 16 bit immediate rather than 12 bits.
       // It is contrary to the psABI document, but GNU ld has special
@@ -346,7 +348,18 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
         write_k12(loc, S + A);
       break;
     case R_LARCH_PCALA_HI20:
-      write_j20(loc, hi20(S + A, P));
+      if (i + 4 <= rels.size()
+          && rels[i+2].r_type == R_LARCH_PCALA_LO12
+          && rels[i+1].r_type == R_LARCH_RELAX
+          && rels[i+3].r_type == R_LARCH_RELAX
+          && get_r_delta(i+3) - get_r_delta(i+2) == 4) {
+        // relax pcalau12i/addi.d to pcaddi
+        i64 rd = bits(*(ul32 *)(contents.data() + rel.r_offset), 4, 0);
+        *(ul32 *)loc = rd | 0x18000000;
+        write_j20(loc, (S + A - P) >> 2);
+      } else {
+        write_j20(loc, hi20(S + A, P));
+      }
       break;
     case R_LARCH_PCALA64_LO20:
       write_j20(loc, higher20(S + A, P));
@@ -754,6 +767,33 @@ void shrink_section(Context<E> &ctx, InputSection<E> &isec, bool use_rvc) {
       if (i64 val = sym.get_addr(ctx) + r.r_addend - ctx.tp_addr;
           sign_extend(val, 11) == val)
         delta += 4;
+      break;
+    case R_LARCH_PCALA_HI20:
+      if ((i+4) > rels.size())
+        continue;
+
+      ul32 pcala = *(ul32 *)(isec.contents.data() + rels[i].r_offset);
+      ul32 addi = *(ul32 *)(isec.contents.data() + rels[i+2].r_offset);
+
+      i64 rd = pcala & 0x1f;
+      const ul32 addi_d = 0x02c00000;
+      const u64 loc = isec.get_addr() + r.r_offset - delta;
+
+      u64 symval = sym.get_addr(ctx) + r.r_addend;
+      /* Is pcalau12i + addi.d insns?  */
+      if (rels[i+2].r_type != R_LARCH_PCALA_LO12
+          || rels[i+3].r_type != R_LARCH_RELAX
+          || (addi & addi_d) != addi_d
+          /* Is pcalau12i $rd + addi.d $rd,$rd?  */
+          || (addi & 0x1f) != rd
+          || symval & 0x3 /* 4 bytes align */
+          || (i64)(symval - loc) < (i64)(i32)0xffe00000
+          || (i64)(symval - loc) > (i64)(i32)0x1ffffc)
+        continue;
+
+      isec.extra.r_deltas[i+1] = isec.extra.r_deltas[i+2] = delta;
+      delta += 4;
+      i += 2;
       break;
     }
   }


### PR DESCRIPTION
Similar to riscv, doing relaxation on LoongArch for some instruction pairs can reduce the number of instructions, a few cases have been supported now.