### PR TITLE
Replace abort() with diagnostic message in redo_main()

### DIFF
--- a/src/passes.cc
+++ b/src/passes.cc
@@ -79,7 +79,9 @@ int redo_main(std::string_view target, int argc, char **argv) {
   if constexpr (HAVE_TARGET_LOONGARCH64)
     if (target == LOONGARCH64::name)
       return mold_main<LOONGARCH64>(argc, argv);
-  abort();
+  std::cerr << "mold: unsupported target: " << target
+            << "; rebuild mold with the appropriate target support\n";
+  exit(1);
 }
 
 template <typename E>


### PR DESCRIPTION
## Summary

- `redo_main()` called `abort()` when no compiled-in target matched the auto-detected architecture
- Users saw only `Aborted (core dumped)` with no indication of the cause
- Now prints: `mold: unsupported target: <name>; rebuild mold with the appropriate target support`

This aligns the auto-detection path (`redo_main()` in `passes.cc`) with the explicit `-m` path (`cmdline.cc:763`), which already provides a helpful `Fatal(ctx)` message.

## Details

`redo_main()` does not have access to `Context<E>` (it runs before `mold_main<E>` creates one), so `Fatal(ctx)` cannot be used. The fix uses `std::cerr` + `exit(1)` instead.

Fixes #1553