### PR TITLE
Fix ambiguous readelf option in gdb-index-dwarf5 test

### DIFF
--- a/test/gdb-index-dwarf5.sh
+++ b/test/gdb-index-dwarf5.sh
@@ -63,8 +63,8 @@ $CC -c -o $t/d.o $t/d.c -fPIC -g -ggnu-pubnames -gdwarf-5 -ffunction-sections
 
 $CC -B. -shared -o $t/e.so $t/a.o $t/b.o $t/c.o $t/d.o -Wl,--gdb-index
 readelf -WS $t/e.so 2> /dev/null | grep -F .gdb_index
-readelf --debug=gdb_index $t/e.so 2> /dev/null | grep 'fn1: .* \[global, function\]'
-readelf --debug=gdb_index $t/e.so 2> /dev/null | grep 'char: .* \[static, type\]'
+readelf --debug-dump=gdb_index $t/e.so 2> /dev/null | grep 'fn1: .* \[global, function\]'
+readelf --debug-dump=gdb_index $t/e.so 2> /dev/null | grep 'char: .* \[static, type\]'
 
 cat <<EOF | $CC -c -o $t/f.o -fPIC -g -ggnu-pubnames -gdwarf-5 -xc - -gz
 void fn1();
@@ -76,7 +76,7 @@ EOF
 
 $CC -B. -o $t/exe $t/e.so $t/f.o -Wl,--gdb-index
 readelf -WS $t/exe 2> /dev/null | grep -F .gdb_index
-readelf --debug=gdb_index $t/exe 2> /dev/null | grep 'main: .* \[global, function\]'
+readelf --debug-dump=gdb_index $t/exe 2> /dev/null | grep 'main: .* \[global, function\]'
 
 $QEMU $t/exe | grep 'Hello world'
 


### PR DESCRIPTION
The binutils readelf command now accepts a --debug-dir=<DIR> option which
makes --debug=gdb_index ambiguous.
