### PR TITLE
ICF: don't fold sections with different alignments

### DIFF
--- a/src/icf.cc
+++ b/src/icf.cc
@@ -161,6 +161,7 @@ template <typename E>
 struct LeafHasher {
   size_t operator()(InputSection<E> *isec) const {
     u64 h = hash_string(isec->contents);
+    h = combine_hash(h, isec->p2align);
     for (FdeRecord<E> &fde : isec->get_fdes()) {
       u64 h2 = hash_string(fde.get_contents(isec->file).substr(8));
       h = combine_hash(h, h2);
@@ -173,6 +174,8 @@ template <typename E>
 struct LeafEq {
   bool operator()(InputSection<E> *a, InputSection<E> *b) const {
     if (a->contents != b->contents)
+      return false;
+    if (a->p2align != b->p2align)
       return false;
 
     std::span<FdeRecord<E>> x = a->get_fdes();
@@ -277,6 +280,7 @@ static Digest compute_digest(Context<E> &ctx, InputSection<E> &isec) {
 
   hash_string(isec.contents);
   hash(isec.shdr().sh_flags);
+  hash(isec.p2align);
   hash(isec.get_fdes().size());
   hash(isec.get_rels(ctx).size());
 

--- a/test/icf-align.sh
+++ b/test/icf-align.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# ICF folds two sections by hash/content equality only. If two read-only
+# sections have identical bytes but different alignment requirements, mold
+# must not fold them together: the follower would then resolve to the
+# leader's address, which may not satisfy the follower's alignment, and
+# any aligned-SIMD load against it would SIGSEGV.
+#
+# Use clang because mold relies on the .llvm_addrsig table that clang
+# generates to decide ICF eligibility. The data must be address-insignifi-
+# cant for ICF to consider folding, so the test files only access the
+# constants by subscript and never take their address.
+
+CLANG="${TEST_CLANG:-clang}"
+$CLANG --version > /dev/null 2>&1 || skip
+
+# Object 'a' is passed first, so its 4-byte-aligned constants get the
+# lower priority and would be chosen as ICF leaders.
+cat <<EOF | $CLANG -c -o $t/a.o -ffunction-sections -fdata-sections -fPIC -O2 -xc -
+__attribute__((aligned(4))) const int x[4] = {1, 2, 3, 4};
+int get_x(int i) { return x[i]; }
+EOF
+
+cat <<EOF | $CLANG -c -o $t/b.o -ffunction-sections -fdata-sections -fPIC -O2 -xc -
+__attribute__((aligned(16))) const int x_aligned[4] = {1, 2, 3, 4};
+int get_xa(int i) { return x_aligned[i]; }
+EOF
+
+./mold -shared -o $t/exe.so $t/a.o $t/b.o -icf=all \
+    --print-icf-sections=$t/icf.log
+
+# .rodata.x and .rodata.x_aligned have identical 16 bytes but different
+# alignment requirements. They must not be folded together.
+not grep -q x_aligned $t/icf.log


### PR DESCRIPTION
LeafHasher/LeafEq and compute_digest hashed and compared section contents but not p2align, so two sections with identical bytes but different alignment requirements could be folded together. The follower then resolved to the leader's address, which may not satisfy the follower's alignment, and an aligned SIMD load (e.g. movaps) against it would SIGSEGV.

Include p2align in the hash and equality check so such sections are kept distinct.

---

This fixes the following issue:

Building chromium with mold causes a `mksnapshot` segfault:
```
[1920/1920] ACTION //v8:run_mksnapshot_default(//build/toolchain/linux/unbundle:default)
ninja: job failed: python3 ../../v8/tools/run.py ./mksnapshot --turbo_instruction_scheduling --stress-turbo-late-spilling --target_os=linux --target_arch=x64 --embedded_src gen/v8/embedded.S --embedded_variant Default --random-seed 314159265 --startup_blob snapshot_blob.bin --no-native-code-counters
Return code is -11
ninja: subcommand failed
```

Reported here: https://github.com/rui314/mold/issues/336#issuecomment-2128636987

---

This PR is heavily AI-assisted, but reproduced locally (issue and fix). Please review carefully.