### PR TITLE
Increase max_thunk_size from 1 MiB to 8 MiB

### DIFF
--- a/src/thunks.cc
+++ b/src/thunks.cc
@@ -36,8 +36,8 @@ using E = MOLD_TARGET;
 // ARM64/ARM32/PPC, respectively.
 static constexpr i64 batch_size = branch_distance<E> / 5;
 
-// We assume that a single thunk group is smaller than 1 MiB.
-static constexpr i64 max_thunk_size = 1024 * 1024;
+// We assume that a single thunk group is smaller than 8 MiB.
+static constexpr i64 max_thunk_size = 8 * 1024 * 1024;
 
 // We align thunks to 16 byte boundaries because many processor vendors
 // recommend we align branch targets to 16 byte boundaries for performance


### PR DESCRIPTION
Large C++ debug libraries on ARM64 (e.g. deal.II's libdeal_II.g.so) can have batches whose first-pass thunk group exceeds 4 MiB — mostly PLT- routed DSO imports — tripping the assertion at thunks.cc:217. 8 MiB is the smallest clean power-of-two cap above the empirical threshold (4 MiB fails, 5 MiB works).

d_thunk_end already reserves max_thunk_size of space ahead of d, so a larger cap is safe by construction. No measurable wall-time or RSS impact in our testing.

Fixes #1538.