### PR TITLE
 Fix infinite loop in `split_by_comma_or_colon()`.

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -429,7 +429,7 @@ split_by_comma_or_colon(std::string_view str) {
       break;
     }
     vec.push_back(str.substr(0, pos));
-    str = str.substr(pos);
+    str = str.substr(pos + 1);
   }
   return vec;
 }

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -422,13 +422,15 @@ static std::vector<std::string_view>
 split_by_comma_or_colon(std::string_view str) {
   std::vector<std::string_view> vec;
 
-  for (;;) {
+  while (!str.empty()) {
     i64 pos = str.find_first_of(",:");
     if (pos == str.npos) {
       vec.push_back(str);
       break;
     }
-    vec.push_back(str.substr(0, pos));
+    if (pos > 0) {
+      vec.push_back(str.substr(0, pos));
+    }
     str = str.substr(pos + 1);
   }
   return vec;


### PR DESCRIPTION
The mere presence of a `,` or a `:` in the input string would make the function enter an infinite loop, effectively freezing the program until all available memory was exhausted. The string position in the loop was not incremented past the `,` or the `;` character that had just been read.

The function is currently used only in the `--exclude-libs` option. The freeze is reproducible with:

```bash
$ mold --exclude-libs foo,bar
```

The longer the string after the first `,` or `:` is, the faster memory exhaustion is reached.

Bonus: Empty parts are skipped now.