### PR TITLE
Upgrade checkout actions

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Login to GitHub Container Registry
       uses: redhat-actions/podman-login@v1

--- a/.github/workflows/build-x86.yml
+++ b/.github/workflows/build-x86.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Login to GitHub Container Registry
       uses: redhat-actions/podman-login@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         - '-DMOLD_USE_TSAN=On'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: rui314/setup-mold@staging
     - run: sudo ./install-build-deps.sh
     - name: build
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     container: gcc:11.1.0
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install-build-deps
       shell: bash
       run: |
@@ -89,7 +89,7 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: build
       run: |
         mkdir build
@@ -100,7 +100,7 @@ jobs:
   build-windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: build
       run: |
         mkdir build
@@ -111,7 +111,7 @@ jobs:
   build-msys:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup MSYS2
       uses: msys2/setup-msys2@v2
       with:
@@ -129,7 +129,7 @@ jobs:
   build-freebsd:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and test
       uses: vmactions/freebsd-vm@v1
       with:

--- a/.github/workflows/update-manpage.yml
+++ b/.github/workflows/update-manpage.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install ronn
       run: sudo apt-get update && sudo apt-get install -y ronn


### PR DESCRIPTION
The version of checkout actions is outdated, so I upgrad it to the latest version.
ref: https://github.com/actions/checkout/releases/tag/v4.0.0