### PR TITLE
New section-order feature: noinit

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -518,6 +518,7 @@ parse_section_order(Context<E> &ctx, std::string_view arg) {
                std::regex_constants::optimize;
   static std::regex re1(R"(^\s*(TEXT|DATA|RODATA|BSS)(?:\s|$))", flags);
   static std::regex re2(R"(^\s*([a-zA-Z0-9_.][^\s]*|EHDR|PHDR)(?:\s|$))", flags);
+  static std::regex re2_noinit(R"(^\s*noinit:([a-zA-Z0-9_.][^\s]*)(?:\s|$))", flags);
   static std::regex re3(R"(^\s*=(0x[0-9a-f]+|\d+)(?:\s|$))", flags);
   static std::regex re4(R"(^\s*%(0x[0-9a-f]+|\d*)(?:\s|$))", flags);
   static std::regex re5(R"(^\s*!(\S+)(?:\s|$))", flags);
@@ -531,6 +532,10 @@ parse_section_order(Context<E> &ctx, std::string_view arg) {
 
     if (std::regex_search(arg.data(), arg.data() + arg.size(), m, re1)) {
       ord.type = SectionOrder::GROUP;
+      ord.name = m[1].str();
+    } else if (std::regex_search(arg.data(), arg.data() + arg.size(), m, re2_noinit)) {
+      ord.type = SectionOrder::SECTION;
+      ord.noinit = true;
       ord.name = m[1].str();
     } else if (std::regex_search(arg.data(), arg.data() + arg.size(), m, re2)) {
       ord.type = SectionOrder::SECTION;

--- a/src/mold.h
+++ b/src/mold.h
@@ -2249,6 +2249,7 @@ struct SectionOrder {
   enum { NONE, SECTION, GROUP, ADDR, ALIGN, SYMBOL } type = NONE;
   std::string name;
   u64 value = 0;
+  bool noinit = false;
 };
 
 // Target-specific context members


### PR DESCRIPTION
I am consulting another team, working on a micro controller project, trying to move them to mold. They do have a lot of code and icf does help. But these manually placed uninitialized arrays usually eat up all gains by icf. So I need this to remove another linker script.. 

Allow the user to override the section types for custom input sections This is rather common in micro controller projects: to make data structures, that would otherwise be grouped to BSS, magically appear in a special location, the structure is placed inside a custom section which then gets defaulted to SHT_PROGBITS. This then leads to an output section that would be all zeros in your final binary. In gnu linker scripts this could be avoided by adding a NOLOAD attribute to the section.

The use case above could be easily implemented in a driver - simply by setting a pointer or writing a custom allocator.
Still every CPU vendor will give you overly complicated linker scripts examples. This feature only makes sense for supporting older frameworks, and future MCU vendor code.