### PR TITLE
Don't pull archive members for versioned DSO undefineds

### DIFF
--- a/src/input-files.cc
+++ b/src/input-files.cc
@@ -1386,10 +1386,9 @@ void SharedFile<E>::parse(Context<E> &ctx) {
 
     this->elf_syms2.push_back(esyms[i]);
 
-    // resolve_symbols only consults versyms[] for defined symbols
-    // (see SharedFile::resolve_symbols), so VER_NDX_GLOBAL is fine
-    // for undefined entries.
-    this->versyms.push_back(esyms[i].is_undef() ? (u16)VER_NDX_GLOBAL : ver);
+    // Keep the version index for undefined symbols as well; mark_live_objects
+    // needs it to avoid pulling archive members for versioned DSO undefineds.
+    this->versyms.push_back(ver);
 
     std::string_view name = this->symbol_strtab.data() + esyms[i].st_name;
 
@@ -1596,11 +1595,16 @@ SharedFile<E>::mark_live_objects(Context<E> &ctx,
       print_trace_symbol(ctx, *this, esym, sym);
 
     // We follow undefined symbols in a DSO only to handle
-    // --no-allow-shlib-undefined.
+    // --no-allow-shlib-undefined. A versioned DSO undefined will be resolved
+    // by the dynamic linker at runtime, so don't pull an archive member for it.
     if (esym.is_undef() && !esym.is_weak() && sym.file &&
-        (!sym.file->is_dso || !ctx.arg.allow_shlib_undefined) &&
-        !sym.file->is_reachable.test_and_set()) {
-      feeder(sym.file);
+        (!sym.file->is_dso || !ctx.arg.allow_shlib_undefined)) {
+      if (!sym.file->is_dso && versyms[i] != VER_NDX_GLOBAL &&
+          versyms[i] != VER_NDX_LOCAL)
+        continue;
+
+      if (!sym.file->is_reachable.test_and_set())
+        feeder(sym.file);
 
       if (sym.is_traced)
         Out(ctx) << "trace-symbol: " << *this << " keeps " << *sym.file

--- a/test/dso-undef-versioned.sh
+++ b/test/dso-undef-versioned.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+. $(dirname $0)/common.inc
+
+is_musl && skip
+
+# libbar.so provides bar@BAR_1.0.
+cat <<EOF | $CC -fPIC -c -o $t/a.o -xc -
+__asm__(".symver bar,bar@BAR_1.0");
+int bar(void) { return 42; }
+EOF
+
+echo 'BAR_1.0 { global: bar; local: *; };' > $t/b.map
+
+$CC -B. -shared -o $t/libbar.so $t/a.o -Wl,--version-script,$t/b.map
+
+# libfoo.so has a versioned undefined bar@BAR_1.0.
+cat <<EOF | $CC -fPIC -c -o $t/c.o -xc -
+__asm__(".symver bar,bar@BAR_1.0");
+int bar(void);
+int foo(void) { return bar(); }
+EOF
+
+$CC -B. -shared -o $t/libfoo.so $t/c.o -L$t -lbar -Wl,-rpath,$t
+
+# libbar.a also provides bar@BAR_1.0 (with a different value).
+cat <<EOF | $CC -fPIC -c -o $t/d.o -xc -
+__asm__(".symver bar,bar@BAR_1.0");
+int bar(void) { return 13; }
+EOF
+
+rm -f $t/e.a
+ar rcs $t/e.a $t/d.o
+
+cat <<EOF | $CC -fPIE -c -o $t/f.o -xc -
+int foo(void);
+int main(void) { return foo() - 42; }
+EOF
+
+# Archive before libfoo.so. It must not be pulled in.
+$CC -B. -pie -o $t/exe $t/f.o $t/e.a -L$t -lfoo -Wl,-rpath,$t
+
+nm $t/exe | not grep -E ' bar$'
+readelf --dyn-syms $t/exe | not grep -E ' bar$'
+$QEMU $t/exe


### PR DESCRIPTION
SharedFile::parse() used to set versyms[i] to VER_NDX_GLOBAL for all undefined symbols in a DSO, discarding their real version index. Because of that, a versioned DSO undefined symbol such as foo@VERSION was resolved to an unversioned symbol in an archive, pulling in the archive member and statically linking it into the output. This could cause crashes at runtime when the DSO reference was actually meant to be resolved by another DSO at load time.

Preserve the version index for DSO undefined symbols and skip archive extraction in mark_live_objects() when the DSO undefined symbol is versioned. The dynamic linker will resolve it from the DSO's DT_NEEDED dependencies at runtime.

Fixes https://github.com/rui314/mold/issues/1619

Tested on Arch Linux x86_64.