### PR TITLE
perf: pre-fault ConcurrentMap pages with MAP_POPULATE

### DIFF
--- a/lib/lib.h
+++ b/lib/lib.h
@@ -395,14 +395,19 @@ public:
     this->nbuckets = std::max<i64>(MIN_NBUCKETS, bit_ceil(nbuckets));
     i64 bufsize = sizeof(Entry) * this->nbuckets;
 
-    // Allocate a zero-initialized buffer. We use mmap() if available
-    // because it's faster than malloc() and memset().
+    // Allocate a zero-initialized buffer. mmap() is faster than
+    // malloc()+memset(), and MAP_POPULATE pre-faults pages here to
+    // avoid CoW faults and TLB shootdowns under concurrent inserts.
 #ifdef _WIN32
     entries = (Entry *)_aligned_malloc(bufsize, alignof(Entry));
     memset((void *)entries, 0, bufsize);
 #else
+    int flags = MAP_ANONYMOUS | MAP_PRIVATE;
+#ifdef MAP_POPULATE
+    flags |= MAP_POPULATE;
+#endif
     entries = (Entry *)mmap(nullptr, bufsize, PROT_READ | PROT_WRITE,
-                            MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+                            flags, -1, 0);
 #endif
   }
 


### PR DESCRIPTION
ConcurrentMap::insert reads ent.key before writing, so on an empty slot the read first installs a PTE pointing at the system zero page, then the CAS triggers wp_page_copy and a cross-CPU TLB shootdown. Under heavy parallel insertion this shows up as ~3% of link time in smp_call_function_many_cond plus a much larger inclusive cost in asm_exc_page_fault.

Pass MAP_POPULATE to pre-fault the whole map in the mmap() thread. Reads no longer install zero-page PTEs and writes no longer trigger CoW. Linking clang-23 Debug is ~5% faster, llvm-tblgen ~7%, clang-tblgen ~9%; max RSS rises by 0.1-0.6%. Falls back cleanly on platforms that don't define MAP_POPULATE.