### PR TITLE
Add CI pipeline for Debian 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         distro:
         - alpine
         - archlinux
+        - debian:11 # GCC 10 and CMake 3.18 - the minimum supported by mold
         - fedora
         - gentoo/stage3
         - opensuse/tumbleweed


### PR DESCRIPTION
Debian 11 ships GCC 10 and CMake 3.18, which happen to be precisely the minimum versions required for building mold from source.

Add a CI pipeline to prevent future commits from inadvertently breaking compatibility with older toolchains.