### PR TITLE
[SPARC64] Preserve registers used during optimization transforms

### DIFF
--- a/src/arch-sparc64.cc
+++ b/src/arch-sparc64.cc
@@ -358,12 +358,14 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       if (sym.has_tlsgd(ctx)) {
         *(ub32 *)loc |= bits(sym.get_tlsgd_addr(ctx) + A - GOT, 9, 0);
       } else if (sym.has_gottp(ctx)) {
+        u32 rs1 = bits(*(ub32 *)loc, 18, 14);
         u32 rd = bits(*(ub32 *)loc, 29, 25);
-        *(ub32 *)loc = 0x8010'2000 | (rd << 25) | (rd << 14); // or  %reg, $0, %reg
+        *(ub32 *)loc = 0x8010'2000 | (rd << 25) | (rs1 << 14); // or  %rs1, $0, %rd
         *(ub32 *)loc |= bits(sym.get_gottp_addr(ctx) + A - GOT, 9, 0);
       } else {
+        u32 rs1 = bits(*(ub32 *)loc, 18, 14);
         u32 rd = bits(*(ub32 *)loc, 29, 25);
-        *(ub32 *)loc = 0x8018'2000 | (rd << 25) | (rd << 14); // xor %reg, $0, %reg
+        *(ub32 *)loc = 0x8018'2000 | (rd << 25) | (rs1 << 14); // xor %rs1, $0, %rd
         *(ub32 *)loc |= bits(S + A - ctx.tp_addr, 9, 0) | 0b1'1100'0000'0000;
       }
       break;


### PR DESCRIPTION
GCC might decide to put the result of the operation in another register, so remove hardcodings of %o0 as the destination register (`rd` field) during the transform of those relocations.