### PR TITLE
Fix separate-debug-file strtab corruption

### DIFF
--- a/src/passes.cc
+++ b/src/passes.cc
@@ -3397,18 +3397,6 @@ void write_separate_debug_file(Context<E> &ctx) {
   i64 num_chunks = ctx.chunks.size();
   append(ctx.chunks, ctx.debug_chunks);
 
-  tbb::parallel_for(num_chunks, (i64)ctx.chunks.size(), [&](i64 i) {
-    ctx.chunks[i]->compute_section_size(ctx);
-  });
-
-  sort_debug_info_sections(ctx);
-
-  // Handle --compress-debug-info
-  if (ctx.arg.compress_debug_sections != ELFCOMPRESS_NONE)
-    compress_debug_sections(ctx);
-
-  // Recompute section header contents since we have added debug sections
-  compute_section_headers(ctx);
 
   // A debug info file contains all sections as the original file, though
   // most of them can be empty as if they were bss sections. We convert
@@ -3426,6 +3414,19 @@ void write_separate_debug_file(Context<E> &ctx) {
       ctx.chunk_pool.emplace_back(sec);
     }
   }
+
+  tbb::parallel_for(num_chunks, (i64)ctx.chunks.size(), [&](i64 i) {
+    ctx.chunks[i]->compute_section_size(ctx);
+  });
+
+  sort_debug_info_sections(ctx);
+
+  // Handle --compress-debug-info
+  if (ctx.arg.compress_debug_sections != ELFCOMPRESS_NONE)
+    compress_debug_sections(ctx);
+
+  // Recompute section header contents since we have added debug sections
+  compute_section_headers(ctx);
 
   // Assign file offsets to sections
   i64 fileoff = 0;

--- a/test/separate-debug-file.sh
+++ b/test/separate-debug-file.sh
@@ -6,35 +6,51 @@ on_qemu && skip
 command -v gdb >& /dev/null || skip
 command -v flock >& /dev/null || skip
 
+# To check for corruption, we need a binary with many external symbols.
+# The easiest method of doing this is generating the library
+seq 1 20 | sed 's/.*/int return&(void);/' > $t/libret.h
+seq 1 20 | sed 's/.*/int return&(void) { return &; }/' > $t/libret.c
+
 cat <<EOF > $t/a.c
-#include <stdio.h>
+#include <libret.h>
 int main() {
-  printf("Hello world\n");
+  int x;
+  $(seq 1 20 | sed 's/.*/x += return&();/')
+  return x;
 }
 EOF
 
-$CC -c -o $t/a.o $t/a.c -g
-$CC -B. -o $t/exe1 $t/a.o -Wl,--separate-debug-file
+$CC -c -o $t/libret.o $t/libret.c -g
+$CC -B. -o $t/libret.so -shared $t/libret.o
+
+$CC -c -o $t/a.o $t/a.c -I$t -g
+$CC -B. -o $t/exe1 $t/a.o -Wl,--separate-debug-file -L$t -lret
 readelf -SW $t/exe1 | grep -F .gnu_debuglink
 
 flock $t/exe1.dbg true
-gdb $t/exe1 -ex 'list main' -ex 'quit' | grep -F printf
+gdb $t/exe1 -ex 'list main' -ex 'quit' | grep -F return1
 
+# Ensure the internal names for headers didn't leak in (i.e. PHDR)
+# and that there is no corruption (either explicitly called out
+# or in the form of empty undefined symbols past the first one).
+# See issue #1535 for more details
 readelf -W --sections $t/exe1.dbg | not grep -E '[EPS]HDR'
+readelf -W --symbols $t/exe1.dbg | not grep -E '<corrupt>'
+readelf -W --symbols $t/exe1.dbg | not grep -E '^ *[0-9][0-9]:.*UND *$'
 
 
-$CC -c -o $t/a.o $t/a.c -g
-$CC -B. -o $t/exe2 $t/a.o -Wl,--separate-debug-file,--no-build-id
+$CC -c -o $t/a.o $t/a.c -g -I$t
+$CC -B. -o $t/exe2 $t/a.o -Wl,--separate-debug-file,--no-build-id -L$t -lret
 readelf -SW $t/exe2 | grep -F .gnu_debuglink
 
 flock $t/exe2.dbg true
-gdb $t/exe2 -ex 'list main' -ex 'quit' | grep -F printf
+gdb $t/exe2 -ex 'list main' -ex 'quit' | grep -F return1
 
 
-$CC -c -o $t/a.o $t/a.c -g
-$CC -B. -o $t/exe3 $t/a.o -Wl,--separate-debug-file,--compress-debug-sections=zlib
+$CC -c -o $t/a.o $t/a.c -g -I$t
+$CC -B. -o $t/exe3 $t/a.o -Wl,--separate-debug-file,--compress-debug-sections=zlib -L$t -lret
 readelf -SW $t/exe3 | grep -F .gnu_debuglink
 
 flock $t/exe3.dbg true
 readelf -W --sections $t/exe3.dbg | grep '\.debug_info .*C'
-gdb $t/exe3 -ex 'list main' -ex 'quit' | grep -F printf
+gdb $t/exe3 -ex 'list main' -ex 'quit' | grep -F return1


### PR DESCRIPTION
Originally discussed in #1535, the debug data generated by --separate-debug-file is being corrupted. In the best case scenario, there's many blank/nameless undefined symbols in the symtab, but in most production scenario I've encountered, the file is corrupt / gdb refuses to load it:

    $ gdb main
    Reading symbols from $PWD/main.dbg...
    BFD: /$PWD/main.dbg: invalid string offset 4130582 >= 1345 for section `.strtab'
    BFD: /$PWD/main.dbg: invalid string offset 16777228 >= 1345 for section `.strtab'

    $ readelf -Ws main.dbg
    Symbol table '.symtab' contains 139 entries:
    [...]
    38: 0000000000000000     0 SECTION LOCAL  DEFAULT   38 .strtab
    39: 0000000000000000     0 SECTION LOCAL  DEFAULT   39 .symtab
    40: 0018a80200010000 0xb10000003f071500 NOTYPE  LOCAL  DEFAULT bad section index[3232] <corrupt>
    41: 0000003f07140000 0xfd02000100000cc2 NOTYPE  LOCAL  HIDDEN  bad section index[11500] <corrupt>
    42: 02000100000cd300 0x3f0712000008a3 <unknown>: 7 LOCAL  PROTECTED [<other>: 3c]   UND <corrupt>
    43: 3f07110000056202 0x100000cf5000000 NOTYPE  LOCAL  DEFAULT    1 <corrupt>

This appears to be happening because the strtab size is set to be larger than its true value, causing garbage data to be placed in it, which breaks the symtab.

This regression occurred in 5b71029, which fixed a different form of corruption (the PHDR symbol escaping into the section headers, shifting the section offsets), but created this strtab corruption. The root cause is that `compute_section_headers` was moved prior to the wiping of irrelevant chunks. `compute_section_headers` computes the strtab size by adding up individual chunk strtab contributions. It needs to occur _after_ the wiping so that the strtab doesn't account for the data before the wipe.

The core of this patch is really just a partial revert of 5b71029--the compute_section_headers call appears to have been in the correct place prior to this change; I've added a test that catches the issue by intentionally bloating the size of the `.plt` section with many external symbols. This section is wiped in the dbg data, so by bloating it, the test can inspect for corruption.

Fixes #1535

---

My employer, MathWorks, has given me the permission to upstream this fix with the following legal disclaimer:

> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY.