### PR TITLE
Fix PT_LOAD alignment issue

### DIFF
--- a/src/passes.cc
+++ b/src/passes.cc
@@ -2895,6 +2895,12 @@ static i64 set_file_offsets(Context<E> &ctx) {
       if (chunks[i]->shdr.sh_addr < first.shdr.sh_addr)
         break;
 
+      // This section requires larger alignment, we need to adjust the
+      // offset to ensure offset % align == vaddr % align.
+      if (chunks[i]->shdr.sh_addralign > ctx.page_size &&
+          chunks[i]->shdr.sh_addralign > chunks[i - 1]->shdr.sh_addralign)
+        break;
+
       i64 gap_size = chunks[i]->shdr.sh_addr - chunks[i - 1]->shdr.sh_addr -
                      chunks[i - 1]->shdr.sh_size;
 

--- a/test/program-header-align.sh
+++ b/test/program-header-align.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+cat <<EOF | $CC -o $t/a.o -c -xc -fno-PIC -
+__attribute__((section(".sum"))) __attribute__((aligned(8192))) void sum() {};
+int main() {}
+EOF
+
+$CC -B. -o $t/exe1 $t/a.o
+lines=$(readelf -Wl $t/exe1 | grep "LOAD")
+
+while IFS= read -ra line; do
+  read -ra row <<< "$line"
+  offset=${row[1]}
+  vaddr=${row[2]}
+  align=${row[-1]}
+  if (( offset % align != vaddr % align )); then
+    false
+  fi
+done <<< "$lines"


### PR DESCRIPTION
With a PT_LOAD segment, we need to make sure p_offset % p_align == p_vaddr % p_align. In set_file_offsets, we try to assign contiguous file offsets when sections are contiguous in memory. But when the alignment of section changes and it's bigger than page size, we cannot do that. The offset might need to be adjusted to follow the alignment rule.

A test binary with
`__attribute__((section(".sum"))) __attribute__((aligned(8192))) void sum() {}`

Section Headers:
```
[16] .plt.got          PROGBITS        00000000000015c0 0005c0 000008 00  AX  0   0 16
[17] .sum              PROGBITS        0000000000002000 001000 00000b 00  AX  0   0 8192
```
.sum section is assigned contiguous offset to its previous section. As a result, in create_phdr, .sum is mapped to the same PT_LOAD segment as previous sections.
```
Program Headers:

LOAD           0x000588 0x0000000000001588 0x0000000000001588 0x000b80 0x000b80 R E 0x2000
```
p_offset = 0x588
p_vaddr = 0x1588
p_align = 0x2000

So p_offset % p_align != p_vaddr % p_align, it violates the alignment rule. As a result, if this scenario happens to a shared library, it cannot be dlopen() on a system with glibc < 2.35 which is before this commit:
https://github.com/bminor/glibc/commit/163f625cf9becbb82dfec63a29e566324129c0cd.

Fix it by not assigning contiguous offset when section's alignment is different and it's bigger than page size.