### PR TITLE
Add missing `#include "common.h"` - fixes broken `MOLD_USE_SYSTEM_MIMALLOC`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ endif()
 # be stable on 32-bit targets.
 cmake_dependent_option(
   MOLD_USE_MIMALLOC "Use mimalloc" ON
-  "CMAKE_SIZEOF_VOID_P EQUAL 8; NOT APPLE; NOT ANDROID; NOT OPENBSD" OFF)
+  "CMAKE_SIZEOF_VOID_P EQUAL 8; NOT APPLE; NOT ANDROID; NOT OPENBSD; NOT MOLD_USE_ASAN; NOT MOLD_USE_TSAN" OFF)
 
 cmake_dependent_option(
   MOLD_USE_SYSTEM_MIMALLOC "Use system or vendored mimalloc" OFF

--- a/lib/mimalloc.cc
+++ b/lib/mimalloc.cc
@@ -1,3 +1,5 @@
+#include "common.h"
+
 // Including mimalloc-new-delete.h overrides new/delete operators.
 // We need it only when we are using mimalloc as a dynamic library.
 #if MOLD_USE_SYSTEM_MIMALLOC


### PR DESCRIPTION
This allows the compiler to make sure that the implementation of `set_mimalloc_options()` matches its declaration.

More importantly, it indirectly pulls in `config.h`, where the macros `MOLD_USE_SYSTEM_MIMALLOC` and `MOLD_USE_MIMALLOC` are conditionally defined. Without these, the build configuration is ignored.