### PR TITLE
Skip hidden base-version symbols in DSOs

### DIFF
--- a/src/input-files.cc
+++ b/src/input-files.cc
@@ -1465,6 +1465,20 @@ void SharedFile<E>::parse(Context<E> &ctx) {
       ver = VER_NDX_GLOBAL;
     }
 
+    // A defined symbol at the base version with the hidden bit set is a
+    // legacy compat alias. GNU as emits one for `.symver foo, foo@VER`
+    // without the `remove` modifier, so that binaries linked before the
+    // symbol was versioned keep resolving. A new reference to `foo` must
+    // bind to the default version instead. Such a symbol cannot be referred
+    // to by any name, as there is no version string to form `foo@VER` from,
+    // so skip it. Otherwise it would claim the unversioned name and beat
+    // the `foo@@VER` definition in resolve_symbols, which tie-breaks on
+    // dynsym order. lksctp-tools' libsctp.so.1 exports sctp_connectx
+    // this way.
+    if (!vers.empty() && (vers[i] & VERSYM_HIDDEN) &&
+        ver == VER_NDX_GLOBAL && !esyms[i].is_undef())
+      continue;
+
     this->elf_syms2.push_back(esyms[i]);
 
     // resolve_symbols only consults versyms[] for defined symbols

--- a/test/versym-hidden-base-def.sh
+++ b/test/versym-hidden-base-def.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+. $(dirname $0)/common.inc
+
+# musl's dynamic linker ignores symbol versioning, so it may resolve the
+# reference to either definition.
+is_musl && skip
+
+# A defined dynamic symbol at the base version (VER_NDX_GLOBAL) with the
+# hidden bit set is a legacy compat alias. GNU as emits one for
+# `.symver foo, foo@VER1` without the `remove` modifier so that binaries
+# linked before the symbol was versioned keep resolving. Such a symbol must
+# not satisfy a new unversioned reference to `foo`; that has to bind to the
+# default version `foo@@VER3` instead.
+#
+# lksctp-tools' libsctp.so.1 ships sctp_connectx this way. Binding to the
+# alias silently selects the old ABI, which never fills in the caller's
+# association ID.
+
+cat <<EOF | $CC -fPIC -c -o $t/a.o -xc -
+int foo_v1() { return 1; }
+int foo_v3() { return 3; }
+__asm__(".symver foo_v1, foo@VER1");
+__asm__(".symver foo_v3, foo@@VER3");
+EOF
+
+cat <<EOF > $t/a.ver
+VER1 { global: foo; local: *; };
+VER3 { global: foo; } VER1;
+EOF
+
+$CC -B. -shared -o $t/a.so $t/a.o -Wl,--version-script=$t/a.ver
+
+# Rewrite foo@VER1's .gnu.version entry with VER_NDX_GLOBAL | VERSYM_HIDDEN.
+# Current binutils drops the compat alias rather than emitting it, so patch
+# the file with dd. st_name already points to plain "foo"; only the version
+# index tells the two entries apart.
+idx=$(readelf --dyn-syms -W $t/a.so |
+      awk '$8 == "foo@VER1" { sub(/:/, "", $1); print $1 }')
+off=$(readelf -SW $t/a.so | sed 's/\[ *[0-9]*\]//' |
+      awk '$1 == ".gnu.version" { print $4 }')
+[ -n "$idx" ] || skip
+[ -n "$off" ] || skip
+
+off=$((16#$off + idx * 2))
+case $(od -A n -t x1 -j $off -N 2 $t/a.so | tr -d ' ') in
+0280) printf '\x01\x80' | dd of=$t/a.so bs=1 seek=$off conv=notrunc status=none ;;
+8002) printf '\x80\x01' | dd of=$t/a.so bs=1 seek=$off conv=notrunc status=none ;;
+*) skip ;;
+esac
+
+cat <<EOF | $CC -c -o $t/b.o -xc -
+int foo();
+int main() { return foo() == 3 ? 0 : 1; }
+EOF
+
+$CC -B. -o $t/exe $t/b.o $t/a.so -Wl,-rpath,$t
+
+# The reference must end up with a VER3 requirement. Without one the dynamic
+# linker cannot reach foo@@VER3 at all: glibc rejects a non-base version for
+# an unversioned lookup, so it would silently pick the compat alias.
+readelf -V $t/exe | grep -q 'Name: VER3'
+$QEMU $t/exe


### PR DESCRIPTION
Hi @rui314 ,
we are using mold linker in OCUDU project: https://gitlab.com/ocudu/ocudu
Recently we had an issue with `sctp_connectx()` from `libsctp` bind to the wrong symbol: https://gitlab.com/ocudu/ocudu/-/work_items/379
The problem is not happening with ld.bfd linker.

The root cause seems to be that `VERSYM_HIDDEN` bit is cleared before deciding whether a shared-library symbol was versioned. Because of that, libsctp's hidden compat alias for `sctp_connectx` is passed as an ordinary unversioned definition and is chosen instead of `sctp_connectx@@VERS_3` — leaving the binary with no `VERS_3` requirement that we would need in runtime. 

With AI assistance I managed to reproduce the issue (`test/versym-hidden-base-def.sh`) on the main branch and fix it. All the tests I could run locally pass, but it's my first time interacting with mold codebase. Can you have a look?

(I've tried to look for similar issues/PRs already open, I've seen https://github.com/rui314/mold/pull/1620 but as far as I understand it's a different thing related to undefined DSO symbols. There were also some Arch Linux issues I've noticed and this issue was also discovered on Arch Linux, but I'm able to reproduce it on Ubuntu 26.04 too.)

Thanks!

Best Regards,
Frank