### PR TITLE
Support percent-encoded JSON in --package-metadata

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -411,28 +411,6 @@ static std::vector<u8> parse_hex_build_id(Context<E> &ctx, std::string_view arg)
   return vec;
 }
 
-template <typename E>
-static std::string
-parse_encoded_package_metadata(Context<E> &ctx, std::string_view arg) {
-  auto flags = std::regex_constants::optimize | std::regex_constants::ECMAScript;
-  static std::regex re(R"(([^%]|%[0-9a-fA-F][0-9a-fA-F])*)", flags);
-
-  if (!std::regex_match(arg.begin(), arg.end(), re))
-    Fatal(ctx) << "--encoded-package-metadata: invalid string: " << arg;
-
-  std::ostringstream out;
-  while (!arg.empty()) {
-    if (arg[0] == '%') {
-      out << (char)((from_hex(arg[1]) << 4) | from_hex(arg[2]));
-      arg = arg.substr(3);
-    } else {
-      out << arg[0];
-      arg = arg.substr(1);
-    }
-  }
-  return out.str();
-}
-
 // Decode a percent and/or %[string] encoded string.
 // Following %[string] encodings are supported:
 //
@@ -989,8 +967,6 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
     } else if (read_flag("pack-dyn-relocs=none") ||
                read_z_flag("nopack-relative-relocs")) {
       ctx.arg.pack_dyn_relocs_relr = false;
-    } else if (read_arg("encoded-package-metadata")) {
-      ctx.arg.package_metadata = parse_encoded_package_metadata(ctx, arg);
     } else if (read_arg("package-metadata")) {
       ctx.arg.package_metadata = parse_package_metadata(arg);
     } else if (read_flag("stats")) {

--- a/test/package-metadata.sh
+++ b/test/package-metadata.sh
@@ -11,8 +11,20 @@ EOF
 $CC -B. -o $t/exe1 $t/a.o -Wl,-package-metadata='{"foo":"bar"}'
 readelf -x .note.package $t/exe1 | grep -Fq '{"foo":"bar"}'
 
-$CC -B. -o $t/exe2 $t/a.o -Wl,--encoded-package-metadata=%7B%22foo%22%3A%22bar%22%7D
+$CC -B. -o $t/exe2 $t/a.o -Wl,-package-metadata=%7B%22foo%22%3A%22bar%22%7D
 readelf -x .note.package $t/exe2 | grep -Fq '{"foo":"bar"}'
 
-! $CC -B. -o $t/exe3 $t/a.o -Wl,--encoded-package-metadata=foo%x >& $t/log
+$CC -B. -o $t/exe3 $t/a.o -Wl,-package-metadata="%[lbrace]%[quot]foo%[quot]:%[quot]bar%[quot]%[rbrace]"
+readelf -x .note.package $t/exe3 | grep -Fq '{"foo":"bar"}'
+
+$CC -B. -o $t/exe4 $t/a.o -Wl,-package-metadata=%7B%22name%22:%22mold%22%2C%22ver%22%3A%22x%20%%22%7d
+readelf -p .note.package $t/exe4 | grep -Fq '{"name":"mold","ver":"x %"}'
+
+$CC -B. -o $t/exe5 $t/a.o -Wl,-package-metadata="{%[quot]name%[quot]:%[quot]mold%[quot]%[comma]%[quot]ver%[quot]:%[quot]x%[space]%%[quot]}"
+readelf -p .note.package $t/exe5 | grep -Fq '{"name":"mold","ver":"x %"}'
+
+$CC -B. -o $t/exe6 $t/a.o -Wl,--encoded-package-metadata=%7B%22foo%22%3A%22bar%22%7D
+readelf -x .note.package $t/exe6 | grep -Fq '{"foo":"bar"}'
+
+! $CC -B. -o $t/exe7 $t/a.o -Wl,--encoded-package-metadata=foo%x >& $t/log
 grep -q 'invalid string: foo%x' $t/log

--- a/test/package-metadata.sh
+++ b/test/package-metadata.sh
@@ -22,9 +22,3 @@ readelf -p .note.package $t/exe4 | grep -Fq '{"name":"mold","ver":"x %"}'
 
 $CC -B. -o $t/exe5 $t/a.o -Wl,-package-metadata="{%[quot]name%[quot]:%[quot]mold%[quot]%[comma]%[quot]ver%[quot]:%[quot]x%[space]%%[quot]}"
 readelf -p .note.package $t/exe5 | grep -Fq '{"name":"mold","ver":"x %"}'
-
-$CC -B. -o $t/exe6 $t/a.o -Wl,--encoded-package-metadata=%7B%22foo%22%3A%22bar%22%7D
-readelf -x .note.package $t/exe6 | grep -Fq '{"foo":"bar"}'
-
-! $CC -B. -o $t/exe7 $t/a.o -Wl,--encoded-package-metadata=foo%x >& $t/log
-grep -q 'invalid string: foo%x' $t/log


### PR DESCRIPTION
Support for percent-encoded JSON in --package-metadata landed in the ld linker:
https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=b0cc81e87087bb8a6b12dc1e4fd7f2591927977b
So here comes the the pull request to implement the same in mold. The implementation has changed a lot since https://github.com/rui314/mold/pull/1308.

Specifying the compiler flag `-Wl,--package-metadata=<JSON>` will not work in case the JSON contains a comma, because compiler drivers eat commas. Example:

```
$ echo "void main() { }" > test.c
$ gcc -fuse-ld=mold '-Wl,--package-metadata={"type":"deb","os":"ubuntu"}' test.c
mold: fatal: cannot open "os":"ubuntu"}: No such file or directory
collect2: error: ld returned 1 exit status
```

The quotation marks in the JSON value do not work well with shell nor make. Specifying the `--package-metadata` linker flag in a `LDFLAGS` environment variable might loose its quotation marks when it hits the final compiler call.

So support percent-encoded and %[string] encoded JSON data in the `--package-metadata` linker flag. Percent-encoding is used because it is a standard, simple to implement, and does take too many additional characters. %[string] encoding is supported for having a more readable encoding.

Bug-binutils: https://sourceware.org/bugzilla/show_bug.cgi?id=32003
Bug-Ubutru: https://bugs.launchpad.net/bugs/2071468