### PR TITLE
build: update dist.sh by refreshing all distro images 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,14 +43,17 @@
 # of the mold linker of the same version will have the exact same set of
 # features and behave exactly the same.
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14...4.3)
 project(mold VERSION 2.41.0)
 
 include(CMakeDependentOption)
+include(CheckCXXSourceCompiles)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
 
 add_executable(mold)
+# CXX_SCAN_FOR_MODULES exists in CMake 3.28+, and mold does not use C++ modules.
+set_property(TARGET mold PROPERTY CXX_SCAN_FOR_MODULES OFF)
 target_compile_features(mold PRIVATE cxx_std_20)
 
 if(MINGW)
@@ -133,20 +136,63 @@ if(MOLD_USE_MSAN)
   )
 endif()
 
-# Statically-link libstdc++ if -DMOLD_MOSTLY_STATIC=ON.
+# Statically-link some libraries if -DMOLD_MOSTLY_STATIC=ON.
 #
 # This option is intended to be used by `./dist.sh` script to create a
 # mold binary that works on various Linux distros. You probably don't
 # need nor want to set this to ON.
-option(MOLD_MOSTLY_STATIC "Statically link libstdc++ and some other libraries" OFF)
+option(MOLD_MOSTLY_STATIC "Statically link some libraries for portable Linux binaries" OFF)
+
 if(MOLD_MOSTLY_STATIC)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(MOLD_DEFAULT_USE_LIBCXX ON)
+    set(MOLD_DEFAULT_STATIC_LIBCXX ON)
+  else()
+    set(MOLD_DEFAULT_STATIC_LIBSTDCXX ON)
+  endif()
+
+  set(MOLD_DEFAULT_STATIC_ZLIB ON)
+  set(MOLD_DEFAULT_STATIC_BLAKE3 ON)
+  set(MOLD_DEFAULT_STATIC_ZSTD ON)
+endif()
+
+option(MOLD_USE_LIBCXX "Use libc++ as the C++ standard library" ${MOLD_DEFAULT_USE_LIBCXX})
+option(MOLD_STATIC_LIBSTDCXX "Statically link libstdc++" ${MOLD_DEFAULT_STATIC_LIBSTDCXX})
+option(MOLD_STATIC_LIBCXX "Statically link libc++ and libc++abi" ${MOLD_DEFAULT_STATIC_LIBCXX})
+option(MOLD_STATIC_ZLIB "Statically link zlib" ${MOLD_DEFAULT_STATIC_ZLIB})
+option(MOLD_STATIC_BLAKE3 "Statically link BLAKE3" ${MOLD_DEFAULT_STATIC_BLAKE3})
+option(MOLD_STATIC_ZSTD "Statically link zstd" ${MOLD_DEFAULT_STATIC_ZSTD})
+
+if(MOLD_STATIC_LIBCXX)
+  set(MOLD_USE_LIBCXX ON CACHE BOOL "Use libc++ as the C++ standard library" FORCE)
+endif()
+
+if(MOLD_STATIC_LIBSTDCXX AND (MOLD_USE_LIBCXX OR MOLD_STATIC_LIBCXX))
+  message(FATAL_ERROR "MOLD_STATIC_LIBSTDCXX cannot be used with MOLD_USE_LIBCXX or MOLD_STATIC_LIBCXX")
+endif()
+
+if(MOLD_STATIC_LIBSTDCXX)
   target_link_options(mold PRIVATE -static-libstdc++)
+endif()
+
+if(MOLD_USE_LIBCXX)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "MOLD_USE_LIBCXX requires Clang")
+  endif()
+
+  target_compile_options(mold PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>)
+  target_link_options(mold PRIVATE -stdlib=libc++)
+endif()
+
+if(MOLD_STATIC_LIBCXX)
+  target_link_options(mold PRIVATE -nostdlib++)
+  set(MOLD_LIBCXXABI_LINK_LIBRARIES -Wl,-Bstatic c++ c++abi -Wl,-Bdynamic)
 endif()
 
 # Find zlib. If libz.so is not found, we compile a bundled one and
 # statically-link it to mold.
 find_package(ZLIB QUIET)
-if(ZLIB_FOUND AND NOT MOLD_MOSTLY_STATIC)
+if(ZLIB_FOUND AND NOT MOLD_STATIC_ZLIB)
   target_link_libraries(mold PRIVATE ZLIB::ZLIB)
 else()
   set(ZLIB_BUILD_EXAMPLES OFF CACHE INTERNAL "")
@@ -159,7 +205,7 @@ endif()
 # Find BLAKE3 cryptographic hash library. Just like zlib, if libblkae3.so
 # is not found, we compile a bundled one and statically-link it to mold.
 find_package(BLAKE3 QUIET)
-if(BLAKE3_FOUND AND NOT MOLD_MOSTLY_STATIC)
+if(BLAKE3_FOUND AND NOT MOLD_STATIC_BLAKE3)
   target_link_libraries(mold PRIVATE BLAKE3::blake3)
 else()
   function(mold_add_blake3)
@@ -177,7 +223,7 @@ endif()
 include(CheckIncludeFile)
 check_include_file(zstd.h HAVE_ZSTD_H)
 
-if(HAVE_ZSTD_H AND NOT MOLD_MOSTLY_STATIC)
+if(HAVE_ZSTD_H AND NOT MOLD_STATIC_ZSTD)
   target_link_libraries(mold PRIVATE zstd)
 else()
   set(ZSTD_BUILD_PROGRAMS OFF)
@@ -237,17 +283,26 @@ option(MOLD_USE_SYSTEM_TBB "Use system or vendored TBB" OFF)
 if(MOLD_USE_SYSTEM_TBB OR BLAKE3_USE_TBB)
   find_package(TBB REQUIRED)
   target_link_libraries(mold PRIVATE TBB::tbb)
-else()
-  function(mold_add_tbb)
-    set(BUILD_SHARED_LIBS OFF)
-    set(TBB_TEST OFF CACHE INTERNAL "")
-    set(TBB_STRICT OFF CACHE INTERNAL "")
-    add_subdirectory(third-party/tbb EXCLUDE_FROM_ALL)
-    target_compile_definitions(tbb PRIVATE __TBB_DYNAMIC_LOAD_ENABLED=0)
-    target_link_libraries(mold PRIVATE TBB::tbb)
-  endfunction()
+  else()
+    function(mold_add_tbb)
+      set(BUILD_SHARED_LIBS OFF)
+      set(TBB_TEST OFF CACHE INTERNAL "")
+      set(TBB_STRICT OFF CACHE INTERNAL "")
+      add_subdirectory(third-party/tbb EXCLUDE_FROM_ALL)
+      # CXX_SCAN_FOR_MODULES exists in CMake 3.28+, and bundled TBB does not use C++ modules.
+      set_property(TARGET tbb PROPERTY CXX_SCAN_FOR_MODULES OFF)
+      target_compile_definitions(tbb PRIVATE __TBB_DYNAMIC_LOAD_ENABLED=0)
+      if(MOLD_USE_LIBCXX)
+        target_compile_options(tbb PRIVATE -stdlib=libc++)
+      endif()
+      target_link_libraries(mold PRIVATE TBB::tbb)
+    endfunction()
 
   mold_add_tbb()
+endif()
+
+if(MOLD_LIBCXXABI_LINK_LIBRARIES)
+  target_link_libraries(mold PRIVATE ${MOLD_LIBCXXABI_LINK_LIBRARIES})
 endif()
 
 # We always use Clang to build mold on Windows. MSVC can't compile mold.

--- a/dist.sh
+++ b/dist.sh
@@ -19,7 +19,7 @@
 # site the first time.
 #
 # The mold executable created by this script is statically linked to
-# libstdc++, but dynamically linked to glibc, libm and a few other
+# libc++, but dynamically linked to glibc, libm and a few other
 # libraries, as these libraries are almost always available on any Linux
 # system. We can't statically link glibc because doing so would disable
 # dlopen(), which is required to load the LTO linker plugin.
@@ -78,118 +78,126 @@ fi
 
 case $arch in
 x86_64)
-  # Debian 9 (Stretch) released in June 2017.
+  # Debian 10 was initially released on July 6th, 2019.
   #
   # We use a Google-provided mirror (gcr.io) instead of the official Docker
   # Hub (docker.io) because docker.io has a strict rate limit policy.
   #
-  # The toolchain in Debian 9 is too old to build mold, so we rebuild it
+  # The toolchain in Debian 10 is too old to build mold, so we rebuild it
   # from source. We download source archives from official sites and build
   # them locally, rather than downloading pre-built binaries from somewhere
   # else, to avoid relying on unverifiable third-party binary blobs. Podman
   # caches the result of each RUN command, so rebuilding is done only once
   # per host.
   cat <<EOF | $image_build
-FROM mirror.gcr.io/library/debian:stretch@sha256:c5c5200ff1e9c73ffbf188b4a67eb1c91531b644856b4aefe86a58d2f0cb05be
+FROM mirror.gcr.io/library/debian:buster@sha256:58ce6f1271ae1c8a2006ff7d3e54e9874d839f573d8009c20154ad0f2fb0a225
 ENV DEBIAN_FRONTEND=noninteractive TZ=UTC
 RUN sed -i -e '/^deb/d' -e 's/^# deb /deb /g' /etc/apt/sources.list && \
   echo 'Acquire::Retries "10"; Acquire::http::timeout "10"; Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-retries && \
   apt-get update && \
-  apt-get install -y --no-install-recommends wget file make gcc g++ zlib1g-dev libssl-dev ca-certificates && \
+  apt-get install -y --no-install-recommends wget file make gcc g++ zlib1g-dev libssl-dev ca-certificates xz-utils && \
   rm -rf /var/lib/apt/lists
 
-# Build CMake 3.27
+# Build GNU binutils 2.46.1
 RUN mkdir /build && \
   cd /build && \
-  wget -O- --progress=dot:mega https://cmake.org/files/v3.27/cmake-3.27.7.tar.gz | tar xzf - --strip-components=1 && \
-  ./bootstrap --parallel=\$(nproc) && \
-  make -j\$(nproc) && \
-  make install && \
-  rm -rf /build
-
-# Build GCC 14
-RUN mkdir /build && \
-  cd /build && \
-  wget -O- --progress=dot:mega https://ftpmirror.gnu.org/gcc/gcc-14.2.0/gcc-14.2.0.tar.gz | tar xzf - --strip-components=1 && \
-  mkdir gmp mpc mpfr && \
-  wget -O- --progress=dot:mega https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.gz | tar xzf - --strip-components=1 -C gmp && \
-  wget -O- --progress=dot:mega https://ftpmirror.gnu.org/mpc/mpc-1.3.1.tar.gz | tar xzf - --strip-components=1 -C mpc && \
-  wget -O- --progress=dot:mega https://ftpmirror.gnu.org/mpfr/mpfr-4.2.1.tar.gz | tar xzf - --strip-components=1 -C mpfr && \
-  ./configure --prefix=/usr --enable-languages=c,c++ --disable-bootstrap --disable-multilib && \
-  make -j\$(nproc) && \
-  make install && \
-  ln -sf /usr/lib64/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/libstdc++.so.6 && \
-  rm -rf /build
-
-# Build GNU binutils 2.43
-RUN mkdir /build && \
-  cd /build && \
-  wget -O- --progress=dot:mega https://ftpmirror.gnu.org/binutils/binutils-2.43.tar.gz | tar xzf - --strip-components=1 && \
+  wget --prefer-family=IPv4 -O- --progress=dot:mega https://ftpmirror.gnu.org/binutils/binutils-2.46.1.tar.gz | \
+  tar xzf - --strip-components=1 && \
   ./configure --prefix=/usr && \
   make -j\$(nproc) && \
   make install && \
   rm -fr /build
 
-# Build Python 3.12.7
+# Build Python 3.14.6
 RUN mkdir /build && \
   cd /build && \
-  wget -O- --progress=dot:mega https://www.python.org/ftp/python/3.12.7/Python-3.12.7.tgz | tar xzf - --strip-components=1 && \
+  wget --prefer-family=IPv4 -O- --progress=dot:mega https://www.python.org/ftp/python/3.14.6/Python-3.14.6.tgz | \
+  tar xzf - --strip-components=1 && \
   ./configure && \
   make -j\$(nproc) && \
   make install && \
   rm -rf /build
 
-# Build LLVM 20
+# Build CMake 4.3
 RUN mkdir /build && \
   cd /build && \
-  wget -O- --progress=dot:mega https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-20.1.3.tar.gz | tar xzf - --strip-components=1 && \
+  wget --prefer-family=IPv4 -O- --progress=dot:mega https://cmake.org/files/v4.3/cmake-4.3.3.tar.gz | \
+  tar xzf - --strip-components=1 && \
+  ./bootstrap --parallel=\$(nproc) -- -DCMAKE_USE_OPENSSL=OFF && \
+  make -j\$(nproc) && \
+  make install && \
+  rm -rf /build
+
+# Build Ninja 1.13
+RUN mkdir /build && \
+  cd /build && \
+  wget --prefer-family=IPv4 -O- --progress=dot:mega https://github.com/ninja-build/ninja/archive/refs/tags/v1.13.2.tar.gz | \
+  tar xzf - --strip-components=1 && \
+  python3 ./configure.py --bootstrap && \
+  mv ./ninja /usr/bin/ninja && \
+  rm -rf /build
+
+# Build LLVM 22 w/ clang and libc++
+RUN mkdir /build && \
+  cd /build && \
+  wget --prefer-family=IPv4 -O- --progress=dot:mega https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-22.1.8.tar.gz | \
+  tar xzf - --strip-components=1 && \
   mkdir b && \
-  cd b && \
-  cmake -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang ../llvm && \
-  cmake --build . -j\$(nproc) && \
-  cmake --install . --strip && \
+  cmake -S llvm -B b -GNinja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang \
+  -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt" \
+  -DLLVM_RUNTIME_TARGETS="x86_64-unknown-linux-gnu" \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  -DLIBCXX_INCLUDE_BENCHMARKS=OFF && \
+  cmake --build b && \
+  cmake --install b --strip && \
   rm -rf /build
 EOF
   ;;
 aarch64 | arm | ppc64le | s390x)
-  # Debian 11 (Bullseye) released in August 2021
+  # Debian 11 (Bullseye) was initially released on August 14th, 2021
   #
   # We don't want to build Clang for these targets on QEMU becuase it
   # would take an extremely long time. Also, I believe old Linux boxes
   # are typically x86-64.
   cat <<EOF | $image_build
-FROM mirror.gcr.io/library/debian:bullseye-20240904@sha256:8ccc486c29a3ad02ad5af7f1156e2152dff3ba5634eec9be375269ef123457d8
+FROM mirror.gcr.io/library/debian:bullseye-20260610@sha256:68cf0d859b046494f3c4288171bc477580e424f981d08f2a77742b982c32a38f
 ENV DEBIAN_FRONTEND=noninteractive TZ=UTC
 RUN sed -i -e '/^deb/d' -e 's/^# deb /deb /g' /etc/apt/sources.list && \
   echo 'Acquire::Retries "10"; Acquire::http::timeout "10"; Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-retries && \
   apt-get update && \
-  apt-get install -y --no-install-recommends build-essential gcc-10 g++-10 clang-16 cmake && \
-  ln -sf /usr/bin/clang-16 /usr/bin/clang && \
-  ln -sf /usr/bin/clang++-16 /usr/bin/clang++ && \
+  apt-get install -y --no-install-recommends build-essential gcc-10 g++-10 clang-19 libc++-19-dev cmake && \
+  ln -sf /usr/bin/clang-19 /usr/bin/clang && \
+  ln -sf /usr/bin/clang++-19 /usr/bin/clang++ && \
   rm -rf /var/lib/apt/lists
 EOF
   ;;
 riscv64)
+  # Debian 13 (Trixie) was initially released on August 9th, 2025
+  #
+  # This was the first Debian stable release that included riscv64
   cat <<EOF | $image_build
-FROM mirror.gcr.io/riscv64/debian:unstable-20240926@sha256:25654919c2926f38952cdd14b3300d83d13f2d820715f78c9f4b7a1d9399bf48
+FROM mirror.gcr.io/riscv64/debian:trixie-20260610@sha256:514de625d1bf895c317bb512d021c366c7a51c1ef0e92b0ce0700cb1f3408a77
 ENV DEBIAN_FRONTEND=noninteractive TZ=UTC
 RUN sed -i -e '/^URIs/d' -e 's/^# http/URIs: http/' /etc/apt/sources.list.d/debian.sources && \
   echo 'Acquire::Retries "10"; Acquire::http::timeout "10"; Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-retries && \
   apt-get update && \
-  apt-get install -y --no-install-recommends build-essential gcc-14 g++-14 clang-18 cmake && \
-  ln -sf /usr/bin/clang-18 /usr/bin/clang && \
-  ln -sf /usr/bin/clang++-18 /usr/bin/clang++ && \
+  apt-get install -y --no-install-recommends build-essential gcc-14 g++-14 clang-19 libc++-19-dev cmake && \
+  ln -sf /usr/bin/clang-19 /usr/bin/clang && \
+  ln -sf /usr/bin/clang++-19 /usr/bin/clang++ && \
   rm -rf /var/lib/apt/lists
 EOF
   ;;
 loongarch64)
+  # Debian sid snapshot from September 24, 2024
+  #
+  # This is the only available Debian OCI for loongarch64 as of June 2026
   cat <<EOF | $image_build
 FROM mirror.gcr.io/loongarch64/debian:sid@sha256:0356df4e494bbb86bb469377a00789a5b42bbf67d5ff649a3f9721b745cbef77
 ENV DEBIAN_FRONTEND=noninteractive TZ=UTC
 RUN sed -i -e 's!http[^ ]*!http://snapshot.debian.org/archive/debian-ports/20250620T014755Z!g' /etc/apt/sources.list && \
   echo 'Acquire::Retries "10"; Acquire::http::timeout "10"; Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-retries && \
   apt-get update && \
-  apt-get install -y --no-install-recommends build-essential gcc-14 g++-14 clang-19 cmake && \
+  apt-get install -y --no-install-recommends build-essential gcc-14 g++-14 clang-19 libc++-19-dev cmake && \
   ln -sf /usr/bin/clang-19 /usr/bin/clang && \
   ln -sf /usr/bin/clang++-19 /usr/bin/clang++ && \
   rm -rf /var/lib/apt/lists

--- a/test/cmake-libcxx-gcc.sh
+++ b/test/cmake-libcxx-gcc.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+[ -z "$TRIPLE" ] || skip
+
+build=$t/build
+
+if cmake -S $(dirname $0)/.. -B $build -DBUILD_TESTING=OFF \
+  -DCMAKE_CXX_COMPILER="$GXX" -DMOLD_USE_LIBCXX=ON >$t/configure.log 2>&1; then
+  false
+fi
+
+grep -F 'MOLD_USE_LIBCXX requires Clang' $t/configure.log


### PR DESCRIPTION
* update x86-64 to Debian 10. This has glibc 2.28 which matches the oldest actually used distro these days (rhel 8) and gcc-8.5 is new enough to bootstrap clang and libc++, which saves the whole gcc build step
* set the riscv64 target to use debian Trixie, which was the first stable release for that arch
* bullseye (arm,ppac,s390), trixie (riscv), and the loongarch sid snapshot all have clang-19 available
* make sure all images install the libc++-19-dev package to get libc++ static version