### PR TITLE
Simplify ShardedMap

### DIFF
--- a/lib/lib.h
+++ b/lib/lib.h
@@ -528,18 +528,15 @@ public:
 // add(), which only appends the key and a caller-supplied payload to
 // a thread-local buffer binned by the key's hash. gather() then ends
 // the phase: it deduplicates the recorded keys into per-shard hash
-// tables and invokes `callback(payload, value)` for each record,
-// where `value` is the T created for (or found for) the record's key.
+// tables and invokes `callback(payload, value, key, created)` for
+// each record, where `value` is the T created for (or found for) the
+// record's key. `created` is true only for the call that created the
+// value, so callers can initialize it from the key there.
 //
 // Keys whose hashes fall into different shards never interact, and
 // each shard is processed by exactly one thread during gather(), so
 // unlike with a concurrent hash table, no synchronization is needed,
 // and each key is hashed only once, in add().
-//
-// Values are default-constructed. If a value needs to be initialized
-// from its key, e.g. to store the key in the value, pass an
-// `on_create(value, key)` callback, which is called exactly once per
-// value, when it's created.
 //
 // insert() is a mutex-protected slow path for keys that arrive
 // outside this pattern.
@@ -551,25 +548,15 @@ public:
     bins.local()[hash % NUM_SHARDS].push_back({key, hash, std::move(payload)});
   }
 
-  T *insert(std::string_view key) {
-    return insert(key, [](T &, std::string_view) {});
-  }
-
-  template <typename OnCreate>
-  T *insert(std::string_view key, OnCreate on_create) {
+  std::pair<T *, bool> insert(std::string_view key) {
     u64 hash = hash_string(key);
     Shard &shard = shards[hash % NUM_SHARDS];
     std::scoped_lock lock(shard.mu);
-    return shard.insert(key, hash, on_create);
+    return shard.insert(key, hash);
   }
 
   template <typename Callback>
   void gather(Callback callback) {
-    gather([](T &, std::string_view) {}, callback);
-  }
-
-  template <typename OnCreate, typename Callback>
-  void gather(OnCreate on_create, Callback callback) {
     tbb::parallel_for((i64)0, NUM_SHARDS, [&](i64 i) {
       Shard &shard = shards[i];
 
@@ -582,8 +569,10 @@ public:
       shard.map.reserve(shard.map.size() + count);
 
       for (Bin &bin : bins)
-        for (Pending &p : bin[i])
-          callback(p.payload, shard.insert(p.key, p.hash, on_create));
+        for (Pending &p : bin[i]) {
+          auto [val, created] = shard.insert(p.key, p.hash);
+          callback(p.payload, val, p.key, created);
+        }
     });
 
     bins.clear();
@@ -607,20 +596,16 @@ private:
     }
   };
 
+  // Values live directly in the map; std::unordered_map keeps value
+  // addresses stable across rehashing.
   struct Shard {
-    template <typename OnCreate>
-    T *insert(std::string_view key, u64 hash, OnCreate on_create) {
-      auto [it, inserted] = map.try_emplace({hash, key}, nullptr);
-      if (inserted) {
-        it->second = &pool.emplace_back();
-        on_create(*it->second, key);
-      }
-      return it->second;
+    std::pair<T *, bool> insert(std::string_view key, u64 hash) {
+      auto [it, created] = map.try_emplace({hash, key});
+      return {&it->second, created};
     }
 
     std::mutex mu;
-    std::unordered_map<std::pair<u64, std::string_view>, T *, PassThroughHash> map;
-    std::deque<T> pool;
+    std::unordered_map<std::pair<u64, std::string_view>, T, PassThroughHash> map;
   };
 
   using Bin = std::array<std::vector<Pending>, NUM_SHARDS>;

--- a/src/input-files.cc
+++ b/src/input-files.cc
@@ -16,10 +16,12 @@ namespace mold {
 template <typename E>
 Symbol<E> *get_symbol(Context<E> &ctx, std::string_view key,
                       std::string_view name) {
-  return ctx.symbol_map.insert(key, [&](Symbol<E> &sym, std::string_view) {
-    sym.set_name(name);
-    sym.demangle = ctx.arg.demangle;
-  });
+  auto [sym, created] = ctx.symbol_map.insert(key);
+  if (created) {
+    sym->set_name(name);
+    sym->demangle = ctx.arg.demangle;
+  }
+  return sym;
 }
 
 template <typename E>

--- a/src/lto-unix.cc
+++ b/src/lto-unix.cc
@@ -676,7 +676,7 @@ ObjectFile<E> *read_lto_object(Context<E> &ctx, MappedFile *mf) {
     // have input sections.
     if (psym.comdat_key) {
       std::string_view key = save_string(ctx, psym.comdat_key);
-      obj->lto_comdat_groups[i + 1] = ctx.comdat_groups.insert(key);
+      obj->lto_comdat_groups[i + 1] = ctx.comdat_groups.insert(key).first;
     }
   }
 

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -315,11 +315,12 @@ void gather_symbols(Context<E> &ctx) {
   Timer t(ctx, "gather_symbols");
 
   ctx.symbol_map.gather(
-    [&](Symbol<E> &sym, std::string_view key) {
-      sym.set_name(key.substr(0, key.find('@')));
-      sym.demangle = ctx.arg.demangle;
-    },
-    [](std::pair<InputFile<E> *, i32> &ref, Symbol<E> *sym) {
+    [&](std::pair<InputFile<E> *, i32> &ref, Symbol<E> *sym,
+        std::string_view key, bool created) {
+      if (created) {
+        sym->set_name(key.substr(0, key.find('@')));
+        sym->demangle = ctx.arg.demangle;
+      }
       ref.first->symbols[ref.second] = sym;
     });
 }
@@ -380,7 +381,8 @@ void resolve_symbols(Context<E> &ctx) {
   // object files after that, in which case we redo symbol resolution
   // and take this path again.
   ctx.comdat_groups.gather(
-    [](std::pair<ObjectFile<E> *, i32> &ref, ComdatGroup *group) {
+    [](std::pair<ObjectFile<E> *, i32> &ref, ComdatGroup *group,
+       std::string_view, bool) {
       ref.first->comdat_groups[ref.second].group = group;
     });
 


### PR DESCRIPTION
Fold the `on_create` callback into the main `gather`/`insert` interface: `insert()` now returns `std::pair<T *, bool>` and `gather()`'s callback receives `(payload, value, key, created)`, so callers initialize newly-created values themselves behind `if (created)`. This removes the second `gather()` overload and the `OnCreate` template parameter threaded through `Shard::insert`.

Also store `T` directly in the shard map instead of behind a `T *` into a side deque; `std::unordered_map` keeps value addresses stable across rehashing, so pointer stability is unchanged and the pool is redundant.

Performance properties are preserved: keys are still hashed exactly once (in `add()`), and `gather()` still pre-reserves each shard.

Testing:
- All 5694 tests pass (Release build).
- A/B benchmark vs baseline 1d306dc0, alternating runs, medians:
  - chrome-debug-x86_64: 2.76s → 2.77s
  - chrome-release-x86_64: 1.075s → 1.07s (10 runs each)
  - clang-release: 0.15s → 0.14s
- `--perf` phase times for gather_symbols/resolve_symbols on chrome-debug-x86_64 match within noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)