### PR TITLE
Fix linked executable segfaulting if -I and -static are both passed

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -1444,6 +1444,9 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
   if (ctx.arg.relocatable)
     ctx.arg.static_ = true;
 
+  if (ctx.arg.static_)
+    ctx.arg.dynamic_linker = "";
+
   if (ctx.arg.shuffle_sections == SHUFFLE_SECTIONS_SHUFFLE) {
     if (shuffle_sections_seed)
       ctx.arg.shuffle_sections_seed = *shuffle_sections_seed;


### PR DESCRIPTION
If a `--dynamic-linker` is specified and `--static` is also passed, mold tries to fulfill both, making an executable that segfaults immediately.  For example, since musl-gcc always passes `-Wl,I/lib/ld-musl-$(uname -m).so.1`:

```
$ musl-gcc -fuse-ld=bfd -static helloworld.c
$ file a.out
a.out: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
$ ./a.out
hello world
$ musl-gcc -fuse-ld=bfd -static helloworld.c
$ file a.out
a.out: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, interpreter /lib/ld-musl-aarch64.so.1, with debug_info, not stripped
$ ./a.out
Segmentation fault (core dumped)
```

This patch makes mold imitate GNU ld.bfd (not sure about other linkers), so `-static` anywhere in the command line overrides `--dynamic-linker`.