### PR TITLE
Use readelf for compress-debug-sections verification

### DIFF
--- a/test/compress-debug-sections.sh
+++ b/test/compress-debug-sections.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
-command -v dwarfdump >& /dev/null || skip
-
 cat <<EOF | $CC -c -g -o $t/a.o -xc -
 #include <stdio.h>
 
@@ -13,6 +11,6 @@ int main() {
 EOF
 
 $CC -B. -o $t/exe $t/a.o -Wl,--compress-debug-sections=zlib
-dwarfdump $t/exe > $t/log
-grep -Fq '.debug_info SHF_COMPRESSED' $t/log
-grep -Fq '.debug_str SHF_COMPRESSED' $t/log
+readelf -tW $t/exe > $t/log
+grep -F -A2 '.debug_info' $t/log | tr '\n' ' ' | grep -qw 'COMPRESSED'
+grep -F -A2 '.debug_str' $t/log | tr '\n' ' ' | grep -qw 'COMPRESSED'


### PR DESCRIPTION
RHEL 8.7's version of dwarfdump (2018-01-29) is too old to recognize the SHF_COMPRESSED flag in debug info, so the compress-debug-sections test fails despite the debug sections being compressed as intended.

To fix this, we will use readelf to dump information about the executable. The COMPRESSED flag can be verified using this.