### PR TITLE
Fix getting output type from linker scripts that use AS_NEEDED

### DIFF
--- a/src/linker-script.cc
+++ b/src/linker-script.cc
@@ -249,9 +249,12 @@ std::string_view Script<E>::get_script_output_type() {
   }
 
   if (tok.size() >= 3 && (tok[0] == "INPUT" || tok[0] == "GROUP") &&
-      tok[1] == "(")
+      tok[1] == "(") {
+    if (tok.size() >= 5 && tok[2] == "AS_NEEDED" && tok[3] == "(")
+      tok = tok.subspan(2);
     if (MappedFile *mf = resolve_path(tok[2], false))
       return get_machine_type(ctx, rctx, mf);
+  }
   return "";
 }
 

--- a/test/linker-script-group-as-needed.sh
+++ b/test/linker-script-group-as-needed.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -o $t/a.o -c -xc -
+#include <stdio.h>
+int main() {
+  printf("Hello world\n");
+}
+EOF
+
+cat <<EOF | $CC -B. -shared -o $t/libB.so -c -xc -
+void not_needed() { }
+EOF
+$AR
+
+cat <<EOF > $t/libscript.a
+GROUP(AS_NEEDED("$t/libB.so"))
+EOF
+
+$CC -B. -o $t/exe -L$t -lscript $t/a.o
+$QEMU $t/exe | grep 'Hello world'
+
+$CC -B. -o $t/exe -L$t -l:libscript.a $t/a.o
+$QEMU $t/exe | grep 'Hello world'


### PR DESCRIPTION
Make `Script<E>::get_script_output_type` support `AS_NEEDED` inside an `INPUT` or `GROUP` group, so that the `libatomic_asneeded.so` linker script used by GCC 16 works.

Fixes #1545