### PR TITLE
Honor --compress-debug-sections with --separate-debug-file

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -504,9 +504,6 @@ int mold_main(int argc, char **argv) {
   // create as few segments as possible.
   sort_output_sections(ctx);
 
-  if (!ctx.arg.separate_debug_file.empty())
-    separate_debug_sections(ctx);
-
   // Compute sizes of output sections while assigning offsets
   // within an output section to input sections.
   compute_section_sizes(ctx);
@@ -550,6 +547,9 @@ int mold_main(int argc, char **argv) {
 
   // Compute the section header values for all sections.
   compute_section_headers(ctx);
+
+  if (!ctx.arg.separate_debug_file.empty())
+    separate_debug_sections(ctx);
 
   // Assign offsets to output sections
   i64 filesize = set_osec_offsets(ctx);

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -2964,8 +2964,10 @@ template <typename E>
 void compress_debug_sections(Context<E> &ctx) {
   Timer t(ctx, "compress_debug_sections");
 
-  tbb::parallel_for((i64)0, (i64)ctx.chunks.size(), [&](i64 i) {
-    Chunk<E> &chunk = *ctx.chunks[i];
+  std::vector<Chunk<E> *> &chunks = ctx.debug_chunks.empty() ? ctx.chunks : ctx.debug_chunks;
+
+  tbb::parallel_for((i64)0, (i64)chunks.size(), [&](i64 i) {
+    Chunk<E> &chunk = *chunks[i];
 
     if ((chunk.shdr.sh_flags & SHF_ALLOC) || chunk.shdr.sh_size == 0 ||
         !chunk.name.starts_with(".debug"))
@@ -2973,7 +2975,7 @@ void compress_debug_sections(Context<E> &ctx) {
 
     Chunk<E> *comp = new CompressedSection<E>(ctx, chunk);
     ctx.chunk_pool.emplace_back(comp);
-    ctx.chunks[i] = comp;
+    chunks[i] = comp;
   });
 
   if (ctx.shstrtab)

--- a/test/compress-debug-sections-separate-debug-file.sh
+++ b/test/compress-debug-sections-separate-debug-file.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -c -g -o $t/a.o -xc -
+#include <stdio.h>
+int main() { printf("Hello world\n"); }
+EOF
+
+$CC -B. -o $t/exe $t/a.o -Wl,--compress-debug-sections=zlib -Wl,--separate-debug-file
+
+readelf -WS $t/exe.dbg > $t/log
+grep -q '\.debug_info .* [Cx] ' $t/log
+grep -q '\.debug_str .* MS[Cx] ' $t/log

--- a/test/compress-debug-sections-separate-debug-file.sh
+++ b/test/compress-debug-sections-separate-debug-file.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 . $(dirname $0)/common.inc
 
+nm mold | grep -q '__tsan_init' && skip
+on_qemu && skip
+
 cat <<EOF | $CC -c -g -o $t/a.o -xc -
 #include <stdio.h>
 int main() { printf("Hello world\n"); }
 EOF
 
-$CC -B. -o $t/exe $t/a.o -Wl,--compress-debug-sections=zlib -Wl,--separate-debug-file
+$CC -B. -o $t/exe $t/a.o -Wl,--compress-debug-sections=zlib -Wl,--separate-debug-file -Wl,--no-detach
 
 readelf -WS $t/exe.dbg > $t/log
 grep -q '\.debug_info .* [Cx] ' $t/log


### PR DESCRIPTION
Fix a bug when `--compress-debug-sections` is used along with `--separate-debug-file`. The problem was that if both are used together, the debug info file does NOT have its debug sections compressed !!