### PR TITLE
RISC-V: Correctly relocate R_RISCV_CALL_PLTs against weak undef symbols

### DIFF
--- a/src/arch-riscv.cc
+++ b/src/arch-riscv.cc
@@ -321,10 +321,10 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       i64 val = S + A - P;
       i64 rd = get_rd(buf + rel.r_offset + 4);
 
-      // Calling an undefined weak symbol does not make sense.
-      // We make such call into an infinite loop. This should
+      // Calling an undefined weak symbol without PLT entries does not make
+      // sense. We make such call into an infinite loop. This should
       // help debugging of a faulty program.
-      if (sym.esym().is_undef_weak())
+      if (sym.esym().is_undef_weak() && rel.r_type != R_RISCV_CALL_PLT)
         val = 0;
 
       if (removed_bytes == 4) {


### PR DESCRIPTION
Previously, all R_RISCV_CALL* relocations, regardless through or not through PLT entries, are turned into dead loops if they're against an undefined weak symbol.

This isn't desired in case of R_RISCV_CALL_PLT where the undefined symbol may be satisified at runtime. Let's correctly relocate the symbol in this case.

Fixes: e76f7c0d474e ("Add an initial support of RISC-V")
Closes: https://github.com/rui314/mold/issues/1451