### PR TITLE
Don't emit PT_INTERP for -shared outputs

### DIFF
--- a/src/passes.cc
+++ b/src/passes.cc
@@ -158,7 +158,7 @@ void create_synthetic_sections(Context<E> &ctx) {
   if (ctx.shdr)
     ctx.shstrtab = push(new ShstrtabSection<E>);
 
-  if (!ctx.arg.dynamic_linker.empty())
+  if (!ctx.arg.dynamic_linker.empty() && (!ctx.arg.shared || ctx.arg.pie))
     ctx.interp = push(new InterpSection<E>);
   if (ctx.arg.build_id.kind != BuildId::NONE)
     ctx.buildid = push(new BuildIdSection<E>);

--- a/test/no-interp-on-shared.sh
+++ b/test/no-interp-on-shared.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Object with an entry point: used for PIE / runnable-.so cases
+cat <<EOF | $CC -fPIC -xc -c -o $t/a.o -
+void _start(void) {}
+EOF
+
+# Object without an entry point: used for the regular shared case
+cat <<EOF | $CC -fPIC -xc -c -o $t/b.o -
+int foo(void) { return 42; }
+EOF
+
+DL=/lib/ld.so
+
+# Control: bare -shared (no --dynamic-linker) must NOT emit PT_INTERP or .interp
+./mold -shared -o $t/control.so $t/b.o
+readelf -l $t/control.so | not grep INTERP
+readelf -S $t/control.so | not grep '\.interp'
+
+# Bug case: -shared with --dynamic-linker must NOT emit PT_INTERP or .interp
+./mold -shared --dynamic-linker=$DL -o $t/regular.so $t/b.o
+readelf -l $t/regular.so | not grep INTERP
+readelf -S $t/regular.so | not grep '\.interp'
+
+# Regression: -pie executable still gets PT_INTERP and .interp
+./mold -pie --dynamic-linker=$DL -e _start -o $t/pie-exe $t/a.o
+readelf -l $t/pie-exe | grep INTERP
+readelf -S $t/pie-exe | grep '\.interp'
+
+# Regression: -shared -pie (runnable .so) still gets PT_INTERP and .interp -- BFD parity
+./mold -shared -pie --dynamic-linker=$DL -e _start -o $t/runnable.so $t/a.o
+readelf -l $t/runnable.so | grep INTERP
+readelf -S $t/runnable.so | grep '\.interp'


### PR DESCRIPTION
When --dynamic-linker is passed alongside -shared, mold currently emits a .interp section and a PT_INTERP program header. Both lld and BFD ld silently drop --dynamic-linker for -shared outputs because shared libraries are loaded by the dynamic linker rather than bootstrapped by the kernel, so PT_INTERP serves no purpose there.

Gate .interp creation on (!shared || pie) so we keep it for regular executables, -pie executables, and -shared -pie runnable shared libraries (the libc.so.6-style case), and drop it only for the pure shared-library case. The PT_INTERP program header at output-chunks.cc:219 is conditional on ctx.interp being non-null, so the segment vanishes automatically with no second edit.

Fixes https://github.com/rui314/mold/issues/1572