### PR TITLE
ci: run ctest with --output-on-failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 ${{ matrix.target }} ..
         cmake --build . -j$(nproc)
-    - run: cd build; ctest -j$(nproc)
+    - run: cd build; ctest --output-on-failure -j$(nproc)
     - name: archive test results
       uses: actions/upload-artifact@v3
       if: failure()
@@ -52,7 +52,7 @@ jobs:
         cd build
         cmake ..
         cmake --build . -j$(nproc)
-    - run: cd build; ctest -j$(nproc)
+    - run: cd build; ctest --output-on-failure -j$(nproc)
     - name: archive test results
       uses: actions/upload-artifact@v3
       if: failure()
@@ -83,7 +83,7 @@ jobs:
         cd build
         cmake ..
         cmake --build . -j$(nproc)
-    - run: cd build; ctest -j$(nproc)
+    - run: cd build; ctest --output-on-failure -j$(nproc)
 
   build-macos:
     runs-on: macos-latest
@@ -139,4 +139,4 @@ jobs:
           cd build
           cmake ..
           cmake --build . -j$(nproc)
-          ctest -j$(nproc)
+          ctest --output-on-failure -j$(nproc)

--- a/dist.sh
+++ b/dist.sh
@@ -195,7 +195,7 @@ cmake --build . -j\$(nproc)
 cmake --install .
 cmake -DMOLD_USE_MOLD=1 .
 cmake --build . -j\$(nproc)
-ctest -j\$(nproc)
+ctest --output-on-failure -j\$(nproc)
 cmake --install . --prefix $dest --strip
 find $dest -print | xargs touch --no-dereference --date='$timestamp'
 find $dest -print | sort | tar -cf - --no-recursion --files-from=- | gzip -9nc > /mold/$dest.tar.gz


### PR DESCRIPTION
In case ctest fails in the CI, no error logs are printed. This makes debugging harder.

So run ctest with `--output-on-failure` to ease debugging in case of failures.