### PR TITLE
shrink-sections: Relax weak undef symbols if promotion is possible

### DIFF
--- a/src/shrink-sections.cc
+++ b/src/shrink-sections.cc
@@ -122,8 +122,9 @@ i64 compute_distance(Context<E> &ctx, Symbol<E> &sym,
   if (sym.is_absolute())
     return INT64_MAX;
 
-  // Likewise, relocations against weak undefined symbols won't be relaxed.
-  if (sym.esym().is_undef_weak())
+  // Likewise, relocations against weak undefined symbols won't be relaxed if
+  // it cannot be promoted to a dynamic symbol.
+  if (sym.is_remaining_undef_weak())
     return INT64_MAX;
 
   // Compute a distance between the relocated place and the symbol.

--- a/test/arch-riscv64-weak-undef-call.sh
+++ b/test/arch-riscv64-weak-undef-call.sh
@@ -10,4 +10,4 @@ foo:
 EOF
 
 $CC -B. -shared -o $t/b.so $t/a.o
-$OBJDUMP -d $t/b.so | grep -E '\bjalr\b.*<bar\$plt>'
+$OBJDUMP -d $t/b.so | grep -E '\bjal\b.*<bar\$plt>'


### PR DESCRIPTION
A call to weak undefined symbol could be relaxed as long as the symbol could be promoted to a dynamic symbol, where the relaxation is done against the known PLT address and the address of the symbol itself doesn't really matter.