### PR TITLE
Support -w / --no-warnings to suppress warnings

### DIFF
--- a/docs/mold.md
+++ b/docs/mold.md
@@ -778,6 +778,9 @@ but as `-o magic`.
   directory, it is searched from library search paths for the sake of
   compatibility with GNU ld.
 
+* `-w`, `--no-warnings`:
+  Suppress warnings and cancel `--fatal-warnings`.
+
 * `--warn-common`, `--no-warn-common`:
   Warn about common symbols.
 

--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -62,6 +62,7 @@ Options:
   -s, --strip-all             Strip .symtab section
   -u SYMBOL, --undefined SYMBOL
                               Force to resolve SYMBOL
+  -w, --no-warnings           Suppress warnings
   -y SYMBOL, --trace-symbol SYMBOL
                               Trace references to SYMBOL
   --Bdynamic, --dy            Link against shared libraries (default)
@@ -1220,6 +1221,8 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.fatal_warnings = true;
     } else if (read_flag("no-fatal-warnings")) {
       ctx.arg.fatal_warnings = false;
+    } else if (read_flag("w") || read_flag("no-warnings")) {
+      ctx.arg.suppress_warnings = true;
     } else if (read_flag("fork")) {
       ctx.arg.fork = true;
     } else if (read_flag("no-fork")) {

--- a/test/no-warnings.sh
+++ b/test/no-warnings.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -fcommon -xc -c -o $t/a.o -
+int foo;
+EOF
+
+cat <<EOF | $CC -fcommon -xc -c -o $t/b.o -
+int foo;
+int main() { return 0; }
+EOF
+
+# Control: -warn-common emits a warning by default
+$CC -B. -o $t/exe $t/a.o $t/b.o -Wl,-warn-common 2> $t/log
+grep -q "multiple common symbols" $t/log
+
+# -w suppresses the warning
+$CC -B. -o $t/exe $t/a.o $t/b.o -Wl,-warn-common -Wl,-w 2> $t/log
+not grep -q "multiple common symbols" $t/log
+
+# --no-warnings does the same
+$CC -B. -o $t/exe $t/a.o $t/b.o -Wl,-warn-common -Wl,--no-warnings 2> $t/log
+not grep -q "multiple common symbols" $t/log
+
+# Sanity: -fatal-warnings without -w would have failed
+not $CC -B. -o $t/exe $t/a.o $t/b.o -Wl,-warn-common -Wl,-fatal-warnings 2> /dev/null
+
+# -w cancels -fatal-warnings (lld parity)
+$CC -B. -o $t/exe $t/a.o $t/b.o -Wl,-warn-common -Wl,-fatal-warnings -Wl,-w


### PR DESCRIPTION
The Warn() machinery has consulted ctx.arg.suppress_warnings since 6d2dbd42 ("Preparation to support Apple ld64's -w option", March 2023), but no cmdline flag ever set it. Wire -w (the GNU/BFD spelling) and --no-warnings (the lld long form) to set the field.

Because Warn::Warn early-returns when the flag is true, before the ctx.arg.fatal_warnings branch sets has_error, -w also cancels --fatal-warnings - matching lld's documented behavior.

The "warnings only" semantics match GCC, clang, and lld: real errors still print and still fail the link. BFD ld's -w is broader and suppresses error messages too, which would hide the cause of link failures.

Fixes https://github.com/rui314/mold/issues/1493