### PR TITLE
 --print-gc-sections and --print-icf-sections can now take =FILE to s…

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -137,9 +137,9 @@ Options:
   --pie, --pic-executable     Create a position-independent executable
     --no-pie, --no-pic-executable
   --pop-state                 Restore the state of flags governing input file handling
-  --print-gc-sections         Print removed unreferenced sections
+  --print-gc-sections[=FILE]  Print, or save in FILE, removed unreferenced sections
     --no-print-gc-sections
-  --print-icf-sections        Print folded identical sections
+  --print-icf-sections[=FILE] Print, or save in FILE, folded identical sections
     --no-print-icf-sections
   --push-state                Save the state of flags governing input file handling
   --quick-exit                Use quick_exit to exit (default)
@@ -1176,8 +1176,13 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.gc_sections = false;
     } else if (read_flag("print-gc-sections")) {
       ctx.arg.print_gc_sections = true;
+      ctx.arg.print_gc_sections_file = "";
+    } else if (read_eq("print-gc-sections")) {
+      ctx.arg.print_gc_sections = true;
+      ctx.arg.print_gc_sections_file = arg;
     } else if (read_flag("no-print-gc-sections")) {
       ctx.arg.print_gc_sections = false;
+      ctx.arg.print_gc_sections_file = "";
     } else if (read_arg("discard-section")) {
       ctx.arg.discard_section.insert(arg);
     } else if (read_arg("no-discard-section")) {
@@ -1203,8 +1208,13 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.physical_image_base = parse_number(ctx, "physical-image-base", arg);
     } else if (read_flag("print-icf-sections")) {
       ctx.arg.print_icf_sections = true;
+      ctx.arg.print_icf_sections_file = "";
+    } else if (read_eq("print-icf-sections")) {
+      ctx.arg.print_icf_sections = true;
+      ctx.arg.print_icf_sections_file = arg;
     } else if (read_flag("no-print-icf-sections")) {
       ctx.arg.print_icf_sections = false;
+      ctx.arg.print_icf_sections_file = "";
     } else if (read_flag("quick-exit")) {
       ctx.arg.quick_exit = true;
     } else if (read_flag("no-quick-exit")) {

--- a/src/mold.h
+++ b/src/mold.h
@@ -2424,6 +2424,8 @@ struct Context {
     std::string dynamic_linker;
     std::string output = "a.out";
     std::string package_metadata;
+    std::string print_gc_sections_file;
+    std::string print_icf_sections_file;
     std::string plugin;
     std::string rpaths;
     std::string separate_debug_file;


### PR DESCRIPTION
`--print-gc-sections` and `print-icf-sections` now take a file (`--print-gc-sections=/tmp/foo.txt`), which makes it easier to get that information without as it doesn't require redirection.

I added to `print-gc-sections` a message with the total bytes saved, similar to the one in ICF, and added subtotal reports. For the `gc-sections` sizes we report the same metric used for ICF (`contents.size()`).
