### PR TITLE
Add the extra statistics of relative relocations in large binaries 

### DIFF
--- a/src/arch-arm32.cc
+++ b/src/arch-arm32.cc
@@ -253,6 +253,7 @@ static bool is_jump_reachable(i64 val) {
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   auto get_tls_trampoline_addr = [&, i = 0](u64 addr) mutable {
     for (; i < output_section->thunks.size(); i++) {
@@ -273,6 +274,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -532,6 +535,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       Error(ctx) << *this << ": unknown relocation: " << rel;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-arm64.cc
+++ b/src/arch-arm64.cc
@@ -146,6 +146,7 @@ static bool is_add(u8 *loc) {
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -156,6 +157,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -434,11 +437,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -449,6 +455,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -481,6 +489,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       break;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-i386.cc
+++ b/src/arch-i386.cc
@@ -285,6 +285,7 @@ static u32 relax_tlsdesc_to_le(u8 *loc) {
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -295,6 +296,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -435,11 +438,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -450,6 +456,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -509,6 +517,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-loongarch.cc
+++ b/src/arch-loongarch.cc
@@ -265,6 +265,7 @@ void EhFrameSection<E>::apply_eh_reloc(Context<E> &ctx, const ElfRel<E> &rel,
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   auto get_r_delta = [&](i64 idx) {
     return extra.r_deltas.empty() ? 0 : extra.r_deltas[idx];
@@ -284,6 +285,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -657,6 +660,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-m68k.cc
+++ b/src/arch-m68k.cc
@@ -77,6 +77,7 @@ void EhFrameSection<E>::apply_eh_reloc(Context<E> &ctx, const ElfRel<E> &rel,
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -87,6 +88,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -207,6 +210,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-ppc64v1.cc
+++ b/src/arch-ppc64v1.cc
@@ -153,6 +153,7 @@ void EhFrameSection<E>::apply_eh_reloc(Context<E> &ctx, const ElfRel<E> &rel,
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -163,6 +164,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -279,11 +282,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -294,6 +300,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -328,6 +336,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
                  << rel;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-ppc64v2.cc
+++ b/src/arch-ppc64v2.cc
@@ -344,6 +344,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -354,6 +355,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -388,6 +391,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
                  << rel;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-riscv.cc
+++ b/src/arch-riscv.cc
@@ -208,6 +208,7 @@ static inline bool is_hi20(const ElfRel<E> &rel) {
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
   u64 GP = ctx.__global_pointer ? ctx.__global_pointer->get_addr(ctx) : 0;
 
   auto get_r_delta = [&](i64 idx) {
@@ -225,6 +226,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -620,6 +623,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-s390x.cc
+++ b/src/arch-s390x.cc
@@ -115,6 +115,7 @@ void EhFrameSection<E>::apply_eh_reloc(Context<E> &ctx, const ElfRel<E> &rel,
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -125,6 +126,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -323,11 +326,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -338,6 +344,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -372,6 +380,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       Fatal(ctx) << *this << ": apply_reloc_nonalloc: " << rel;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-sparc64.cc
+++ b/src/arch-sparc64.cc
@@ -141,6 +141,7 @@ void EhFrameSection<E>::apply_eh_reloc(Context<E> &ctx, const ElfRel<E> &rel,
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -151,6 +152,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -452,11 +455,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -467,6 +473,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -505,6 +513,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       Fatal(ctx) << *this << ": apply_reloc_nonalloc: " << rel;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 template <>

--- a/src/arch-x86-64.cc
+++ b/src/arch-x86-64.cc
@@ -367,6 +367,7 @@ static void relax_ld_to_le(u8 *loc, ElfRel<E> rel, i64 tls_size) {
 template <>
 void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -377,6 +378,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -589,6 +592,8 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       unreachable();
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 // This function is responsible for applying relocations against
@@ -606,6 +611,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
 template <>
 void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
   std::span<const ElfRel<E>> rels = get_rels(ctx);
+  RelocationsStats rels_stats;
 
   for (i64 i = 0; i < rels.size(); i++) {
     const ElfRel<E> &rel = rels[i];
@@ -616,6 +622,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
     u8 *loc = base + rel.r_offset;
 
     auto check = [&](i64 val, i64 lo, i64 hi) {
+      if (ctx.arg.stats)
+        update_relocation_stats(rels_stats, i, val, lo, hi);
       if (val < lo || hi <= val)
         Error(ctx) << *this << ": relocation " << rel << " against "
                    << sym << " out of range: " << val << " is not in ["
@@ -693,6 +701,8 @@ void InputSection<E>::apply_reloc_nonalloc(Context<E> &ctx, u8 *base) {
       break;
     }
   }
+  if (ctx.arg.stats)
+    save_relocation_stats<E>(ctx, *this, rels_stats);
 }
 
 // Linker has to create data structures in an output file to apply

--- a/src/mold.h
+++ b/src/mold.h
@@ -310,6 +310,12 @@ public:
   bool icf_eligible = false;
   bool icf_leaf = false;
 
+  // For stats recovering
+  struct {
+    Atomic<i64> relative_relocations_offset_supremum = -1;
+    Atomic<i64> relative_relocations_offset_infimum = -1;
+  } stats;
+
   [[no_unique_address]] InputSectionExtras<E> extra;
 
 private:
@@ -328,6 +334,39 @@ private:
 
   std::optional<u64> get_tombstone(Symbol<E> &sym, SectionFragment<E> *frag);
 };
+
+struct RelocationsStats {
+  i64 min_offset_lower_bound {std::numeric_limits<i64>::max()};
+  i64 min_offset_upper_bound {std::numeric_limits<i64>::max()};
+  i64 min_offset_lower_bound_rel_idx {-1};
+  i64 min_offset_upper_bound_rel_idx {-1};
+};
+
+inline void update_relocation_stats(RelocationsStats &stats, const i64 i, const i64 val, const i64 lo, const i64 hi) {
+  const auto to_lo = std::abs(lo - val);
+  const auto to_hi = std::abs(hi - val);
+  if (to_lo < stats.min_offset_lower_bound) {
+    stats.min_offset_lower_bound = to_lo;
+    stats.min_offset_lower_bound_rel_idx = i;
+  }
+  if (to_hi < stats.min_offset_upper_bound) {
+    stats.min_offset_upper_bound = to_hi;
+    stats.min_offset_upper_bound_rel_idx = i;
+  }
+}
+
+template<typename E>
+inline void save_relocation_stats(Context<E> &ctx, InputSection<E> &isec, const RelocationsStats &stats) {
+  if (stats.min_offset_lower_bound < ctx.stats.relative_relocations_offset_infimum) {
+    ctx.stats.relative_relocations_offset_infimum = stats.min_offset_lower_bound;
+    isec.stats.relative_relocations_offset_infimum = stats.min_offset_lower_bound;
+  }
+  if (stats.min_offset_upper_bound < ctx.stats.relative_relocations_offset_supremum) {
+    ctx.stats.relative_relocations_offset_supremum = stats.min_offset_upper_bound;
+    isec.stats.relative_relocations_offset_supremum = stats.min_offset_upper_bound;
+  }
+}
+
 
 //
 // tls.cc
@@ -2147,6 +2186,12 @@ struct Context {
   Symbol<E> *edata = nullptr;
   Symbol<E> *end = nullptr;
   Symbol<E> *etext = nullptr;
+
+  struct {
+    // Extra statistic for "free space" observation in output binary
+    Atomic<i64> relative_relocations_offset_infimum = std::numeric_limits<i64>::max();
+    Atomic<i64> relative_relocations_offset_supremum = std::numeric_limits<i64>::max();
+  } stats;
 
   [[no_unique_address]] ContextExtras<E> extra;
 };

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -3214,10 +3214,24 @@ void show_stats(Context<E> &ctx) {
           thunk_bytes += thunk->size();
   }
 
+  static Counter alloc_dist_to_lower_limit("rel_reloc_offset_infimum", ctx.stats.relative_relocations_offset_infimum);
+  static Counter alloc_dist_to_upper_limit("rel_reloc_offset_supremum", ctx.stats.relative_relocations_offset_supremum);
+
   Counter::print();
 
   for (std::unique_ptr<MergedSection<E>> &sec : ctx.merged_sections)
     sec->print_stats(ctx);
+
+  for (ObjectFile<E> *obj : ctx.objs) {
+    for (std::unique_ptr<InputSection<E>> &sec : obj->sections) {
+      if (!sec || !sec->is_alive)
+        continue;
+      if (ctx.stats.relative_relocations_offset_infimum == sec->stats.relative_relocations_offset_infimum)
+        Out(ctx) << "'rel_reloc_offset_infimum' is relevant for " << *sec;
+      if (ctx.stats.relative_relocations_offset_supremum == sec->stats.relative_relocations_offset_supremum)
+        Out(ctx) << "'rel_reloc_offset_supremum' is relevant for " << *sec;
+    }
+  }
 }
 
 using E = MOLD_TARGET;


### PR DESCRIPTION
## Motivation 
I am using the `mold` linker to quickly link a large monolithic application (over 20 GB with debug information). The primary challenge with my binary is the constantly growing (and sometimes uncontrolled) portion of the business logic. Furthermore, the structure of the application's dependencies is highly heterogeneous, and I lack the ability to control how they were compiled — whether with `PIE` or without, and whether with `-mcmodel=large` or not. This leads to unpredictable issues during linking; for example, certain relocations (e.g., PC-relative) cannot be resolved because sections containing business logic have become too large (e.g., R_X86_64_32S allows for offsets less than ±2GB).

Using the `-mcmodel=large` and producing only absolute relocations for all components of the binary is not feasible in my case. **Therefore, I need a method to detect the relocations nearest to overflowing.** Based on your design principles of determinism and build reproducibility, I can rely on the fact that the resulting binary structure will not change significantly from one build to another.

## Solution 
For each architecture, there are `apply_reloc_alloc` and `apply_reloc_nonalloc` methods in `InputSection` where the `check` routine verifies the relocation range depending on the relocation type. We can update the `check` routine to record the minimum distance to the upper and lower bounds of the range for the current section. After processing all relocation entries of a section, we can update the global minimums in the context. 

As a result, we will obtain two new metrics: `relative_relocations_offset_infimum` and `relative_relocations_offset_supremum`, which can be interpreted as indicators of "how much space is still available" in the large binary. Although these aren't universal indicators, they may be extremely helpful for managing large monolithic applications.

## Impact 
* The performance impact is minimal, as statistics collection is performed only when the `--stats` option is enabled.
* Memory overhead is minimized (as much as possible for this case).
* Improvements for statistics collection are integrated into the current architecture without significant modifications.
* The inclusion of new helpful metrics, which can be valuable for large applications.            