### PR TITLE
Improve performance by skipping char copies

### DIFF
--- a/src/arch-riscv.cc
+++ b/src/arch-riscv.cc
@@ -1025,7 +1025,7 @@ struct Extn {
 // This function returns true if the first extension name should precede
 // the second one as per the rule.
 static bool extn_name_less(std::string_view x, std::string_view y) {
-  auto get_single_letter_rank = [](char c) -> i64 {
+  auto get_single_letter_rank = [](const char& c) -> i64 {
     std::string_view exts = "iemafdqlcbkjtpvnh";
     size_t pos = exts.find_first_of(c);
     if (pos != exts.npos)

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -378,7 +378,7 @@ static i64 parse_number(Context<E> &ctx, std::string opt,
   return ret;
 }
 
-static char from_hex(char c) {
+static char from_hex(const char& c) {
   if ('0' <= c && c <= '9')
     return c - '0';
   if ('a' <= c && c <= 'f')

--- a/src/filetype.cc
+++ b/src/filetype.cc
@@ -4,7 +4,7 @@
 namespace mold {
 
 static bool is_text_file(MappedFile *mf) {
-  auto istext = [](char c) {
+  auto istext = [](const char& c) {
     return isprint(c) || c == '\n' || c == '\t';
   };
 

--- a/src/mold.h
+++ b/src/mold.h
@@ -3096,11 +3096,11 @@ inline bool is_c_identifier(std::string_view s) {
   if (s.empty())
     return false;
 
-  auto is_alpha = [](char c) {
+  auto is_alpha = [](const char& c) {
     return c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
   };
 
-  auto is_alnum = [&](char c) {
+  auto is_alnum = [&](const char& c) {
     return is_alpha(c) || ('0' <= c && c <= '9');
   };
 

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -706,7 +706,7 @@ get_start_stop_name(Context<E> &ctx, Chunk<E> &chunk) {
       return std::string(chunk.name);
 
     if (ctx.arg.start_stop) {
-      auto isalnum = [](char c) {
+      auto isalnum = [](const char& c) {
         return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') ||
                ('0' <= c && c <= '9');
       };


### PR DESCRIPTION
All of the lambdas that check if a character is a certain value get their char by value. This creates a lot of unnecessary copies, and if you're doing these in a hot loop, this creates a huge slowdown. I had just that happen in my RISC-V assembler (https://github.com/Slackadays/Chata/commit/727838c2db0dd0255b23bc880a67d4ac59c4f31f) and switching `char c` (actually `int c` for the standard library functions) to `const char& c` to get the value by const reference yielded an instant 15% speedup for free. Best of all, this change does not impact the lambas' usage semantics.