### PR TITLE
Assign visibility to Symbol objects for linker-synthesized symbols

### DIFF
--- a/src/output-chunks.cc
+++ b/src/output-chunks.cc
@@ -2161,6 +2161,7 @@ to_output_esym(Context<E> &ctx, Symbol<E> &sym, u32 st_name, U32<E> *shn_xindex)
     // Linker-synthesized symbols
     shndx = osec->shndx;
     esym.st_value = sym.get_addr(ctx);
+    esym.st_visibility = sym.visibility;
   } else if (SectionFragment<E> *frag = sym.get_frag()) {
     // Section fragment
     shndx = frag->get_output_section(ctx).shndx;

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -955,6 +955,7 @@ void add_synthetic_symbols(Context<E> &ctx) {
 
     Symbol<E> *sym = get_symbol(ctx, name);
     sym->value = 0xdeadbeef; // unique dummy value
+    sym->visibility = STV_HIDDEN;
     obj.symbols.emplace_back(sym);
     return sym;
   };
@@ -997,8 +998,10 @@ void add_synthetic_symbols(Context<E> &ctx) {
 
   if constexpr (is_riscv<E>) {
     ctx.__global_pointer = add("__global_pointer$");
-    if (ctx.dynamic && !ctx.arg.shared)
+    if (ctx.dynamic && !ctx.arg.shared) {
       ctx.__global_pointer->is_exported = true;
+      ctx.__global_pointer->visibility = STV_DEFAULT;
+    }
   }
 
   if constexpr (is_arm32<E>) {

--- a/src/passes.cc
+++ b/src/passes.cc
@@ -1033,7 +1033,7 @@ void add_synthetic_symbols(Context<E> &ctx) {
   if constexpr (is_ppc64v2<E>)
     for (std::pair<std::string_view, u32> p : ppc64_save_restore_insns)
       if (std::string_view label = p.first; !label.empty())
-        add(label);
+        add(label, STT_FUNC);
 
   obj.elf_syms = ctx.internal_esyms;
   obj.resolve_symbols(ctx);


### PR DESCRIPTION
When creating linker-synthesized symbols, scope/visibility properties are only applied to corresponding ELF symbols, not the Symbol objects. However, to_output_esym() decides their scope/visibility solely based on properties of the Symbol objects.

Thus after 35f4a334a0d0 ("Do not demote non-exported globals to local symbols in .symtab") removes the logic that demotes non-exported global symbols to local ones, linker synthesized symbols become STB_GLOBAL and STV_DEFAULT in the result binary, breaking ABI checkers of some applications.

Assign STV_HIDDEN to Symbol objects as well when creating linker-synthesized symbols, and copy the visibility when converting them to the ELF form in to_output_esym(). RISC-V-specific "__global_pointer$" needs specical treatment since it's required to be exported in dynamic-linked executables with GP-relocations.