### PR TITLE
Adjust relocations after relaxation on LoongArch

### DIFF
--- a/src/arch-loongarch.cc
+++ b/src/arch-loongarch.cc
@@ -856,6 +856,7 @@ template <>
 void shrink_section(Context<E> &ctx, InputSection<E> &isec) {
   std::span<const ElfRel<E>> rels = isec.get_rels(ctx);
   std::vector<RelocDelta> &deltas = isec.extra.r_deltas;
+  std::unordered_map<i64, u32> &type_overrides = isec.extra.r_type_overrides;
   i64 r_delta = 0;
   u8 *buf = (u8 *)isec.contents.data();
 
@@ -924,8 +925,10 @@ void shrink_section(Context<E> &ctx, InputSection<E> &isec) {
       //
       //  addi.d  $t0, $tp, <tp-offset>
       if (i64 val = sym.get_addr(ctx) + r.r_addend - ctx.tp_addr;
-          is_int(val, 12))
+          is_int(val, 12)) {
+        type_overrides[i] = R_LARCH_NONE;
         remove(4);
+      }
       break;
     case R_LARCH_PCALA_HI20:
       // The following two instructions are used to materialize a
@@ -949,8 +952,11 @@ void shrink_section(Context<E> &ctx, InputSection<E> &isec) {
 
         if ((dist & 0b11) == 0 && is_int(dist, 22) &&
             is_addi_d && get_rd(insn1) == get_rd(insn2) &&
-            get_rd(insn2) == get_rj(insn2))
+            get_rd(insn2) == get_rj(insn2)) {
+          type_overrides[i] = R_LARCH_NONE;
+          type_overrides[i + 2] = R_LARCH_PCREL20_S2;
           remove(4);
+        }
       }
       break;
     case R_LARCH_CALL36:
@@ -965,8 +971,10 @@ void shrink_section(Context<E> &ctx, InputSection<E> &isec) {
       if (i64 dist = compute_distance(ctx, sym, isec, r);
           is_int(dist, 28))
         if (u32 jirl = *(ul32 *)(buf + rels[i].r_offset + 4);
-            get_rd(jirl) == 0 || get_rd(jirl) == 1)
+            get_rd(jirl) == 0 || get_rd(jirl) == 1) {
+          type_overrides[i] = R_LARCH_B26;
           remove(4);
+        }
       break;
     case R_LARCH_GOT_PC_HI20:
       // The following two instructions are used to load a symbol address
@@ -981,28 +989,54 @@ void shrink_section(Context<E> &ctx, InputSection<E> &isec) {
       //   pcaddi    $t0, <offset>
       if (is_relaxable_got_load(ctx, isec, i))
         if (i64 dist = compute_distance(ctx, sym, isec, r);
-            is_int(dist, 22) && (dist & 3) == 0)
+            is_int(dist, 22) && (dist & 3) == 0) {
+          type_overrides[i] = R_LARCH_NONE;
+          type_overrides[i + 2] = R_LARCH_PCREL20_S2;
           remove(4);
+        }
       break;
     case R_LARCH_TLS_DESC_PC_HI20:
       if (sym.has_tlsdesc(ctx)) {
         u64 P = isec.get_addr() + r.r_offset;
         i64 dist = sym.get_tlsdesc_addr(ctx) + r.r_addend - P;
-        if (is_int(dist, 22))
+        if (is_int(dist, 22) && i + 2 < rels.size() &&
+            rels[i + 2].r_type == R_LARCH_TLS_DESC_PC_LO12) {
+          type_overrides[i] = R_LARCH_NONE;
+          type_overrides[i + 2] = R_LARCH_TLS_DESC_PCREL20_S2;
           remove(4);
+        }
       } else {
+        type_overrides[i] = R_LARCH_NONE;
         remove(4);
       }
       break;
     case R_LARCH_TLS_DESC_PC_LO12:
-      if (!sym.has_tlsdesc(ctx))
+      if (!sym.has_tlsdesc(ctx)) {
+        type_overrides[i] = R_LARCH_NONE;
         remove(4);
+      }
       break;
     case R_LARCH_TLS_DESC_LD:
-      if (!sym.has_tlsdesc(ctx) && !sym.has_gottp(ctx))
-        if (i64 val = sym.get_addr(ctx) + r.r_addend - ctx.tp_addr;
-            0 <= val && val < 0x1000)
-          remove(4);
+      if (sym.has_tlsdesc(ctx)) {
+        // Do nothing
+      } else if (sym.has_gottp(ctx)) {
+        type_overrides[i] = R_LARCH_TLS_IE_PC_HI20;
+      } else if (i64 val = sym.get_addr(ctx) + r.r_addend - ctx.tp_addr;
+                 0 <= val && val < 0x1000) {
+        type_overrides[i] = R_LARCH_NONE;
+        remove(4);
+      } else {
+        type_overrides[i] = R_LARCH_TLS_LE_HI20;
+      }
+      break;
+    case R_LARCH_TLS_DESC_CALL:
+      if (sym.has_tlsdesc(ctx)) {
+        // Do nothing
+      } else if (sym.has_gottp(ctx)) {
+        type_overrides[i] = R_LARCH_TLS_IE_PC_LO12;
+      } else {
+        type_overrides[i] = R_LARCH_TLS_LE_LO12;
+      }
       break;
     }
   }

--- a/src/mold.h
+++ b/src/mold.h
@@ -493,11 +493,16 @@ struct RelocDelta {
 // offset need to be shifted towards the beginning of the section by
 // `delta` bytes when copying section contents to the output buffer.
 //
+// r_type_overrides holds the modified, new relocation types after relaxation.
+// Members in this map overrides the original rel.r_type in
+// RelocSection<E>::copy_buf.
+//
 // Since code-shrinking relaxation never bloats section contents, `delta`
 // increases monotonically within the vector as well.
 template <typename E> requires is_riscv<E> || is_loongarch<E>
 struct InputSectionExtras<E> {
   std::vector<RelocDelta> r_deltas;
+  std::unordered_map<i64, u32> r_type_overrides;
 };
 
 // InputSection represents a section in an input object file.

--- a/src/output-chunks.cc
+++ b/src/output-chunks.cc
@@ -3075,13 +3075,22 @@ void RelocSection<E>::copy_buf(Context<E> &ctx) {
     return {0, 0};
   };
 
-  auto write = [&](ElfRel<E> &out, InputSection<E> &isec, const ElfRel<E> &rel) {
+  auto write = [&](ElfRel<E> &out, InputSection<E> &isec, i64 idx,
+                   const ElfRel<E> &rel) {
     i64 symidx;
     i64 addend;
     std::tie(symidx, addend) = get_symidx_addend(isec, rel);
 
     i64 r_offset = isec.output_section->shdr.sh_addr + isec.offset + rel.r_offset;
-    out = ElfRel<E>(r_offset, rel.r_type, symidx, addend);
+    u32 r_type = rel.r_type;
+
+    if constexpr (is_riscv<E> || is_loongarch<E>) {
+      r_offset -= get_r_delta(isec, rel.r_offset);
+      if (isec.extra.r_type_overrides.contains(idx))
+        r_type = isec.extra.r_type_overrides[idx];
+    }
+
+    out = ElfRel<E>(r_offset, r_type, symidx, addend);
 
     if (ctx.arg.relocatable) {
       u8 *base = ctx.buf + isec.output_section->shdr.sh_offset + isec.offset;
@@ -3095,7 +3104,7 @@ void RelocSection<E>::copy_buf(Context<E> &ctx) {
     std::span<const ElfRel<E>> rels = isec.get_rels(ctx);
 
     for (i64 j = 0; j < rels.size(); j++)
-      write(buf[j], isec, rels[j]);
+      write(buf[j], isec, j, rels[j]);
   });
 }
 

--- a/test/arch-loongarch64-emit-relocs-relax.sh
+++ b/test/arch-loongarch64-emit-relocs-relax.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<'EOF' | $CC -o $t/a.o -c -xassembler -
+.text
+.globl _start
+_start:
+  move $s0, $ra
+
+  .reloc ., R_LARCH_RELAX
+  pcalau12i $t0, %pc_hi20(data_1)
+  .reloc ., R_LARCH_RELAX
+  addi.d $t0, $t0, %pc_lo12(data_1)
+  ld.d $t0, $t0, 0
+
+  .reloc ., R_LARCH_RELAX
+  pcalau12i $t1, %got_pc_hi20(data_2)
+  .reloc ., R_LARCH_RELAX
+  ld.d $t1, $t1, %got_pc_lo12(data_2)
+  ld.d $t1, $t1, 0
+
+  pcaddu18i $t2, %call36(call_target)
+  jirl $ra, $t2, 0
+  move $t2, $a0
+
+  add.d $a0, $t0, $t1
+  add.d $a0, $a0, $t2
+
+  pcaddu18i $t0, %call36(tail_target)
+  jirl $zero, $t0, 0
+
+call_target:
+  li.d $a0, 0x33
+  ret
+
+tail_target:
+  li.d $t0, 0x66
+  sub.d $a0, $a0, $t0
+  # exit(0)
+  li.d $a7, 93
+  syscall 0
+
+.section .rodata,"a"
+.p2align 2
+data_1:
+  .8byte 0x11
+
+.data
+.globl data_2
+.hidden data_2
+.p2align 3
+data_2:
+  .8byte 0x22
+EOF
+
+$CC -B. -o $t/exe $t/a.o --static -nostdlib -Wl,-e,_start,--emit-relocs,--relax
+$QEMU $t/exe
+
+$OBJDUMP -dr $t/exe > $t/exe.objdump
+grep -E 'R_LARCH_PCREL20_S2[[:space:]]+data_1' $t/exe.objdump
+grep -E 'R_LARCH_PCREL20_S2[[:space:]]+data_2' $t/exe.objdump
+grep -E 'R_LARCH_B26[[:space:]]+call_target' $t/exe.objdump
+grep -E 'R_LARCH_B26[[:space:]]+tail_target' $t/exe.objdump
+grep -Fw R_LARCH_NONE $t/exe.objdump
+
+not grep -Fw R_LARCH_PCALA_HI20 $t/exe.objdump
+not grep -Fw R_LARCH_PCALA_LO12 $t/exe.objdump
+not grep -Fw R_LARCH_GOT_PC_HI20 $t/exe.objdump
+not grep -Fw R_LARCH_GOT_PC_LO12 $t/exe.objdump
+not grep -Fw R_LARCH_CALL36 $t/exe.objdump

--- a/test/arch-loongarch64-emit-relocs-tls-relax.sh
+++ b/test/arch-loongarch64-emit-relocs-tls-relax.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# TLS LE
+
+cat <<'EOF' | $CC -o $t/le.o -c -xassembler -
+.text
+.globl foo
+foo:
+  lu12i.w $t0, %le_hi20_r(tls_local)
+  add.d $t0, $t0, $tp, %le_add_r(tls_local)
+  ld.d $a0, $t0, %le_lo12_r(tls_local)
+
+  .reloc ., R_LARCH_RELAX
+  pcalau12i $a0, %desc_pc_hi20(tls_local_small)
+  .reloc ., R_LARCH_RELAX
+  addi.d $a0, $a0, %desc_pc_lo12(tls_local_small)
+  .reloc ., R_LARCH_RELAX
+  ld.d $ra, $a0, %desc_ld(tls_local_small)
+  .reloc ., R_LARCH_RELAX
+  jirl $ra, $ra, %desc_call(tls_local_small)
+
+  .reloc ., R_LARCH_RELAX
+  pcalau12i $a0, %desc_pc_hi20(tls_local_large)
+  .reloc ., R_LARCH_RELAX
+  addi.d $a0, $a0, %desc_pc_lo12(tls_local_large)
+  .reloc ., R_LARCH_RELAX
+  ld.d $ra, $a0, %desc_ld(tls_local_large)
+  .reloc ., R_LARCH_RELAX
+  jirl $ra, $ra, %desc_call(tls_local_large)
+
+  ret
+
+.section .tbss,"awT",@nobits
+.globl tls_local
+.p2align 2
+tls_local:
+  .8byte 0
+
+.globl tls_local_small
+tls_local_small:
+  .8byte 0
+
+  .zero 8192
+
+.globl tls_local_large
+tls_local_large:
+  .8byte 0
+EOF
+
+cat <<'EOF' | $CC -o $t/le-main.o -c -xc -
+extern void foo(void);
+
+int main() {
+  foo();
+  return 0;
+}
+EOF
+
+$CC -B. -o $t/le $t/le.o $t/le-main.o -Wl,--emit-relocs,--relax
+$QEMU $t/le
+$OBJDUMP -dr $t/le > $t/le.objdump
+grep -E 'R_LARCH_TLS_LE_LO12_R[[:space:]]+tls_local' $t/le.objdump
+grep -E 'R_LARCH_TLS_LE_HI20[[:space:]]+tls_local_large' $t/le.objdump
+grep -E 'R_LARCH_TLS_LE_LO12[[:space:]]+tls_local_(small|large)' $t/le.objdump
+grep -Fw R_LARCH_NONE $t/le.objdump
+not grep -Fw R_LARCH_TLS_LE_HI20_R $t/le.objdump
+not grep -Fw R_LARCH_TLS_LE_ADD_R $t/le.objdump
+not grep -Fw R_LARCH_TLS_DESC_PC_HI20 $t/le.objdump
+not grep -Fw R_LARCH_TLS_DESC_PC_LO12 $t/le.objdump
+not grep -Fw R_LARCH_TLS_DESC_LD $t/le.objdump
+not grep -Fw R_LARCH_TLS_DESC_CALL $t/le.objdump
+
+# TLS DESC
+
+cat <<'EOF' | $CC -o $t/desc.o -c -xassembler -
+.text
+.globl bar
+bar:
+  .reloc ., R_LARCH_RELAX
+  pcalau12i $a0, %desc_pc_hi20(tlsdesc_external)
+  .reloc ., R_LARCH_RELAX
+  addi.d $a0, $a0, %desc_pc_lo12(tlsdesc_external)
+  .reloc ., R_LARCH_RELAX
+  ld.d $ra, $a0, %desc_ld(tlsdesc_external)
+  .reloc ., R_LARCH_RELAX
+  jirl $ra, $ra, %desc_call(tlsdesc_external)
+
+  .reloc ., R_LARCH_RELAX
+  pcalau12i $a0, %desc_pc_hi20(tlsdesc_ie)
+  .reloc ., R_LARCH_RELAX
+  addi.d $a0, $a0, %desc_pc_lo12(tlsdesc_ie)
+  .reloc ., R_LARCH_RELAX
+  ld.d $ra, $a0, %desc_ld(tlsdesc_ie)
+  .reloc ., R_LARCH_RELAX
+  jirl $ra, $ra, %desc_call(tlsdesc_ie)
+
+  ret
+EOF
+
+$CC -B. -shared -o $t/desc.so $t/desc.o -nostdlib -Wl,--emit-relocs,--relax
+$OBJDUMP -dr $t/desc.so > $t/desc.objdump
+grep -E 'R_LARCH_TLS_DESC_PCREL20_S2[[:space:]]+tlsdesc_external' \
+  $t/desc.objdump
+grep -E 'R_LARCH_TLS_DESC_LD[[:space:]]+tlsdesc_external' \
+  $t/desc.objdump
+grep -E 'R_LARCH_TLS_DESC_CALL[[:space:]]+tlsdesc_external' \
+  $t/desc.objdump
+not grep -Fw R_LARCH_TLS_DESC_PC_HI20 $t/desc.objdump
+not grep -Fw R_LARCH_TLS_DESC_PC_LO12 $t/desc.objdump
+
+# TLS IE
+
+cat <<'EOF' | $CC -o $t/ext.o -c -xassembler -
+.section .tbss,"awT",@nobits
+.globl tlsdesc_ie
+.p2align 2
+tlsdesc_ie:
+  .word 0
+EOF
+
+cat <<'EOF' | $CC -o $t/local.o -c -xassembler -
+.section .tbss,"awT",@nobits
+.globl tlsdesc_external
+.p2align 2
+tlsdesc_external:
+  .word 0
+EOF
+
+cat <<'EOF' | $CC -o $t/desc-main.o -c -xc -
+extern void bar(void);
+
+int main() {
+  bar();
+  return 0;
+}
+EOF
+
+$CC -B. -shared -o $t/def.so $t/ext.o -nostdlib
+$CC -B. -o $t/ie $t/desc.o $t/local.o $t/def.so $t/desc-main.o -Wl,--emit-relocs,--relax,-rpath=$t
+$QEMU $t/ie
+$OBJDUMP -dr $t/ie > $t/ie.objdump
+grep -E 'R_LARCH_TLS_IE_PC_HI20[[:space:]]+tlsdesc_ie' $t/ie.objdump
+grep -E 'R_LARCH_TLS_IE_PC_LO12[[:space:]]+tlsdesc_ie' $t/ie.objdump
+not grep -Fw R_LARCH_TLS_DESC_PC_HI20 $t/ie.objdump
+not grep -Fw R_LARCH_TLS_DESC_PC_LO12 $t/ie.objdump
+not grep -Fw R_LARCH_TLS_DESC_LD $t/ie.objdump
+not grep -Fw R_LARCH_TLS_DESC_CALL $t/ie.objdump


### PR DESCRIPTION
This PR adds relocation adjustment to discard stale ones after relaxation. For simplicity, this PR does not delete old relocation entries. Instead, we set them to `R_LARCH_NONE` to make them a no-op.

Fixes #1584. With this applied, relaxed instructions in <https://github.com/CSharperMantle/mold-issue-1584> are attached with correct relocations.

```console
$ make CC=clang CFLAGS='--target=loongarch64-unknown-linux-gnu' MOLD=~/workspace/mold-dev/build/mold disasm
clang  --target=loongarch64-unknown-linux-gnu -c repro.s -o repro.o
clang -nostdlib -static --ld-path=/home/csmantle/workspace/mold-dev/build/mold -Wl,--emit-relocs -o repro repro.o
objdump --disassemble --reloc repro

repro:     file format elf64-loongarch


Disassembly of section .text:

0000000000210278 <_start>:
  210278:       19f7ffcc        pcaddi          $t0, -16386
                        210278: R_LARCH_NONE    sym
                        210278: R_LARCH_RELAX   *ABS*
                        210278: R_LARCH_PCREL20_S2      sym
                        210278: R_LARCH_RELAX   *ABS*
  21027c:       19f7ffad        pcaddi          $t1, -16387
                        21027c: R_LARCH_NONE    sym
                        21027c: R_LARCH_RELAX   *ABS*
                        21027c: R_LARCH_PCREL20_S2      sym
                        21027c: R_LARCH_RELAX   *ABS*
  210280:       0381740b        li.w            $a7, 0x5d
  210284:       03800004        li.w            $a0, 0x0
  210288:       002b0000        syscall         0x0
```

---

**v2** (44859df922372d7664f708ac6db989e507ff9c80):
* Fix test bugs caused by <https://github.com/llvm/llvm-project/issues/107749>.
* Rebase.