### PR TITLE
Add Zorin Distribution to install deps script

### DIFF
--- a/install-build-deps.sh
+++ b/install-build-deps.sh
@@ -8,7 +8,7 @@ set -e
 set -x
 
 case "$ID" in
-ubuntu | pop | linuxmint | debian | raspbian | neon)
+ubuntu | pop | linuxmint | debian | raspbian | neon | zorin)
   apt-get update
   apt-get install -y cmake gcc g++ clang gdb
   ;;


### PR DESCRIPTION
Hi there ! 

I try to use mold as default linker, even if it was very to build from source, I had  to install deps manually since my os distribution is not available into dedicated scripts. So here is a little patch to add "zorin" distribution to this scripts.

Feel free to comment ! 