### PR TITLE
icf: Merge alignments of folded sections

### DIFF
--- a/src/icf.cc
+++ b/src/icf.cc
@@ -614,6 +614,18 @@ void icf_sections(Context<E> &ctx) {
   if (!ctx.arg.print_icf_sections.empty())
     print_icf_sections(ctx);
 
+  // Update alignment of leaders.
+  {
+    Timer t(ctx, "update_alignment");
+    tbb::parallel_for_each(ctx.objs, [](ObjectFile<E> *file) {
+      for (std::unique_ptr<InputSection<E>> &isec : file->sections) {
+        if (isec && isec->is_alive && isec->leader && isec->leader != isec.get()) {
+          update_maximum(isec->leader->p2align, isec->p2align);
+        }
+      }
+    });
+  }
+
   // Eliminate duplicate sections.
   // Symbols pointing to eliminated sections will be redirected on the fly when
   // exporting to the symtab.

--- a/src/mold.h
+++ b/src/mold.h
@@ -546,7 +546,7 @@ public:
 
   // For COMDAT de-duplication and garbage collection
   Atomic<bool> is_alive = true;
-  u8 p2align = 0;
+  Atomic<u8> p2align = 0;
 
   // For ICF
   Atomic<bool> address_taken = false;

--- a/test/icf-alignment-bug.sh
+++ b/test/icf-alignment-bug.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# This test is only applicable to x86 and x86_64 because they use the lowest
+# bit of member function pointers for virtuality.
+case $MACHINE in
+  x86_64 | i686) ;;
+  *) skip ;;
+esac
+
+# We use assembly to define functions to have full control over alignment.
+# We swap the order so that regular_func (alignment 1) comes first and
+# is more likely to be chosen as the leader by ICF.
+# We make pre_func size 2 to try to make regular_func start at an odd address.
+cat <<EOF | $CC -c -o $t/fns.o -x assembler -
+  .text
+
+  .section .text.pre_func, "ax", @progbits
+  .globl pre_func
+  .p2align 0
+pre_func:
+  .byte 0x90, 0x90 # two nops (size 2)
+
+  .section .text.regular_func, "ax", @progbits
+  .globl regular_func
+  .p2align 0 # 1-byte alignment
+regular_func:
+  ret
+
+  .section .text.member_func, "ax", @progbits
+  .globl _ZN3Foo11member_funcEv
+  .p2align 2 # 4-byte alignment
+_ZN3Foo11member_funcEv:
+  ret
+EOF
+
+cat <<EOF | $CXX -c -o $t/main.o -xc++ -
+#include <iostream>
+#include <stdint.h>
+
+struct Foo {
+  void member_func();
+};
+
+extern "C" void regular_func();
+
+int main() {
+  void (Foo::*ptr)() = &Foo::member_func;
+  union {
+    void (Foo::*mem_ptr)();
+    struct {
+      void* ptr;
+      ptrdiff_t adj;
+    } parts;
+  } u;
+  u.mem_ptr = ptr;
+
+  std::cout << "member_func address:  " << u.parts.ptr << std::endl;
+  std::cout << "regular_func address: " << (void*)&regular_func << std::endl;
+
+  if (u.parts.ptr != (void*)&regular_func) {
+    std::cerr << "FAIL: functions were not folded!" << std::endl;
+    return 2;
+  }
+
+  if (reinterpret_cast<uintptr_t>(u.parts.ptr) & 1) {
+    std::cerr << "FAIL: member function pointer has odd address (treated as virtual)" << std::endl;
+    return 1;
+  }
+  return 0;
+}
+EOF
+
+$CXX -B. -o $t/exe $t/main.o $t/fns.o -Wl,--icf=all
+$QEMU $t/exe


### PR DESCRIPTION
When folding identical sections, ICF was discarding the alignment of the folded sections and only keeping the alignment of the chosen leader. If a section with stricter alignment (e.g. 4-byte) was folded into a section with looser alignment (e.g. 1-byte), the folded function could be placed at an odd address.

On x86/x86_64, member function pointers use the lowest bit of the address for virtual/non-virtual distinction. If a non-virtual member function is folded and placed at an odd address, it is incorrectly interpreted as virtual, leading to crashes. This fix ensures that we update the leader's alignment to be the maximum alignment of all folded sections. We do this in a global pass over all sections (both leaf and non-leaf merged sections) before the sweep phase.

Fixes #1596