### PR TITLE
[ELF][S390X] Skip tests that fail due to buggy code produced by GCC

### DIFF
--- a/test/bno-symbolic.sh
+++ b/test/bno-symbolic.sh
@@ -3,7 +3,7 @@
 
 # GCC produces buggy code for this test case on s390x.
 # https://sourceware.org/bugzilla/show_bug.cgi?id=29655
-[ $MACHINE = s390x ] && $CC -v 2>&1 | grep -E '^gcc version 1[0-4]\.' && skip
+[ $MACHINE = s390x ] && $CC -v 2>&1 | grep -E '^gcc version 1[0-5]\.' && skip
 
 cat <<EOF | $CC -c -fPIC -o$t/a.o -xc -
 int foo = 4;

--- a/test/canonical-plt.sh
+++ b/test/canonical-plt.sh
@@ -3,7 +3,7 @@
 
 # GCC produces buggy code for this test case on s390x.
 # https://sourceware.org/bugzilla/show_bug.cgi?id=29655
-[ $MACHINE = s390x ] && $CC -v 2>&1 | grep -E '^gcc version 1[0-4]\.' && skip
+[ $MACHINE = s390x ] && $CC -v 2>&1 | grep -E '^gcc version 1[0-5]\.' && skip
 
 cat <<EOF | $CC -o $t/a.so -fPIC -shared -xc -
 void *foo() {

--- a/test/rodata-name.sh
+++ b/test/rodata-name.sh
@@ -5,6 +5,10 @@
 # Concretely speaking, ARM as uses "@" as a start of a comment.
 [ $MACHINE = arm ] && skip
 
+# GCC produces buggy code for this test case on s390x.
+# https://sourceware.org/bugzilla/show_bug.cgi?id=29655
+[ $MACHINE = s390x ] && $CC -v 2>&1 | grep -E '^gcc version 1[45]\.' && skip
+
 cat <<'EOF' | $CC -c -o $t/a.o -x assembler -
 .globl val1, val2, val3, val4, val5
 


### PR DESCRIPTION
This pull request addresses testsuite failures we're seeing on S390X Fedora Rawhide with GCC 15 (https://bugzilla.redhat.com/show_bug.cgi?id=2340876).

`bno-symbolic` and `canonical-plt` still fail with GCC 15; adjust the regex accordingly.

Also skip `rodata-name`, which started failing with GCC 14. Whether this has the same root cause as the other two is speculation on my part.