### PR TITLE
Remove temporary lto files from dependency-file

### DIFF
--- a/src/lto-unix.cc
+++ b/src/lto-unix.cc
@@ -177,6 +177,7 @@ static PluginStatus add_input_file(const char *path) {
   static i64 file_priority = 100;
 
   MappedFile *mf = must_open_file(ctx, path);
+  mf->is_dependency = false;
 
   ObjectFile<E> *file = new ObjectFile<E>(ctx, mf, "");
   ctx.obj_pool.emplace_back(file);

--- a/test/dependency-file-lto.sh
+++ b/test/dependency-file-lto.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -flto -o $t/a.o -c -xc -
+#include <stdio.h>
+int main() {
+  printf("Hello world\n");
+}
+EOF
+
+$CC -B. -flto -o $t/exe $t/a.o -Wl,-dependency-file=$t/dep
+
+grep '/exe:.*/a.o ' $t/dep
+grep '/a.o:$' $t/dep
+not grep '^/tmp' $t/dep
+


### PR DESCRIPTION
Mark lto temporary files to not be a dependency
    
Removes the temporary file created by the compiler
 from the dependency list created with --dependency-file.
    
 Without this build systems will never report "Nothing to do",
 but always do a re-link of the final object.

