### PR TITLE
Fix `textrel2` test on Fedora 44

### DIFF
--- a/test/textrel2.sh
+++ b/test/textrel2.sh
@@ -16,13 +16,13 @@ int main() {
 }
 EOF
 
-$CC -o $t/exe1 $t/a.o -pie
+$CC -o $t/exe1 $t/a.o -pie -Wl,-z,notext
 $QEMU $t/exe1 || skip
 
 $CC -B. -o $t/exe2 $t/a.o -pie
 $QEMU $t/exe2 | grep 'Hello world'
 
-$CC -o $t/exe3 $t/a.o -pie -Wl,-z,pack-relative-relocs 2> /dev/null || skip
+$CC -o $t/exe3 $t/a.o -pie -Wl,-z,notext -Wl,-z,pack-relative-relocs 2> /dev/null || skip
 readelf -WS $t/exe3 | grep -F .relr.dyn || skip
 $QEMU $t/exe3 2> /dev/null | grep 'Hello world' || skip
 


### PR DESCRIPTION
Tell the GNU linker to not report dynamic relocations in read-only sections as an error.

(I'm unsure what exactly has changed in the GNU linker and why mold does not need `-Wl,-z,notext` on the exact same input file.)