### PR TITLE
Correctly track --static value inside --push-state/--pop-state

### DIFF
--- a/test/push-pop-state.sh
+++ b/test/push-pop-state.sh
@@ -19,3 +19,10 @@ $CC -B. -o $t/exe $t/c.o -Wl,-as-needed \
 readelf --dynamic $t/exe > $t/log
 grep -F a.so $t/log
 not grep -F b.so $t/log
+
+$CC -no-pie -B. -o $t/exe $t/c.o -Wl,-no-as-needed \
+  -Wl,-push-state,-Bstatic -lstdc++ -Wl,-pop-state -lc
+
+readelf --dynamic $t/exe > $t/log
+not grep -F libstdc++ $t/log
+grep -F libc $t/log


### PR DESCRIPTION
Currently, when using --static inside --push-state and --pop-state, we incorrectly mark the global state as static. This commit changes to the correct behavior where global state is marked as static only when --static is used at the outer most (outside of any --push-state, --pop-state).