### PR TITLE
Add (default on) --as-needed-gc flag to remove DSOs used only by GC'ed sections

### DIFF
--- a/src/cmdline.cc
+++ b/src/cmdline.cc
@@ -81,6 +81,8 @@ Options:
     --no-apply-dynamic-relocs
   --as-needed                 Only set DT_NEEDED if used
     --no-as-needed
+  --as-needed-gc              Remove unused DSOs if they are only referenced by GC'ed sections
+    --no-as-needed-gc
   --audit LIBNAME             Set DT_AUDIT to the specified value
   --build-id [none,md5,sha1,sha256,fast,uuid,HEXSTRING]
                               Generate build ID
@@ -1230,6 +1232,10 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
       ctx.arg.gc_sections = true;
     } else if (read_flag("no-gc-sections")) {
       ctx.arg.gc_sections = false;
+    } else if (read_flag("as-needed-gc")) {
+      ctx.arg.as_needed_gc = true;
+    } else if (read_flag("no-as-needed-gc")) {
+      ctx.arg.as_needed_gc = false;
     } else if (read_flag("print-gc-sections")) {
       ctx.arg.print_gc_sections = "-";
     } else if (read_eq("print-gc-sections")) {

--- a/src/gc-sections.cc
+++ b/src/gc-sections.cc
@@ -151,6 +151,8 @@ static void visit_section(Context<E> &ctx, InputSection<E> *isec,
   for (const ElfRel<E> &rel : isec->get_rels(ctx)) {
     // Symbol can refer to either a section fragment or an input section.
     Symbol<E> &sym = *isec->file.symbols[rel.r_sym];
+    if (ctx.arg.as_needed_gc && sym.file && sym.file->is_dso)
+      sym.file->is_reachable.test_and_set();
     if (SectionFragment<E> *frag = sym.get_frag()) {
       frag->is_alive = true;
       continue;
@@ -229,10 +231,28 @@ static void sweep(Context<E> &ctx) {
 template <typename E>
 void gc_sections(Context<E> &ctx) {
   Timer t(ctx, "gc");
+
+  if (ctx.arg.as_needed_gc) {
+    for (SharedFile<E> *file : ctx.dsos)
+      if (file->as_needed)
+        file->is_reachable = false;
+
+    for (Symbol<E> *sym : ctx.arg.undefined)
+      if (sym->file && sym->file->is_dso)
+        sym->file->is_reachable = true;
+
+    for (Symbol<E> *sym : ctx.arg.require_defined)
+      if (sym->file && sym->file->is_dso)
+        sym->file->is_reachable = true;
+  }
+
   tbb::concurrent_vector<InputSection<E> *> rootset = collect_root_set(ctx);
   StartStopMap<E> start_stop_map = build_start_stop_map(ctx);
   mark(ctx, rootset, start_stop_map);
   sweep(ctx);
+
+  if (ctx.arg.as_needed_gc)
+    std::erase_if(ctx.dsos, [](SharedFile<E> *file) { return !file->is_reachable; });
 }
 
 using E = MOLD_TARGET;

--- a/src/mold.h
+++ b/src/mold.h
@@ -2425,6 +2425,7 @@ struct Context {
     bool allow_multiple_definition = false;
     bool allow_shlib_undefined = true;
     bool apply_dynamic_relocs = true;
+    bool as_needed_gc = true;
     bool be8 = false;
     bool color_diagnostics = false;
     bool default_symver = false;

--- a/test/as-needed-gc.sh
+++ b/test/as-needed-gc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Create a shared library
+cat <<EOF | $CC -o $t/libfoo.so -shared -fPIC -Wl,-soname,libfoo.so -xc -
+int foo() { return 42; }
+EOF
+
+# Create an object file with a dead function referencing foo(),
+# and a main() that does not reference foo().
+cat <<EOF | $CC -ffunction-sections -o $t/prog.o -c -xc -
+int foo();
+int dead() { return foo(); }
+int main() { return 0; }
+EOF
+
+# Link without flags (default behavior, should remove libfoo.so because of default-on as-needed-gc)
+$CC -B. -o $t/exe1 $t/prog.o -Wl,--as-needed -Wl,--gc-sections $t/libfoo.so
+readelf --dynamic $t/exe1 > $t/log1
+not grep -F 'Shared library: [libfoo.so]' $t/log1
+
+# Link with --no-as-needed-gc (should keep libfoo.so)
+$CC -B. -o $t/exe2 $t/prog.o -Wl,--as-needed -Wl,--no-as-needed-gc -Wl,--gc-sections $t/libfoo.so
+readelf --dynamic $t/exe2 > $t/log2
+grep -F 'Shared library: [libfoo.so]' $t/log2
+
+# Link without --gc-sections (should keep libfoo.so because dead() is not GC'ed)
+$CC -B. -o $t/exe3 $t/prog.o -Wl,--as-needed -Wl,--no-gc-sections $t/libfoo.so
+readelf --dynamic $t/exe3 > $t/log3
+grep -F 'Shared library: [libfoo.so]' $t/log3
+
+echo "OK"


### PR DESCRIPTION
`lld` does this by default. `bfd` and `gold` do not. See: https://crbug.com/529102889

This flag makes mold behave like `lld` when both `--as-needed` and `--gc-sections` are used. If a DSO is only referenced by sections that are garbage-collected, the DSO's `DT_NEEDED` entry will be omitted.