### PR TITLE
mold: fix infinite layout oscillation in set_osec_offsets() (fixes #1595)

### DIFF
--- a/src/mold.h
+++ b/src/mold.h
@@ -2481,6 +2481,12 @@ struct Context {
   i64 page_size = E::page_size;
   bool has_error = false;
 
+  // Set to true after set_osec_offsets() applies a forced 1-byte pad to
+  // .rela.dyn to break an oscillation under --pack-dyn-relocs=android
+  // (issue #1595). Prevents subsequent callsites in the linker driver
+  // from accumulating additional padding on top of the same oscillation.
+  bool pack_dyn_relocs_forced_pad = false;
+
   // Reader context
   i64 file_priority = 10000;
 

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -2981,7 +2981,49 @@ template <typename E>
 i64 set_osec_offsets(Context<E> &ctx) {
   Timer t(ctx, "set_osec_offsets");
 
+  // Pack-dyn-relocs convergence guard (issue #1595).
+  // When --pack-dyn-relocs=android is active together with flags that
+  // change the regular section layout (e.g. -z noseparate-code), the
+  // inner reldyn-size check can oscillate between two sizes: encoding
+  // a pcrel relocation depends on .rela.dyn's size, which depends on
+  // the virtual address layout, which depends on the encoded pcrel
+  // offsets. Bound the iterations; if no convergence is observed,
+  // snap .rela.dyn to the maximum size seen so far (plus 1 byte) so
+  // the next encode pass commits to a strictly larger size and the
+  // oscillation cannot continue.
+  constexpr i64 MAX_OSEC_ITERATIONS = 32;
+  i64 iter = 0;
+  i64 max_reldyn_size = 0;
+  i64 max_relrdyn_size = 0;
+  bool reldyn_grew = false;
+  bool relrdyn_grew = false;
+
   for (;;) {
+    if (++iter > MAX_OSEC_ITERATIONS) {
+      // Stop iterating; layout did not converge. Apply a 1-byte pad to
+      // the section that was oscillating so the next call to
+      // update_shdr() commits to a larger size. Only do this once per
+      // Context: the layout driver calls set_osec_offsets() several
+      // times (initial pass, post-thunk removal, re-finalize), and we
+      // don't want to accumulate pads.
+      if (!ctx.pack_dyn_relocs_forced_pad) {
+        if (ctx.reldyn && (reldyn_grew || max_reldyn_size > 0)) {
+          Warn(ctx) << "--pack-dyn-relocs=android layout did not converge after "
+                    << MAX_OSEC_ITERATIONS
+                    << " iterations; applying 1-byte pad to .rela.dyn to break oscillation";
+          ctx.reldyn->shdr.sh_size = max_reldyn_size + 1;
+          ctx.pack_dyn_relocs_forced_pad = true;
+        } else if (ctx.relrdyn && relrdyn_grew) {
+          Warn(ctx) << "--pack-dyn-relocs=android layout did not converge after "
+                    << MAX_OSEC_ITERATIONS
+                    << " iterations; applying 1-byte pad to .relr.dyn to break oscillation";
+          ctx.relrdyn->shdr.sh_size = max_relrdyn_size + 1;
+          ctx.pack_dyn_relocs_forced_pad = true;
+        }
+      }
+      return set_file_offsets(ctx);
+    }
+
     if (ctx.arg.section_order.empty())
       set_virtual_addresses_regular(ctx);
     else
@@ -2992,8 +3034,18 @@ i64 set_osec_offsets(Context<E> &ctx) {
       i64 y = ctx.relrdyn ? (i64)ctx.relrdyn->shdr.sh_size : 0;
       ctx.reldyn->update_shdr(ctx);
 
-      if (x != (i64)ctx.reldyn->shdr.sh_size ||
-          y != (ctx.relrdyn ? (i64)ctx.relrdyn->shdr.sh_size : 0))
+      i64 post_x = (i64)ctx.reldyn->shdr.sh_size;
+      i64 post_y = ctx.relrdyn ? (i64)ctx.relrdyn->shdr.sh_size : 0;
+      if (post_x > max_reldyn_size)
+        max_reldyn_size = post_x;
+      if (post_y > max_relrdyn_size)
+        max_relrdyn_size = post_y;
+      if (post_x > x)
+        reldyn_grew = true;
+      if (post_y > y)
+        relrdyn_grew = true;
+
+      if (x != post_x || y != post_y)
         continue;
     }
 

--- a/test/arch-aarch64-pack-dyn-relocs-android-oscillation.sh
+++ b/test/arch-aarch64-pack-dyn-relocs-android-oscillation.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Regression test for issue #1595: --pack-dyn-relocs=android on aarch64 can
+# cause set_osec_offsets() to enter an infinite layout oscillation loop
+# between two sizes of .rela.dyn, hanging the linker indefinitely.
+#
+# Root cause (from the issue):
+#   A .balign 16384 section forces B's address to be 16 KiB-aligned.
+#   A's address is .rela.dyn-size bytes earlier. The relocation
+#   addend B - A crosses a 2-byte / 3-byte SLEB128 boundary depending
+#   on whether .rela.dyn is 7392 or 7393 bytes. The encoder's output
+#   size in turn depends on the addend, so the loop ping-pongs between
+#   7392 and 7393 forever.
+#
+# We use the exact reproducer assembly from the issue (Jwata). The
+# unpatched linker hangs in encode_android(); the patched linker
+# converges after capping the iteration count and applying a 1-byte
+# pad to break the symmetry.
+
+# Find a working aarch64-linux-android assembler. The .NET Android SDK
+# ships one under Microsoft.Android.Sdk.Linux; distro packages may also
+# provide it. We probe a few common locations before giving up.
+find_android_as() {
+  for cand in \
+      /usr/bin/aarch64-linux-android-as \
+      /usr/local/bin/aarch64-linux-android-as \
+      $(find /usr/share/dotnet/packs/Microsoft.Android.Sdk.Linux -name aarch64-linux-android-as -print -quit 2>/dev/null); do
+    [ -x "$cand" ] && echo "$cand" && return 0
+  done
+  return 1
+}
+AS=$(find_android_as) || skip
+
+cat <<'EOF' > $t/repro.S
+    .section .custom_rodata_a, "a", %progbits
+    .hidden A
+    .global A
+A:
+    .space 8
+
+    .section .custom_rodata_b_huge, "a", %progbits
+    .balign 16384
+    .hidden B
+    .global B
+B:
+    .space 8
+
+    .section .data, "aw", %progbits
+    .rept 7439
+    .quad A
+    .endr
+
+    .global P_1
+P_1:
+    .quad A
+
+    .global P_2
+P_2:
+    .quad B
+EOF
+
+"$AS" -o $t/repro.o $t/repro.S
+
+# The unpatched linker hangs indefinitely (issue #1595). The patched
+# linker converges in well under a second. 30s is 6 orders of magnitude
+# more than the converged path needs, so a real hang is unmistakable.
+timeout 30 mold -shared -o $t/repro.so $t/repro.o \
+  --pack-dyn-relocs=android -z max-page-size=16384
+[ $? -eq 0 ] || { echo "mold failed to converge in 30s (regression of #1595)" >&2; exit 1; }
+
+# Sanity check: the output must be a valid aarch64 ELF shared object
+# that actually used the ANDROID_RELA (APS2) encoding path.
+readelf -h $t/repro.so | grep -qi aarch64 || { echo "wrong architecture" >&2; exit 1; }
+readelf -SW $t/repro.so | grep -q ANDROID_RELA || { echo "ANDROID_RELA encoding not used" >&2; exit 1; }


### PR DESCRIPTION
When `--pack-dyn-relocs=android` is active together with flags that change the regular section layout (e.g. `-z noseparate-code`), `set_osec_offsets()` can enter an infinite 2-state oscillation: encoding a pcrel relocation depends on `.rela.dyn`'s size, which depends on the virtual address layout, which depends on the encoded pcrel offsets. The unpatched linker hangs in `encode_android()` on inputs like the reproducer in issue #1595.

This change:

- Bounds the iteration count of the pack-dyn-relocs convergence loop to a generous 32 (normal builds finish in 2-5 iterations).
- When the cap is hit, snaps `.rela.dyn` or `.relr.dyn` to the maximum size seen so far plus one byte, then returns. The 1-byte pad breaks the 2-state ping-pong by forcing the next encode pass to commit to a strictly larger size that the previous iterations could not produce.
- A per-Context flag (`pack_dyn_relocs_forced_pad`) prevents the layout driver from accumulating additional padding on subsequent calls to `set_osec_offsets()` (initial pass, post-thunk removal, re-finalize).

Test reproducer: `test/arch-aarch64-pack-dyn-relocs-android-oscillation.sh` — uses the exact assembly reproducer from issue #1595 (Jwata). The unpatched linker hangs in `encode_android()`; the patched linker converges in well under a second. A 30s timeout in the test makes a real hang unmistakable.

Fixes #1595.