### PR TITLE
[SPARC64] Don't turn R_SPARC_GOTDATA_OP into a nop

### DIFF
--- a/src/arch-sparc64.cc
+++ b/src/arch-sparc64.cc
@@ -301,10 +301,7 @@ void InputSection<E>::apply_reloc_alloc(Context<E> &ctx, u8 *base) {
       }
       break;
     case R_SPARC_GOTDATA_OP:
-      if (sym.is_absolute()) {
-        // ldx [ %g2 + %g1 ], %g1  →  nop
-        *(ub32 *)loc = 0x0100'0000;
-      } else if (sym.is_pcrel_linktime_const(ctx)) {
+      if (sym.is_pcrel_linktime_const(ctx)) {
         // ldx [ %g2 + %g1 ], %g1  →  add %g2, %g1, %g1
         *(ub32 *)loc &= 0b00'11111'000000'11111'1'11111111'11111;
         *(ub32 *)loc |= 0b10'00000'000000'00000'0'00000000'00000;


### PR DESCRIPTION
This is to fix issue 1529.
See also: https://github.com/rui314/mold/issues/1529#issuecomment-3483047265