### PR TITLE
Clean up `#include` statements

### DIFF
--- a/lib/jobs-unix.cc
+++ b/lib/jobs-unix.cc
@@ -11,9 +11,9 @@
 
 #include "common.h"
 
+#include <cstdlib>
 #include <fcntl.h>
 #include <pwd.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/lib/perf.cc
+++ b/lib/perf.cc
@@ -3,6 +3,7 @@
 #include <functional>
 #include <iomanip>
 #include <ios>
+#include <tbb/concurrent_vector.h>
 
 #ifndef _WIN32
 #include <sys/resource.h>

--- a/lib/signal-unix.cc
+++ b/lib/signal-unix.cc
@@ -1,6 +1,6 @@
 #include "common.h"
 
-#include <signal.h>
+#include <csignal>
 #include <tbb/version.h>
 
 #ifdef __FreeBSD__

--- a/src/arch-arm32.cc
+++ b/src/arch-arm32.cc
@@ -34,8 +34,6 @@
 #include "mold.h"
 
 #include <tbb/parallel_for.h>
-#include <tbb/parallel_for_each.h>
-#include <tbb/parallel_sort.h>
 
 namespace mold {
 

--- a/src/arch-riscv.cc
+++ b/src/arch-riscv.cc
@@ -22,8 +22,6 @@
 #include "mold.h"
 
 #include <regex>
-#include <tbb/parallel_for.h>
-#include <tbb/parallel_for_each.h>
 
 namespace mold {
 

--- a/src/gdb-index.cc
+++ b/src/gdb-index.cc
@@ -58,7 +58,6 @@
 
 #include "mold.h"
 #include <tbb/parallel_for_each.h>
-#include <tbb/parallel_sort.h>
 
 namespace mold {
 

--- a/src/input-sections.cc
+++ b/src/input-sections.cc
@@ -1,6 +1,5 @@
 #include "mold.h"
 
-#include <limits>
 #include <zlib.h>
 #include <zstd.h>
 

--- a/src/linker-script.cc
+++ b/src/linker-script.cc
@@ -6,7 +6,6 @@
 #include "mold.h"
 
 #include <cctype>
-#include <iomanip>
 
 namespace mold {
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,10 +3,6 @@
 
 #include <cstring>
 #include <functional>
-#include <iomanip>
-#include <map>
-#include <regex>
-#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <tbb/global_control.h>

--- a/src/main.cc
+++ b/src/main.cc
@@ -6,7 +6,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <tbb/global_control.h>
-#include <tbb/parallel_for_each.h>
 #include <unordered_set>
 
 #ifdef _WIN32

--- a/src/mapfile.cc
+++ b/src/mapfile.cc
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <ios>
 #include <sstream>
+#include <tbb/concurrent_hash_map.h>
 #include <tbb/parallel_for_each.h>
 
 namespace mold {

--- a/src/mapfile.cc
+++ b/src/mapfile.cc
@@ -5,7 +5,6 @@
 #include <ios>
 #include <sstream>
 #include <tbb/parallel_for_each.h>
-#include <unordered_map>
 
 namespace mold {
 

--- a/src/mold.h
+++ b/src/mold.h
@@ -3,11 +3,8 @@
 #include "../lib/common.h"
 #include "elf.h"
 
-#include <atomic>
-#include <bitset>
 #include <cassert>
 #include <cstdint>
-#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -15,7 +12,6 @@
 #include <mutex>
 #include <optional>
 #include <span>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <tbb/concurrent_hash_map.h>

--- a/src/mold.h
+++ b/src/mold.h
@@ -15,9 +15,7 @@
 #include <string>
 #include <string_view>
 #include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_mutex.h>
 #include <tbb/task_group.h>
 #include <type_traits>

--- a/src/output-file-win32.cc
+++ b/src/output-file-win32.cc
@@ -1,7 +1,6 @@
 #include "mold.h"
 
 #include <fcntl.h>
-#include <filesystem>
 #include <windows.h>
 
 namespace mold {

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -3,7 +3,6 @@
 
 #include <fstream>
 #include <functional>
-#include <map>
 #include <optional>
 #include <regex>
 #include <shared_mutex>

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -6,9 +6,9 @@
 #include <optional>
 #include <regex>
 #include <shared_mutex>
+#include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_sort.h>
-#include <tbb/partitioner.h>
 #include <unordered_set>
 
 namespace mold {

--- a/src/subprocess-unix.cc
+++ b/src/subprocess-unix.cc
@@ -1,7 +1,7 @@
 #include "mold.h"
 
+#include <csignal>
 #include <filesystem>
-#include <signal.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/thunks.cc
+++ b/src/thunks.cc
@@ -25,9 +25,6 @@
 
 #include "mold.h"
 
-#include <tbb/parallel_for.h>
-#include <tbb/parallel_for_each.h>
-
 namespace mold {
 
 using E = MOLD_TARGET;


### PR DESCRIPTION
Remove unused `#include`s, add missing ones and use the correct C++ wrappers for libc headers.