### PR TITLE
--gdb-index: use DW_FORM_rnglistx index instead of iterating all offset entries

### DIFF
--- a/src/gdb-index.cc
+++ b/src/gdb-index.cc
@@ -456,11 +456,9 @@ read_address_ranges(Context<E> &ctx, const Compunit &cu) {
         Fatal(ctx) << "--gdb-index: missing DW_AT_rnglists_base";
 
       u8 *base = buf + rnglists_base;
-      i64 num_offsets = *(U32<E> *)(base - 4);
       Offset *offsets = (Offset *)base;
-
-      for (i64 i = 0; i < num_offsets; i++)
-        read_rnglist_range<E>(vec, base + offsets[i], addrx, low_pc.value);
+      read_rnglist_range<E>(vec, base + offsets[ranges.value], addrx,
+                            low_pc.value);
     }
     return vec;
   }

--- a/test/gdb-index-dwarf5-rnglistx.sh
+++ b/test/gdb-index-dwarf5-rnglistx.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Bug only triggers on DW_FORM_rnglistx, which clang emits but gcc through 13 doesn't.
+[ $MACHINE = $(uname -m) ] || skip
+clang++ --version >& /dev/null || skip
+echo 'int main() {}' | clang++ -gdwarf-5 -g -fexceptions -c -o /dev/null -xc++ - 2>/dev/null || skip
+
+# Throwing destructor + nested scopes => non-contiguous lexical_blocks => rnglistx.
+cat <<'EOF' > $t/a.cc
+void may_throw(int x) { if (x < 0) throw x; }
+struct Guard {
+  int val;
+  explicit Guard(int v) : val(v) {}
+  ~Guard() { may_throw(val); }
+};
+int work(int x) {
+  int r = 0;
+  { int a = x + 1;
+    { Guard g(a);
+      { int b = x * 2; may_throw(b); r = b; }
+      r += a; }
+    r += x; }
+  return r;
+}
+int main() { return work(3); }
+EOF
+
+clang++ -c -o $t/a.o $t/a.cc -gdwarf-5 -ggdb3 -fexceptions -O0 -fno-inline
+readelf --debug-dump=info $t/a.o | grep -E 'DW_AT_ranges.*\(index:' > /dev/null || skip
+
+clang++ -B. -o $t/exe $t/a.o -gdwarf-5 -ggdb3 -ggnu-pubnames -fexceptions \
+  -O0 -fno-inline -Wl,--gdb-index
+
+readelf -WS $t/exe | grep -F .gdb_index
+
+readelf --debug-dump=gdb_index $t/exe |
+  awk '/^Address table:/ { in_tab=1; next }
+       /^Symbol table:/ { in_tab=0 }
+       in_tab && NF==3 && $1 ~ /^[0-9a-f]+$/ { print $1, $2 }' |
+  sort > $t/addrtab
+
+# 16-char zero-padded hex; lexicographic compare == numeric compare.
+awk '{
+    if (NR > 1 && $1 < prev_hi) {
+      printf "overlap: previous range ends 0x%s, current starts 0x%s\n", prev_hi, $1
+      exit 1
+    }
+    prev_hi = $2
+  }' $t/addrtab
+
+# A wrong-index regression would be overlap-free but miss main's address.
+main_addr=$(readelf -s $t/exe | awk '$NF == "main" { print $2; exit }')
+awk -v a="$main_addr" '
+  BEGIN { found = 0 }
+  $1 <= a && a < $2 { found = 1; print "found main 0x" a " in [0x" $1 ", 0x" $2 ")"; exit }
+  END { if (!found) { print "main 0x" a " not covered"; exit 1 } }
+' $t/addrtab


### PR DESCRIPTION
A compile unit's DW_AT_ranges attribute in DW_FORM_rnglistx form holds an index into the offset table at DW_AT_rnglists_base; the corresponding entry locates the range list for that DIE. mold was ignoring the index and iterating every offset, picking up range lists belonging to child DIEs (subprograms, lexical_blocks, inlined_subroutines) that use DW_FORM_rnglistx as well.

The resulting .gdb_index address table contained child-DIE ranges nested inside the CU's range. GDB 17 detects the overlap, prints "warning: .gdb_index address table has a range (...) that overlaps with an earlier range, ignoring .gdb_index", and discards the index. Older GDBs accept the bloated table without complaint -- the duplicate entries all point to the same CU, so lookups still resolve correctly - which is why this went undetected for years.

The bug only triggers when a CU contains a non-contiguous lexical_block, which clang emits for scopes with EH landing pads from throwing RAII destructors. Replace the loop with offsets[ranges.value], matching the DW_FORM_sec_offset branch and GDB's own read_rnglist_index.

The new test invokes clang++ directly since DW_FORM_rnglistx is a clang-specific behavior; gcc through 13 uses DW_FORM_sec_offset, which mold has always handled correctly. The test skips cleanly if clang++ isn't installed or doesn't emit rnglistx for the source.

Reported by @MikeWang000000

Fixes https://github.com/rui314/mold/issues/1578