### PR TITLE
Try again to use Podman instead of Docker

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -24,17 +24,14 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: redhat-actions/podman-login@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-qemu-action@v3
 
     - name: Build a tarball
       run: ./dist.sh ${{ matrix.target }}

--- a/.github/workflows/build-x86.yml
+++ b/.github/workflows/build-x86.yml
@@ -17,14 +17,11 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: redhat-actions/podman-login@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
 
     - name: Build a tarball
       run: ./dist.sh

--- a/dist.sh
+++ b/dist.sh
@@ -18,7 +18,7 @@
 # commit with release tags by rebuilding the binaries yourself.
 #
 # Debian provides snapshot.debian.org to host all historical binary
-# packages. We use it to construct Docker images pinned to a
+# packages. We use it to construct Podman images pinned to a
 # particular timestamp.
 #
 # We aim to use a reasonably old Debian version because we'll dynamically
@@ -60,7 +60,7 @@ case $# in
   usage
 esac
 
-# Create a Docker image.
+# Create a Podman image.
 if [ "$GITHUB_REPOSITORY" = '' ]; then
   cmd="podman run --userns=host"
   image=mold-builder-$arch
@@ -68,9 +68,9 @@ if [ "$GITHUB_REPOSITORY" = '' ]; then
 else
   # If this script is running on GitHub Actions, we want to cache
   # the created container image in GitHub's container repostiory.
-  cmd="docker run"
+  cmd="podman run"
   image=ghcr.io/$GITHUB_REPOSITORY/mold-builder-$arch
-  image_build="docker buildx build --platform linux/$arch -t $image --push --cache-to type=inline --cache-from type=registry,ref=$image -"
+  image_build="podman build --platform linux/$arch -t $image --output=type=registry --layers --cache-to $image  --cache-from $image -"
 fi
 
 case $arch in


### PR DESCRIPTION
Switch from Docker to Podman for container builds and remove unused buildx steps. 

Also this commit updates GitHub Actions workflows to use redhat-actions/podman-login and docker/setup-qemu-action@v3, removing references to Docker Buildx.

Fixes: ec1d7120aa44 ("Use docker only on GitHub Actions")
