### PR TITLE
alloca.h is missing on NetBSD

### DIFF
--- a/src/mold-wrapper.c
+++ b/src/mold-wrapper.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#if !defined(__OpenBSD__) && !defined(__FreeBSD__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
 # include <alloca.h>
 #endif
 


### PR DESCRIPTION
alloca(3) is defined in stdlib.h on NetBSD

Reference: https://man.netbsd.org/alloca.3