### PR TITLE
Small improvements: lambdas and ranges

### DIFF
--- a/src/gdb-index.cc
+++ b/src/gdb-index.cc
@@ -619,7 +619,7 @@ static std::vector<Compunit> read_compunits(Context<E> &ctx) {
 
   // Uniquify elements because GCC 11 seems to emit one record for each
   // comdat group which results in having a lot of duplicate records.
-  tbb::parallel_for_each(cus, [&](Compunit &cu) {
+  tbb::parallel_for_each(cus, [](Compunit &cu) {
     sort(cu.nametypes);
     remove_duplicates(cu.nametypes);
   });

--- a/src/icf.cc
+++ b/src/icf.cc
@@ -468,7 +468,7 @@ static void print_icf_sections(Context<E> &ctx) {
   });
 
   tbb::parallel_sort(leaders.begin(), leaders.end(),
-                     [&](InputSection<E> *a, InputSection<E> *b) {
+                     [](InputSection<E> *a, InputSection<E> *b) {
                        return a->get_priority() < b->get_priority();
                      });
 

--- a/src/input-files.cc
+++ b/src/input-files.cc
@@ -656,7 +656,7 @@ void ObjectFile<E>::initialize_symbols(Context<E> &ctx) {
 template <typename E>
 void ObjectFile<E>::sort_relocations(Context<E> &ctx) {
   if constexpr (is_riscv<E> || is_loongarch<E>) {
-    auto less = [&](const ElfRel<E> &a, const ElfRel<E> &b) {
+    auto less = [](const ElfRel<E> &a, const ElfRel<E> &b) {
       return a.r_offset < b.r_offset;
     };
 
@@ -1106,7 +1106,7 @@ template <typename E>
 void ObjectFile<E>::compute_symtab_size(Context<E> &ctx) {
   this->output_sym_indices.resize(this->elf_syms.size(), -1);
 
-  auto is_alive = [&](Symbol<E> &sym) -> bool {
+  auto is_alive = [](Symbol<E> &sym) -> bool {
     if (SectionFragment<E> *frag = sym.get_frag())
       return frag->is_alive;
     if (InputSection<E> *isec = sym.get_input_section())
@@ -1399,7 +1399,7 @@ std::span<Symbol<E> *> SharedFile<E>::get_symbols_at(Symbol<E> *sym) {
   });
 
   auto [begin, end] = std::equal_range(sorted_syms.begin(), sorted_syms.end(),
-                                       sym, [&](Symbol<E> *a, Symbol<E> *b) {
+                                       sym, [](Symbol<E> *a, Symbol<E> *b) {
     return a->esym().st_value < b->esym().st_value;
   });
 

--- a/src/lto-unix.cc
+++ b/src/lto-unix.cc
@@ -685,7 +685,7 @@ std::vector<ObjectFile<E> *> run_lto_plugin(Context<E> &ctx) {
   phase = 2;
 
   // Set `referenced_by_regular_obj` bit.
-  tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
+  tbb::parallel_for_each(ctx.objs, [](ObjectFile<E> *file) {
     if (!file->is_lto_obj) {
       for (Symbol<E> *sym : file->get_global_syms()) {
         if (sym->file && !sym->file->is_dso &&

--- a/src/output-chunks.cc
+++ b/src/output-chunks.cc
@@ -2238,7 +2238,7 @@ void EhFrameSection<E>::construct(Context<E> &ctx) {
 
   // Remove dead FDEs and assign them offsets within their corresponding
   // CIE group.
-  tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
+  tbb::parallel_for_each(ctx.objs, [](ObjectFile<E> *file) {
     std::erase_if(file->fdes, [](FdeRecord<E> &fde) { return !fde.is_alive; });
 
     i64 offset = 0;

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -1180,7 +1180,7 @@ void sort_init_fini(Context<E> &ctx) {
             vec.push_back({isec, get_init_fini_priority(isec)});
         }
 
-        sort(vec, [&](const Entry &a, const Entry &b) { return a.prio < b.prio; });
+        sort(vec, [](const Entry &a, const Entry &b) { return a.prio < b.prio; });
 
         for (i64 i = 0; i < vec.size(); i++)
           osec->members[i] = vec[i].sect;
@@ -1208,7 +1208,7 @@ void sort_ctor_dtor(Context<E> &ctx) {
         for (InputSection<E> *isec : osec->members)
           vec.push_back({isec, get_ctor_dtor_priority(isec)});
 
-        sort(vec, [&](const Entry &a, const Entry &b) { return a.prio < b.prio; });
+        sort(vec, [](const Entry &a, const Entry &b) { return a.prio < b.prio; });
 
         for (i64 i = 0; i < vec.size(); i++)
           osec->members[i] = vec[i].sect;
@@ -1542,7 +1542,7 @@ template <typename E>
 void compute_imported_symbol_weakness(Context<E> &ctx) {
   Timer t(ctx, "compute_imported_symbol_weakness");
 
-  tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
+  tbb::parallel_for_each(ctx.objs, [](ObjectFile<E> *file) {
     for (i64 i = file->first_global; i < file->elf_syms.size(); i++) {
       const ElfSym<E> &esym = file->elf_syms[i];
       Symbol<E> &sym = *file->symbols[i];
@@ -1697,7 +1697,7 @@ void sort_dynsyms(Context<E> &ctx) {
   // .dynsym.
   if (ctx.gnu_hash) {
     auto first_exported = std::stable_partition(first_global, syms.end(),
-                                                [&](Symbol<E> *sym) {
+                                                [](Symbol<E> *sym) {
       return !sym->is_exported;
     });
 
@@ -1939,7 +1939,7 @@ void compute_import_export(Context<E> &ctx) {
   // If we are creating an executable, we want to export symbols referenced
   // by DSOs unless they are explicitly marked as local by a version script.
   if (!ctx.arg.shared) {
-    tbb::parallel_for_each(ctx.dsos, [&](SharedFile<E> *file) {
+    tbb::parallel_for_each(ctx.dsos, [](SharedFile<E> *file) {
       for (Symbol<E> *sym : file->symbols) {
         if (sym->file && !sym->file->is_dso && sym->visibility != STV_HIDDEN &&
             sym->ver_idx != VER_NDX_LOCAL) {
@@ -2299,7 +2299,7 @@ void sort_output_sections_by_order(Context<E> &ctx) {
     chunk->sect_order = get_rank(chunk);
 
   // Sort output sections by --section-order
-  sort(ctx.chunks, [&](Chunk<E> *a, Chunk<E> *b) {
+  sort(ctx.chunks, [](Chunk<E> *a, Chunk<E> *b) {
     return a->sect_order < b->sect_order;
   });
 }

--- a/src/relocatable.cc
+++ b/src/relocatable.cc
@@ -111,7 +111,7 @@ template <typename E>
 static void r_claim_unresolved_symbols(Context<E> &ctx) {
   Timer t(ctx, "r_claim_unresolved_symbols");
 
-  tbb::parallel_for_each(ctx.objs, [&](ObjectFile<E> *file) {
+  tbb::parallel_for_each(ctx.objs, [](ObjectFile<E> *file) {
     if (!file->is_alive)
       return;
 

--- a/src/shrink-sections.cc
+++ b/src/shrink-sections.cc
@@ -109,7 +109,7 @@ void shrink_sections<E>(Context<E> &ctx) {
 
       std::span<const ElfRel<E>> rels = isec->get_rels(ctx);
       auto it = std::lower_bound(rels.begin(), rels.end(), sym->value,
-                                 [&](const ElfRel<E> &r, u64 val) {
+                                 [](const ElfRel<E> &r, u64 val) {
         return r.r_offset < val;
       });
 


### PR DESCRIPTION
In principle, compilers ought to be smart enough to detect lambdas that are needlessly declared as capturing, and to generate efficient code for them. Still, I personally like being able to spot non-capturing lambdas right away when reading through code.

Moreover, I propose making use of the C++20 ranges library for greater conciseness and readability.

As always, feel free to reject any changes that run counter to your preferences.