### PR TITLE
Fix `arch-x86_64-ifunc-alias` test on RHEL 10

### DIFF
--- a/test/arch-x86_64-ifunc-alias.sh
+++ b/test/arch-x86_64-ifunc-alias.sh
@@ -4,7 +4,7 @@
 supports_ifunc || skip
 test_cflags -static || skip
 
-cat <<EOF | $CXX -o $t/a.o -c -xc++ - -fno-PIE
+cat <<EOF | $CXX -march=x86-64 -o $t/a.o -c -xc++ - -fno-PIE
 #include <assert.h>
 #include <stdio.h>
 


### PR DESCRIPTION
On RHEL 10, GCC is configured with the `--with-arch_64=x86-64-v3` option, which makes it implicitly use the `-march=x86-64-v3` command-line flag by default.

This breaks the `arch-x86_64-ifunc-alias` test: since the `x86-64-v3` microarchitecture level includes SSSE3 and AVX2, GCC appears to interpret the `default` and `ssse3,avx2` targets as the same thing, and omits generating a resolver function.

Fix the test by forcing GCC's target architecture to the `x86-64` baseline.