### PR TITLE
✨ Enable building mold with git reftable backend

### DIFF
--- a/lib/update-git-hash.cmake
+++ b/lib/update-git-hash.cmake
@@ -6,7 +6,37 @@ if(EXISTS "${SOURCE_DIR}/.git/HEAD")
 
   if(HASH MATCHES "^ref: (.*)")
     set(HEAD "${CMAKE_MATCH_1}")
-    if(EXISTS "${SOURCE_DIR}/.git/${HEAD}")
+    if(HEAD STREQUAL "refs/heads/.invalid")
+      # Git v2.45+ with config `feature.experimental`=true, config `extensions.refstorage`=reftable,
+      # or `--ref-format=reftable`, uses the new binary reftable format, which does not expose
+      # plaintext files and breaks our no-Git wishes as the HEAD hash is not directly stored.
+      #
+      # Provide an option to disable Git and fall back to no hash if desired. Else, best-effort
+      # attempt to find ans use Git.
+      option(MOLD_NO_GIT "Do not look for Git if the new reftable format is in use" OFF)
+      if(MOLD_NO_GIT)
+        set(HASH "")
+      else()
+        find_package(Git QUIET)
+        if (NOT Git_FOUND)
+          message(WARNING "In a git repo with a reftable format, but could not find Git. No hash will be embedded in the binary.")
+          set(HASH "")
+        else()
+          execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+            OUTPUT_VARIABLE git_output
+            RESULT_VARIABLE git_result
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+          if(git_result EQUAL 0)
+            set(HASH "${git_output}")
+          else()
+            message(WARNING "Git returned ${git_result} when querying the HEAD revision")
+          endif()
+        endif()
+      endif()
+    elseif(EXISTS "${SOURCE_DIR}/.git/${HEAD}")
       file(READ "${SOURCE_DIR}/.git/${HEAD}" HASH)
       string(STRIP "${HASH}" HASH)
     else()


### PR DESCRIPTION
The git reftable backend mirrors the file structure of the old backend, but only uses a binary table and removes .packed-refs. This means that mold's current checks detect the git repository as intact, but attempt to read refs that do not exist.

To fix this, first check if the HEAD points to "refs/heads/.invalid", which is how reftable is indicated without using the git CLI. Once we know we are in a reftable repo, use a new option, MOLD_NO_GIT, to gate attempts to find and use the Git executable. This enables us to attempt to use git while maintaining the same fallback paths of no hash if git is not present.

Resolves: #1621