### PR TITLE
[SPARC64] Fix R_SPARC_TLS_GD_ADD handling

### DIFF
--- a/src/arch-sparc64.cc
+++ b/src/arch-sparc64.cc
@@ -370,8 +370,9 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       if (sym.has_tlsgd(ctx)) {
         // do nothing
       } else if (sym.has_gottp(ctx)) {
+        u32 rs1 = bits(*(ub32 *)loc, 18, 14);
         u32 rs2 = bits(*(ub32 *)loc, 4, 0);
-        *(ub32 *)loc = 0xd05d'c000 | rs2; // ldx [ %l7 + %reg ], %o0
+        *(ub32 *)loc = 0xd058'0000 | (rs1 << 14) | rs2; // ldx [ %base + %reg ], %o0
       } else {
         u32 rs2 = bits(*(ub32 *)loc, 4, 0);
         *(ub32 *)loc = 0x9001'c000 | rs2; // add %g7, %reg, %o0


### PR DESCRIPTION
R_SPARC_TLS_GD_ADD can use any register for the base address (ELF Handling For Thread-Local Storage, pg. 21), so remove the hardcoded %l7 usage.