### PR TITLE
Remove DSOs used only by GC'ed sections

### DIFF
--- a/src/gc-sections.cc
+++ b/src/gc-sections.cc
@@ -151,6 +151,8 @@ static void visit_section(Context<E> &ctx, InputSection<E> *isec,
   for (const ElfRel<E> &rel : isec->get_rels(ctx)) {
     // Symbol can refer to either a section fragment or an input section.
     Symbol<E> &sym = *isec->file.symbols[rel.r_sym];
+    if (sym.file && sym.file->is_dso)
+      sym.file->is_reachable.test_and_set();
     if (SectionFragment<E> *frag = sym.get_frag()) {
       frag->is_alive = true;
       continue;
@@ -229,10 +231,25 @@ static void sweep(Context<E> &ctx) {
 template <typename E>
 void gc_sections(Context<E> &ctx) {
   Timer t(ctx, "gc");
+
+  for (SharedFile<E> *file : ctx.dsos)
+    if (file->as_needed)
+      file->is_reachable = false;
+
+  for (Symbol<E> *sym : ctx.arg.undefined)
+    if (sym->file && sym->file->is_dso)
+      sym->file->is_reachable = true;
+
+  for (Symbol<E> *sym : ctx.arg.require_defined)
+    if (sym->file && sym->file->is_dso)
+      sym->file->is_reachable = true;
+
   tbb::concurrent_vector<InputSection<E> *> rootset = collect_root_set(ctx);
   StartStopMap<E> start_stop_map = build_start_stop_map(ctx);
   mark(ctx, rootset, start_stop_map);
   sweep(ctx);
+
+  std::erase_if(ctx.dsos, [](SharedFile<E> *file) { return !file->is_reachable; });
 }
 
 using E = MOLD_TARGET;

--- a/test/as-needed-gc.sh
+++ b/test/as-needed-gc.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+. $(dirname $0)/common.inc
+
+# Create a shared library
+cat <<EOF | $CC -o $t/libfoo.so -shared -fPIC -Wl,-soname,libfoo.so -xc -
+int foo() { return 42; }
+EOF
+
+# Create an object file with a dead function referencing foo(),
+# and a main() that does not reference foo().
+cat <<EOF | $CC -ffunction-sections -o $t/prog.o -c -xc -
+int foo();
+int dead() { return foo(); }
+int main() { return 0; }
+EOF
+
+# Link with --as-needed and --gc-sections (should remove libfoo.so unconditionally now)
+$CC -B. -o $t/exe1 $t/prog.o -Wl,--as-needed -Wl,--gc-sections $t/libfoo.so
+readelf --dynamic $t/exe1 > $t/log1
+not grep -F 'Shared library: [libfoo.so]' $t/log1
+
+# Link with --as-needed but without --gc-sections (should keep libfoo.so because dead() is not GC'ed)
+$CC -B. -o $t/exe2 $t/prog.o -Wl,--as-needed -Wl,--no-gc-sections $t/libfoo.so
+readelf --dynamic $t/exe2 > $t/log2
+grep -F 'Shared library: [libfoo.so]' $t/log2
+
+echo "OK"


### PR DESCRIPTION
lld does this by default. See: https://crbug.com/529102889

If a DSO is only referenced by sections that are garbage-collected, the DSO's DT_NEEDED entry will be omitted.