### PR TITLE
Consider .gcc_except_table* sections for ICF.

### DIFF
--- a/src/icf.cc
+++ b/src/icf.cc
@@ -124,6 +124,9 @@ template <typename E>
 static bool is_eligible(Context<E> &ctx, InputSection<E> &isec) {
   const ElfShdr<E> &shdr = isec.shdr();
   std::string_view name = isec.name();
+  
+  if (name.starts_with(".gcc_except_table"))
+    return true;
 
   if (shdr.sh_size == 0 || !(shdr.sh_flags & SHF_ALLOC) ||
       shdr.sh_type == SHT_NOBITS || is_c_identifier(name))


### PR DESCRIPTION
When considering function sections referenced by an FDE for ICF a corresponding .gcc_except_table section should also be considered. Otherwise all such functions will be distinct as there is a relocation from the FDE to the LSDA inside a .gcc_except_table.* section corresponding to the function. So the functions with exception tables cannot be folded unless the exception tables can be folded too. 
But the .gcc_except_table.* sections are excluded from the ICF unless a --ignore-data-address-equality is given because they have  the **address_taken** set to true via this statement in the passes.cc:compute_address_significance():
```
if (!(isec->shdr().sh_flags & SHF_EXECINSTR))
        isec->address_taken = true;

```
As the exception table is only relevant to the corresponding function it should be safe to consider them in the ICF even without --ignore-data-address-equality.
Here is my code with two identical functions, which don't get folded because they throw an exception:
```
#include <stdexcept>
#include <string>

template<typename T>
struct X {
  T value;
  static void check(X* ptr);
};

int main() {
  X<int> a{};
  X<float> b{};

  a.check(&a);
  b.check(&b);
  return 0;
}

template<typename T>
void X<T>::check(X<T>* ptr) {
  if( ptr == nullptr) {
    throw std::logic_error("orz");
  }
}

template void X<int>::check(X<int>*);
template void X<float>::check(X<float>*);
```
With my patch both functions and their .gcc_except_table* get folded with just -icf=safe.