### PR TITLE
Allow PC-relative relocations against absolute symbols in DSOs and PIEs.

### DIFF
--- a/src/input-sections.cc
+++ b/src/input-sections.cc
@@ -183,8 +183,8 @@ void InputSection<E>::scan_pcrel(Context<E> &ctx, Symbol<E> &sym,
   // linker generally does not support PC-relative relocations.
   static Action table[][4] = {
     // Absolute  Local    Imported data  Imported code
-    {  ERROR,    NONE,    ERROR,         PLT    },  // Shared object
-    {  ERROR,    NONE,    COPYREL,       CPLT   },  // Position-independent exec
+    {  NONE,     NONE,    ERROR,         PLT    },  // Shared object
+    {  NONE,     NONE,    COPYREL,       CPLT   },  // Position-independent exec
     {  NONE,     NONE,    COPYREL,       CPLT   },  // Position-dependent exec
   };
 

--- a/src/mold.h
+++ b/src/mold.h
@@ -3442,8 +3442,8 @@ inline bool Symbol<E>::is_absolute() const {
   if (is_remaining_undef_weak())
     return true;
 
-  return !is_imported && !get_frag() && !get_input_section() &&
-         !get_output_section();
+  return file && !file->is_dso && !esym().is_undef() &&
+         !get_frag() && !get_input_section() && !get_output_section();
 }
 
 template <typename E>

--- a/test/pcrel-absolute.sh
+++ b/test/pcrel-absolute.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Only run on x86_64 and i386 for simplicity of assembler syntax
+[[ $MACHINE = x86_64 ]] || [[ $MACHINE = i386 ]] || skip
+
+# Define absolute symbol
+cat <<EOF | $CC -c -o $t/a.o -xassembler -
+.globl foo
+foo = 0
+EOF
+
+# Use PC-relative relocation to it
+cat <<EOF | $CC -fPIC -c -o $t/b.o -xassembler -
+.text
+.globl bar
+bar:
+  .long foo - .
+EOF
+
+# Try to link into shared library.
+# Should succeed with our fix.
+$CC -B. -shared -o $t/libtest.so $t/a.o $t/b.o


### PR DESCRIPTION
Historically, mold reported an error for PC-relative relocations against absolute symbols in shared libraries and PIEs, because they are marked as imported (preemptible) and dynamic linkers do not support PC-relative dynamic relocations.

However, if the absolute symbol is defined locally, it does not need a dynamic relocation if we assume it is not preempted (matching lld behavior).

This change updates Symbol::is_absolute() to recognize locally defined symbols as absolute even if they are marked as imported for preemption. It also updates the scan_pcrel decision table to allow Absolute symbols (action NONE) in Shared objects and PIEs.

Added a test case test/pcrel-absolute.sh to verify this behavior.

Fixes #1573