### PR TITLE
perf: cache InputSection name to avoid per-call strlen

### DIFF
--- a/src/input-sections.cc
+++ b/src/input-sections.cc
@@ -33,8 +33,15 @@ bool cie_equals(const CieRecord<E> &a, const CieRecord<E> &b) {
 template <typename E>
 InputSection<E>::InputSection(Context<E> &ctx, ObjectFile<E> &file, i64 shndx)
   : file(file), shndx(shndx) {
-  if (shndx < file.elf_sections.size())
+  if (shndx < file.elf_sections.size()) {
     contents = {(char *)file.mf->data + shdr().sh_offset, (size_t)shdr().sh_size};
+    const char *p = file.shstrtab.data() + file.elf_sections[shndx].sh_name;
+    cached_name = std::string_view(p, strlen(p));
+  } else {
+    cached_name = (shdr().sh_flags & SHF_TLS)
+      ? std::string_view(".tls_common", 11)
+      : std::string_view(".common", 7);
+  }
 
   if (shdr().sh_flags & SHF_COMPRESSED) {
     ElfChdr<E> &chdr = *(ElfChdr<E> *)&contents[0];

--- a/src/mold.h
+++ b/src/mold.h
@@ -535,6 +535,9 @@ public:
 
   std::string_view contents;
 
+  // Cached to avoid per-call strlen on the shstrtab entry.
+  std::string_view cached_name;
+
   i32 fde_begin = -1;
   i32 fde_end = -1;
 
@@ -2942,9 +2945,7 @@ inline u64 InputSection<E>::get_addr() const {
 
 template <typename E>
 inline std::string_view InputSection<E>::name() const {
-  if (file.elf_sections.size() <= shndx)
-    return (shdr().sh_flags & SHF_TLS) ? ".tls_common" : ".common";
-  return file.shstrtab.data() + file.elf_sections[shndx].sh_name;
+  return cached_name;
 }
 
 template <typename E>


### PR DESCRIPTION
InputSection::name() implicitly converts a `const char *` to string_view, which calls strlen on the shstrtab entry at every call. Precompute the name as a string_view once in the constructor.

Linking clang Debug is ~1.3% faster; mlir-opt Debug is ~2.6% faster.