### PR TITLE
Include <windows.h> directly in mold.h

### DIFF
--- a/lib/perf.cc
+++ b/lib/perf.cc
@@ -5,7 +5,9 @@
 #include <ios>
 #include <tbb/concurrent_vector.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/resource.h>
 #include <sys/time.h>
 #endif

--- a/src/mold.h
+++ b/src/mold.h
@@ -25,7 +25,9 @@
 #include <variant>
 #include <vector>
 
-#ifndef _WIN32
+#ifdef _WIN32
+# include <windows.h>
+#else
 # include <unistd.h>
 #endif
 


### PR DESCRIPTION
mold.h uses HANDLE and INVALID_HANDLE_VALUE inside #ifdef _WIN32 but has never included <windows.h>. The MSYS2 UCRT64 build worked because <tbb/enumerable_thread_specific.h> (pulled in via lib/lib.h) used to #include <windows.h> for its TLS code.
    
oneTBB 2023.0.0 replaced that bulk include with forward declarations of just the TLS functions ("declare prototypes of just the needed TLS functions, instead of including whole windows.h"). When MSYS2 picked up 2023.0.0, build-msys started failing with "'HANDLE' does not name a type" at src/mold.h:224.
    
Include <windows.h> explicitly so the build doesn't rely on transitive paths through third-party headers.
    
Last passing run: https://github.com/rui314/mold/actions/runs/25585325507/job/75112599227
First failing run: https://github.com/rui314/mold/actions/runs/25767054228/job/75681837767