### PR TITLE
Guard parse_sframe() against a zero-size .sframe section

### DIFF
--- a/src/input-files.cc
+++ b/src/input-files.cc
@@ -805,6 +805,15 @@ void ObjectFile<E>::parse_sframe(Context<E> &ctx) requires supports_sframe<E> {
     isec->kill();
 
     std::string_view data = this->get_string(ctx, isec->shdr());
+
+    // Some assemblers (e.g. GNU as 2.45 on Scrt1.o) emit a placeholder
+    // SHT_GNU_SFRAME section with sh_size == 0 instead of either omitting
+    // the section or writing a valid empty header (num_fdes == 0). Treat
+    // that the same as "nothing to contribute" rather than reading past
+    // the end of the section as if it were a real header.
+    if (data.size() < sizeof(SFrameHeader<E>))
+      continue;
+
     const SFrameHeader<E> &hdr = *(const SFrameHeader<E> *)data.data();
 
     if (hdr.magic != SFRAME_MAGIC)


### PR DESCRIPTION
Fixes #1646.

### Problem

`ObjectFile<E>::parse_sframe()` casts a `.sframe` section's raw bytes
straight into `SFrameHeader<E>` with no check that the section actually
holds enough bytes for one. On Ubuntu 25.10 (GNU as / GNU ld 2.45), GNU as
emits a placeholder `SHT_GNU_SFRAME` section with `sh_size == 0` for
`/usr/lib/x86_64-linux-gnu/Scrt1.o` — instead of either omitting the
section or writing a minimal valid header (`num_fdes == 0`). mold then
reads a "header" out of whatever bytes happen to follow the (empty)
section in the file, its `magic` field doesn't match `SFRAME_MAGIC`, and
the link aborts with a misleading error:

```
$ gcc repro.c -fuse-ld=mold
mold: fatal: /usr/lib/x86_64-linux-gnu/Scrt1.o:(.sframe): corrupted .sframe section
```

Full repro, root-cause writeup and a `readelf` comparison against the
(correctly populated) `.sframe` in `crt1.o`/`gcrt1.o` on the same system
are in #1646.

### Fix

Skip `.sframe` sections shorter than `sizeof(SFrameHeader<E>)` the same
way the existing version check already skips an old-format section,
instead of reading past their end.

### Testing

Built and verified against the exact repro from #1646:

```
$ gcc repro.c -fuse-ld=mold -o repro   # was: mold: fatal: ...: corrupted .sframe section
$ ./repro; echo $?
0
```

Also ran the full `ctest` suite against the patched build: **100% tests
passed out of 491** (476 run, 15 skipped, 0 failed). `test/sframe.sh` and
`test/arch-x86_64-sframe-unwind.sh` are among the skipped ones on this
machine — their `readelf --sframe` probe for a Version-3-capable `as`
doesn't match here, so they don't exercise real `.sframe` content in this
environment — but nothing else regressed.
