### PR TITLE
Allow installing dependencies on centos

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -13,7 +13,7 @@ ubuntu | pop | linuxmint | debian | raspbian | neon)
   apt-get install -y cmake gcc g++
   if [ "$ID-$VERSION_ID" = ubuntu-20.04 ]; then apt-get install -y g++-10; fi
   ;;
-fedora | amzn | rhel)
+fedora | amzn | rhel | centos)
   dnf install -y gcc-g++ cmake glibc-static libstdc++-static diffutils util-linux tar
   ;;
 rocky)


### PR DESCRIPTION
Enables `install_build_deps.sh` to work on centos.

Before:
```
$ ./install-build-deps.sh
+ case "$ID" in
+ echo 'Error: don'\''t know anything about build dependencies on centos-9'
Error: don't know anything about build dependencies on centos-9
+ exit 1
```

After:
```
$ sudo ./install-build-deps.sh
+ case "$ID" in
+ dnf install -y gcc-g++ cmake glibc-static libstdc++-static diffutils util-linux tar
Last metadata expiration check: 0:06:14 ago on Thu 20 Feb 2025 01:38:58 PM PST.
Package gcc-c++-11.5.0-2.el9.x86_64 is already installed.
Package cmake-3.26.5-2.el9.x86_64 is already installed.
Package glibc-static-2.34-147.el9.x86_64 is already installed.
Package libstdc++-static-11.5.0-2.el9.x86_64 is already installed.
Package diffutils-3.7-12.el9.x86_64 is already installed.
Package util-linux-2.37.4-20.el9.x86_64 is already installed.
Package tar-2:1.34-7.el9.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!
```