### PR TITLE
icf: Do not fold relocations pointing to preemptible symbols

### DIFF
--- a/src/icf.cc
+++ b/src/icf.cc
@@ -255,7 +255,7 @@ static Digest compute_digest(Context<E> &ctx, InputSection<E> &isec) {
   auto hash_symbol = [&](Symbol<E> &sym) {
     InputSection<E> *isec = sym.get_input_section();
 
-    if (!sym.file) {
+    if (!sym.file || sym.is_imported) {
       hash('1');
       hash((u64)&sym);
     } else if (SectionFragment<E> *frag = sym.get_frag()) {

--- a/test/icf-preemption.sh
+++ b/test/icf-preemption.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# On PPC64V1, function pointers refer function descriptors in .opd
+# instead of directly referring .text section.
+[ $MACHINE = ppc64 ] && skip
+
+cat <<EOF | $CC -c -o $t/a.o -ffunction-sections -fPIC -xc -
+void local_fn(void) {}
+__attribute__((visibility("hidden"))) void local_fn_hidden(void) {
+  local_fn();
+}
+
+void global_fn(void) {}
+
+void caller_local(void) {
+  local_fn_hidden();
+}
+
+void caller_global(void) {
+  global_fn();
+}
+EOF
+
+# Link as shared library with --icf=all
+$CC -B. -shared -o $t/libtest.so $t/a.o -Wl,--icf=all -Wl,--print-icf-sections > $t/out 2>&1
+
+# Verify that caller_local and caller_global were NOT folded.
+# If they were folded, one of them would be removed.
+not grep -q "removing identical section.*caller_local" $t/out
+not grep -q "removing identical section.*caller_global" $t/out
+
+# Also check with nm to be sure they have different addresses
+nm $t/libtest.so | grep -E 'caller_local|caller_global' | awk '{print $1}' | uniq | wc -l | grep -q 2


### PR DESCRIPTION
If a relocation points to a preemptible (imported) symbol, it should not be considered identical to a relocation pointing to a local symbol, even if their targets currently have identical bodies. Preemptible symbols can be overridden at runtime, so we must preserve their unique identity.

Fixes #1598