### PR TITLE
Fix mingw ERROR macro collision

### DIFF
--- a/src/input-sections.cc
+++ b/src/input-sections.cc
@@ -121,7 +121,8 @@ void InputSection<E>::copy_contents_to(Context<E> &ctx, u8 *buf, i64 sz) {
   }
 }
 
-typedef enum : u8 { NONE, ERROR, COPYREL, PLT, CPLT } Action;
+// ERROR renamed to ACT_ERROR because mingw Windows headers already #define ERROR.
+typedef enum : u8 { NONE, ACT_ERROR, COPYREL, PLT, CPLT } Action;
 
 template <typename E>
 static void do_action(Context<E> &ctx, Action action, InputSection<E> &isec,
@@ -129,7 +130,7 @@ static void do_action(Context<E> &ctx, Action action, InputSection<E> &isec,
   switch (action) {
   case NONE:
     break;
-  case ERROR:
+  case ACT_ERROR:
     Error(ctx) << isec << ": " << rel << " relocation at offset 0x"
                << std::hex << rel.r_offset << " against symbol `"
                << sym << "' can not be used; recompile with -fPIC";
@@ -176,9 +177,9 @@ void InputSection<E>::scan_pcrel(Context<E> &ctx, Symbol<E> &sym,
   // linker generally does not support PC-relative relocations.
   static Action table[][4] = {
     // Absolute  Local    Imported data  Imported code
-    {  ERROR,    NONE,    ERROR,         PLT    },  // Shared object
-    {  ERROR,    NONE,    COPYREL,       CPLT   },  // Position-independent exec
-    {  NONE,     NONE,    COPYREL,       CPLT   },  // Position-dependent exec
+    {  ACT_ERROR, NONE,   ACT_ERROR,     PLT    },  // Shared object
+    {  ACT_ERROR, NONE,   COPYREL,       CPLT   },  // Position-independent exec
+    {  NONE,      NONE,   COPYREL,       CPLT   },  // Position-dependent exec
   };
 
   Action action = table[get_output_type(ctx)][get_sym_type(sym)];
@@ -195,9 +196,9 @@ void InputSection<E>::scan_absrel(Context<E> &ctx, Symbol<E> &sym,
   // resolved at link-time.
   static Action table[][4] = {
     // Absolute  Local    Imported data  Imported code
-    {  NONE,     ERROR,   ERROR,         ERROR },  // Shared object
-    {  NONE,     ERROR,   ERROR,         ERROR },  // Position-independent exec
-    {  NONE,     NONE,    COPYREL,       CPLT  },  // Position-dependent exec
+    {  NONE,     ACT_ERROR, ACT_ERROR,   ACT_ERROR },  // Shared object
+    {  NONE,     ACT_ERROR, ACT_ERROR,   ACT_ERROR },  // Position-independent exec
+    {  NONE,     NONE,      COPYREL,     CPLT      },  // Position-dependent exec
   };
 
   Action action = table[get_output_type(ctx)][get_sym_type(sym)];


### PR DESCRIPTION
Rename the InputSection action enum value ERROR to ACT_ERROR.

When building with mingw-based Windows toolchains, Windows headers may be pulled in through transitive includes (via tbb for instance). In that case wingdi.h defines ERROR as a macro, which collides with the enum value in input-sections.cc and breaks the build.

Rename the enum value to avoid the macro conflict.

## Context
As part of the [llvm](https://registry.bazel.build/modules/llvm) Bazel C/C++ toolchain module, i'm working on bringing support for choosing arbitrary linkers.
Since the toolchain is a fully hermetic cross-platform cross-compiling toolchain, it needs to build any dependencies from source to run on the platform where the compiler toolchain will be invoked. 

I authored Bazel build files for mold and am able build it from source as part of the end user build and wire it as a linker override for all platforms.
The only issue I encountered is for windows since our toolchain can currently only cross-compile for windows using mingw.

This is the only patch I had to do to make mold compile for windows using a mingw toolchain. 
If supporting mingw is an acceptable goal, this patch was the only one necessary !
