### PR TITLE
Add support for static libatomic.a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,11 @@ int main() {
 }" HAVE_FULL_ATOMIC_SUPPORT)
 
 if(NOT HAVE_FULL_ATOMIC_SUPPORT)
-  target_link_libraries(mold PRIVATE atomic)
+  if (MOLD_MOSTLY_STATIC)
+    target_link_options(mold PRIVATE "-Wl,--push-state,-Bstatic" "-latomic" "-Wl,--pop-state")
+  else()
+    target_link_libraries(mold PRIVATE atomic)
+  endif()
 endif()
 
 # Add -pthread


### PR DESCRIPTION
It looks like it's possible to accidentally link against `libatomic.so` even when `MOLD_MOSTLY_STATIC` is set. This PR is an attempt at a fix for this