### PR TITLE
Print MOLD_VERSION after GNU ld compatibility string too.

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -4,9 +4,9 @@ namespace mold {
 
 std::string get_mold_version() {
   if (mold_git_hash.empty())
-    return "mold "s + MOLD_VERSION + " (compatible with GNU ld)";
+    return "mold "s + MOLD_VERSION + " (compatible with GNU ld " + MOLD_VERSION + ")";
   return "mold "s + MOLD_VERSION + " (" + mold_git_hash +
-         "; compatible with GNU ld)";
+         "; compatible with GNU ld " + MOLD_VERSION + ")";
 }
 
 } // namespace mold


### PR DESCRIPTION
As per discussion in https://github.com/rui314/mold/discussions/784#discussioncomment-12936908

I'm not sure if this breaks other scripts that look for mold versions, but this might work around scripts that look for GNU ld versions from looking at the output of `$LD --version`.