### PR TITLE
LoongArch: support relaxation of pcalau12i/ld.d to pcalau12i/addi.d or pcaddi

### DIFF
--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -377,11 +377,12 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
           // loc stores 'ld.d', rewrite ld.d with pcaddi
           *(ul32 *)(loc) = 0x1800'0000 | get_rd(*(ul32 *)loc);
           write_j20(loc, (S + A - P) >> 2);
+          i += 3;
           break;
         case 0:
-          if (i + 3 < rels.size() &&
-            sym.is_pcrel_linktime_const(ctx);
-            ctx.arg.relax &&
+          if (ctx.arg.relax &&
+            sym.is_pcrel_linktime_const(ctx) &&
+            i + 3 < rels.size() &&
             rels[i + 1].r_type == R_LARCH_RELAX &&
             rels[i + 3].r_type == R_LARCH_RELAX &&
             rels[i + 2].r_type == R_LARCH_GOT_PC_LO12 &&
@@ -409,6 +410,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
         default:
           unreachable();
       }
+      break;
     case R_LARCH_GOT64_PC_LO20:
       write_j20(loc, higher20(GOT + G + A, P));
       break;
@@ -870,7 +872,7 @@ void shrink_section(Context<E> &ctx, InputSection<E> &isec, bool use_rvc) {
       //   pcalau12i $t0, 0
       //   addi.d    $t0, $t0, 0
       if (ctx.arg.relax &&
-          sym.is_pcrel_linktime_const(ctx);
+          sym.is_pcrel_linktime_const(ctx) &&
           i + 3 < rels.size() &&
           rels[i + 2].r_type == R_LARCH_GOT_PC_LO12 &&
           rels[i + 2].r_offset == rels[i].r_offset + 4 &&

--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -399,36 +399,38 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       }
       break;
     case R_LARCH_GOT_PC_HI20:
-      if (removed_bytes != 0) {
-        // The first instruction of pcalau12i/ld.d has been removed
-        assert(removed_bytes == 4);
-        break;
-      } else {
-        if (i + 3 < rels.size() &&
-          sym.is_local(ctx) &&
-          !sym.is_absolute() &&
-	  !sym.is_ifunc() &&
-          ctx.arg.relax &&
-          rels[i+1].r_type == R_LARCH_RELAX &&
-          rels[i+3].r_type == R_LARCH_RELAX &&
-          rels[i+2].r_type == R_LARCH_GOT_PC_LO12 &&
-          rels[i+2].r_offset == rel.r_offset + 4) {
-          u32 insn1 = *(ul32 *)(contents.data() + rel.r_offset);
-          u32 insn2 = *(ul32 *)(contents.data() + rels[i+2].r_offset);
-          u32 rd = get_rd(insn1);
+      switch (removed_bytes) {
+        // pcalau12i/ld.d has been relaxed to pcaddi, the first insn has been removed.
+        case 4:
+          break;
+        case 0:
+          if (i + 3 < rels.size() &&
+            sym.is_local(ctx) &&
+            !sym.is_absolute() &&
+            !sym.is_ifunc() &&
+            ctx.arg.relax &&
+            rels[i+1].r_type == R_LARCH_RELAX &&
+            rels[i+3].r_type == R_LARCH_RELAX &&
+            rels[i+2].r_type == R_LARCH_GOT_PC_LO12 &&
+            rels[i+2].r_offset == rel.r_offset + 4) {
+            u32 insn1 = *(ul32 *)(contents.data() + rel.r_offset);
+            u32 insn2 = *(ul32 *)(contents.data() + rels[i+2].r_offset);
+            u32 rd = get_rd(insn1);
 
-          if (rd == get_rd(insn2)) {
-            // pcalau12i/ld.d has been relaxed to pcalau12i/addi.d
-            // reloc the pcalau12i as R_LARCH_PLACA_HI20
-            write_j20(loc, hi20(S + A, P));
-            break;
+            if (rd == get_rd(insn2)) {
+              // pcalau12i/ld.d has been relaxed to pcalau12i/addi.d
+              // reloc the pcalau12i as R_LARCH_PLACA_HI20
+              write_j20(loc, hi20(S + A, P));
+              break;
+            }
           }
-        }
 
-        // relax not applied.
-        write_j20(loc, hi20(GOT + G + A, P));
+          // relax not applied.
+          write_j20(loc, hi20(GOT + G + A, P));
+          break;
+        default:
+          unreachable();
       }
-      break;
     case R_LARCH_GOT64_PC_LO20:
       write_j20(loc, higher20(GOT + G + A, P));
       break;

--- a/elf/arch-loongarch.cc
+++ b/elf/arch-loongarch.cc
@@ -398,6 +398,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
               // rewrite the ld.d insn with addi.d insn
               *(ul32 *)(loc + 4) = 0x02c00000 | rd | (rd << 5);
               write_k12(loc + 4, S + rels[i + 2].r_addend);
+              i += 3;
               break;
             }
           }

--- a/test/elf/loongarch64_relax-got.sh
+++ b/test/elf/loongarch64_relax-got.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
-cat <<'EOF' | $CC -g -o $t/a.o -c -xassembler -
+cat <<'EOF' | $CC -o $t/a.o -c -xassembler -
 .globl get_sym1, get_sym2, get_sym3, get_sym4, get_sym5
 get_sym1:
   la.global $a0, sym1
@@ -25,7 +25,7 @@ get_sym5:
   ret
 EOF
 
-cat <<EOF | $CC -g -o $t/b.o -c -xassembler -
+cat <<EOF | $CC -o $t/b.o -c -xassembler -
 .data
 .globl sym1, sym2, sym3, sym4, sym5
 sym1:
@@ -40,7 +40,7 @@ sym5:
   .word 0xdeadbeef
 EOF
 
-cat <<EOF | $CC -g -o $t/c.o -c -xc -
+cat <<EOF | $CC -o $t/c.o -c -xc -
 #include <stdio.h>
 
 int get_sym1();
@@ -55,10 +55,10 @@ int main() {
 }
 EOF
 
-$CC -B. -g -o $t/exe1 $t/a.o $t/b.o $t/c.o -Wl,--no-relax
+$CC -B. -o $t/exe1 $t/a.o $t/b.o $t/c.o -Wl,--no-relax
 $QEMU $t/exe1 | grep -Eq '^0 ba beef 11beef deadbeef$'
 
-$CC -B. -g -o $t/exe2 $t/a.o $t/b.o $t/c.o
+$CC -B. -o $t/exe2 $t/a.o $t/b.o $t/c.o
 $QEMU $t/exe2 | grep -Eq '^0 ba beef 11beef deadbeef$'
 
 $OBJDUMP -d $t/exe2 | grep -A2 '<get_sym2>:' | grep -Eq $'pcaddi'

--- a/test/elf/loongarch64_relax-got.sh
+++ b/test/elf/loongarch64_relax-got.sh
@@ -2,63 +2,34 @@
 . $(dirname $0)/common.inc
 
 cat <<'EOF' | $CC -o $t/a.o -c -xassembler -
-.globl get_sym1, get_sym2, get_sym3, get_sym4, get_sym5
-get_sym1:
-  la.global $a0, sym1
-  ld.w $a0, $a0, 0
-  ret
-get_sym2:
-  la.global $a0, sym2
-  ld.w $a0, $a0, 0
-  ret
-get_sym3:
-  la.global $a0, sym3
-  ld.w $a0, $a0, 0
-  ret
-get_sym4:
-  la.global $a0, sym4
-  ld.w $a0, $a0, 0
-  ret
-get_sym5:
-  la.global $a0, sym5
+.globl get_sym
+get_sym:
+  la.global $a0, sym
   ld.w $a0, $a0, 0
   ret
 EOF
 
 cat <<EOF | $CC -o $t/b.o -c -xassembler -
 .data
-.globl sym1, sym2, sym3, sym4, sym5
-sym1:
-  .word 0x0
-sym2:
-  .word 0xba
-sym3:
+.globl sym
+sym:
   .word 0xbeef
-sym4:
-  .word 0x11beef
-sym5:
-  .word 0xdeadbeef
 EOF
 
 cat <<EOF | $CC -o $t/c.o -c -xc -
 #include <stdio.h>
 
-int get_sym1();
-int get_sym2();
-int get_sym3();
-int get_sym4();
-int get_sym5();
+int get_sym();
 
 int main() {
-  printf("%x %x %x %x %x\n",
-	 get_sym1(), get_sym2(), get_sym3(), get_sym4(), get_sym5());
+  printf("%x\n", get_sym());
 }
 EOF
 
 $CC -B. -o $t/exe1 $t/a.o $t/b.o $t/c.o -Wl,--no-relax
-$QEMU $t/exe1 | grep -Eq '^0 ba beef 11beef deadbeef$'
+$QEMU $t/exe1 | grep -Eq '^beef$'
 
 $CC -B. -o $t/exe2 $t/a.o $t/b.o $t/c.o
-$QEMU $t/exe2 | grep -Eq '^0 ba beef 11beef deadbeef$'
+$QEMU $t/exe2 | grep -Eq '^beef$'
 
-$OBJDUMP -d $t/exe2 | grep -A2 '<get_sym2>:' | grep -Eq $'pcaddi'
+$OBJDUMP -d $t/exe2 | grep -A2 '<get_sym>:' | grep -Eq $'pcaddi'

--- a/test/elf/loongarch64_relax-got.sh
+++ b/test/elf/loongarch64_relax-got.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<'EOF' | $CC -g -o $t/a.o -c -xassembler -
+.globl get_sym1, get_sym2, get_sym3, get_sym4, get_sym5
+get_sym1:
+  la.global $a0, sym1
+  ld.w $a0, $a0, 0
+  ret
+get_sym2:
+  la.global $a0, sym2
+  ld.w $a0, $a0, 0
+  ret
+get_sym3:
+  la.global $a0, sym3
+  ld.w $a0, $a0, 0
+  ret
+get_sym4:
+  la.global $a0, sym4
+  ld.w $a0, $a0, 0
+  ret
+get_sym5:
+  la.global $a0, sym5
+  ld.w $a0, $a0, 0
+  ret
+EOF
+
+cat <<EOF | $CC -g -o $t/b.o -c -xassembler -
+.data
+.globl sym1, sym2, sym3, sym4, sym5
+sym1:
+  .word 0x0
+sym2:
+  .word 0xba
+sym3:
+  .word 0xbeef
+sym4:
+  .word 0x11beef
+sym5:
+  .word 0xdeadbeef
+EOF
+
+cat <<EOF | $CC -g -o $t/c.o -c -xc -
+#include <stdio.h>
+
+int get_sym1();
+int get_sym2();
+int get_sym3();
+int get_sym4();
+int get_sym5();
+
+int main() {
+  printf("%x %x %x %x %x\n",
+	 get_sym1(), get_sym2(), get_sym3(), get_sym4(), get_sym5());
+}
+EOF
+
+$CC -B. -g -o $t/exe1 $t/a.o $t/b.o $t/c.o -Wl,--no-relax
+$QEMU $t/exe1 | grep -Eq '^0 ba beef 11beef deadbeef$'
+
+$CC -B. -g -o $t/exe2 $t/a.o $t/b.o $t/c.o
+$QEMU $t/exe2 | grep -Eq '^0 ba beef 11beef deadbeef$'
+
+$OBJDUMP -d $t/exe2 | grep -A2 '<get_sym2>:' | grep -Eq $'pcaddi'


### PR DESCRIPTION
If we get symval by accessing to local got, then we can omit one memory loading.
The first phase: pcalau12i/ld.d to pcala12i/addi.d
The second phase: pcalau12i/addi.d to pcaddi