### PR TITLE
parallelize flatten in create_output_sections

### DIFF
--- a/src/passes.cc
+++ b/src/passes.cc
@@ -8,6 +8,7 @@
 #include <regex>
 #include <shared_mutex>
 #include <tbb/enumerable_thread_specific.h>
+#include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>
 #include <tbb/parallel_sort.h>
 #include <unordered_set>
@@ -718,13 +719,14 @@ void create_output_sections(Context<E> &ctx) {
     osec->shdr.sh_addralign = 1 << p2align;
   }
 
-  for (std::unique_ptr<OutputSection<E>> &osec : ctx.osec_pool) {
+  tbb::parallel_for((i64)0, (i64)ctx.osec_pool.size(), [&](i64 i) {
+    std::unique_ptr<OutputSection<E>> &osec = ctx.osec_pool[i];
     osec->shdr.sh_flags = osec->sh_flags;
     osec->is_relro = is_relro(*osec);
     osec->members = flatten(osec->members_vec);
     osec->members_vec.clear();
     osec->members_vec.shrink_to_fit();
-  }
+  });
 
   // Add output sections and mergeable sections to ctx.chunks
   std::vector<Chunk<E> *> chunks;


### PR DESCRIPTION
`create_output_sections()` contains a serial loop over `ctx.osec_pool` that flattens per-object-file `members_vec` into a flat `members` vector for each output section. i've replaced the range-for loop with `tbb::parallel_for` since each `OutputSection` has its own independent `members_vec` and `members`; trivial to parallelize.