### PR TITLE
perf: cache symbol names to avoid per-call strlen

### DIFF
--- a/src/input-files.cc
+++ b/src/input-files.cc
@@ -94,6 +94,15 @@ InputFile<E>::InputFile(Context<E> &ctx, MappedFile *mf)
 }
 
 template <typename E>
+void InputFile<E>::populate_symbol_names() {
+  symbol_names.reserve(elf_syms.size());
+  for (const ElfSym<E> &esym : elf_syms) {
+    const char *p = symbol_strtab.data() + esym.st_name;
+    symbol_names.emplace_back(p, strlen(p));
+  }
+}
+
+template <typename E>
 ElfShdr<E> *InputFile<E>::find_section(i64 type) {
   for (ElfShdr<E> &sec : elf_sections)
     if (sec.sh_type == type)
@@ -329,7 +338,7 @@ void ObjectFile<E>::initialize_sections(Context<E> &ctx) {
         signature = this->shstrtab.data() +
                     this->elf_sections[get_shndx(esym)].sh_name;
       } else {
-        signature = this->symbol_strtab.data() + esym.st_name;
+        signature = this->symbol_names[shdr.sh_info];
       }
 
       // Ignore a broken comdat group GCC emits for .debug_macros.
@@ -646,7 +655,7 @@ void ObjectFile<E>::initialize_symbols(Context<E> &ctx) {
     if (esym.st_type == STT_SECTION)
       name = this->shstrtab.data() + this->elf_sections[get_shndx(esym)].sh_name;
     else
-      name = this->symbol_strtab.data() + esym.st_name;
+      name = this->symbol_names[i];
 
     Symbol<E> &sym = this->local_syms[i];
     sym.set_name(name);
@@ -674,7 +683,7 @@ void ObjectFile<E>::initialize_symbols(Context<E> &ctx) {
       has_common_symbol = true;
 
     // Get a symbol name
-    std::string_view key = this->symbol_strtab.data() + esym.st_name;
+    std::string_view key = this->symbol_names[i];
     std::string_view name = key;
 
     // Parse symbol version after atsign
@@ -889,6 +898,7 @@ void ObjectFile<E>::parse(Context<E> &ctx) {
     this->first_global = symtab_sec->sh_info;
     this->elf_syms = this->template get_data<ElfSym<E>>(ctx, *symtab_sec);
     this->symbol_strtab = this->get_string(ctx, symtab_sec->sh_link);
+    this->populate_symbol_names();
 
     if (ElfShdr<E> *shdr = this->find_section(SHT_SYMTAB_SHNDX))
       symtab_shndx_sec = this->template get_data<U32<E>>(ctx, *shdr);

--- a/src/lto-unix.cc
+++ b/src/lto-unix.cc
@@ -675,6 +675,7 @@ ObjectFile<E> *read_lto_object(Context<E> &ctx, MappedFile *mf) {
 
   obj->symbol_strtab = save_string(ctx, strtab);
   obj->elf_syms = obj->lto_elf_syms;
+  obj->populate_symbol_names();
   obj->initialize_symbols(ctx);
   plugin_symbols.clear();
   return obj;

--- a/src/mold.h
+++ b/src/mold.h
@@ -1709,6 +1709,11 @@ public:
   std::string_view shstrtab;
   std::string_view symbol_strtab;
 
+  // Parallel to elf_syms; cached to avoid per-call strlen.
+  std::vector<std::string_view> symbol_names;
+
+  void populate_symbol_names();
+
   bool as_needed = false;
   bool has_init_array = false;
   bool has_ctors = false;

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -2178,8 +2178,8 @@ void parse_symbol_version(Context<E> &ctx) {
       if (sym->file != file)
         continue;
 
-      const char *name = file->symbol_strtab.data() + file->elf_syms[i].st_name;
-      std::string_view ver = strchr(name, '@') + 1;
+      std::string_view name = file->symbol_names[i];
+      std::string_view ver = name.substr(name.find('@') + 1);
 
       bool is_default = false;
       if (ver.starts_with('@')) {


### PR DESCRIPTION
Several parse-time sites converted `symbol_strtab.data() + st_name` implicitly to string_view, running strlen on each call. Precompute a string_view vector parallel to elf_syms and read from it.